### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Another usecase is if we want to encode a `case class` as an array of values, ra
 ```scala
 case class Things(s: String, i: Int, b: Boolean)
 object Things {
-  implicit val decoder: json.Decoder[Things] = json.Decoder[(String, Int, Boolean)].map(Things.tupled)
+  implicit val decoder: json.Decoder[Things] = json.Decoder[(String, Int, Boolean)].map((Things.apply _).tupled)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Another usecase is if we want to encode a `case class` as an array of values, ra
 ```scala
 case class Things(s: String, i: Int, b: Boolean)
 object Things {
-  implicit val decoder: json.Decoder[Things] = json.Decoder[(String, Int, Boolean)].map((Things.apply _).tupled)
+  implicit val decoder: json.Decoder[Things] =
+    json.Decoder[(String, Int, Boolean)].map { case (p1, p2, p3) => Things(p1, p2, p3) }
 }
 ```
 

--- a/src/main/scala/zio/json/ast.scala
+++ b/src/main/scala/zio/json/ast.scala
@@ -1,7 +1,5 @@
 package zio.json
 
-import scala.collection.mutable.{ListBuffer}
-
 import Decoder.{JsonError, UnsafeJson}
 import zio.json.internal._
 import scala.annotation._

--- a/src/main/scala/zio/json/decoder.scala
+++ b/src/main/scala/zio/json/decoder.scala
@@ -1,8 +1,7 @@
 package zio.json
 
 import scala.annotation._
-import java.io._
-import scala.collection.mutable.{ListBuffer}
+import scala.collection.mutable.ListBuffer
 import scala.util.control.NoStackTrace
 import zio.json.internal._
 import Decoder.JsonError
@@ -281,7 +280,7 @@ object Decoder extends DecoderLowPriority1 with DecoderLowPriority2 {
         trace: List[JsonError],
         in: RetractReader
       ): List[(K, A)] = {
-        var builder: ListBuffer[(K, A)] = new ListBuffer
+        val builder: ListBuffer[(K, A)] = new ListBuffer
         var trace_ = trace
         Lexer.char(trace, in, '{')
         if (Lexer.firstObject(trace, in))

--- a/src/main/scala/zio/json/internal/numbers.scala
+++ b/src/main/scala/zio/json/internal/numbers.scala
@@ -1,8 +1,6 @@
 package zio.json.internal
 
 import java.io._
-import java.util.regex.Pattern
-import scala.annotation._
 import scala.util.control.NoStackTrace
 
 /**


### PR DESCRIPTION
Nice library!

I try to run examples from README and to be able to one I needed a small tweak, change
`Things.tupled`
to
`(Things.apply _).tupled`

here:
```
implicit val decoder: json.Decoder[Things] = json.Decoder[(String, Int, Boolean)].map((Things.apply _).tupled)
```

