### PR TITLE
Add tests for decode Set Map Vector and Set

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,14 +20,14 @@ libraryDependencies += "com.propensive" %% "magnolia" % "0.16.0"
 libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
 
 testFrameworks += new TestFramework("scalaprops.ScalapropsFramework")
-libraryDependencies += "com.github.scalaprops" %% "scalaprops" % "0.8.0" % "test"
+libraryDependencies += "com.github.scalaprops" %% "scalaprops" % "0.8.0" % Test
 parallelExecution in Test := false // scalaprops does not support parallel execution
 
-libraryDependencies += "com.lihaoyi" %% "utest" % "0.7.2" % "test"
+libraryDependencies += "com.lihaoyi" %% "utest" % "0.7.2" % Test
 testFrameworks += new TestFramework("utest.runner.Framework")
 
-libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.5.0" % "test"
-libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.5.0" % "test"
+libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.5.0" % Test
+libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.5.0" % Test
 
 // circe is super easy to install (e_e)
 val circeVersion = "0.13.0"
@@ -35,12 +35,12 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",
   "io.circe" %% "circe-generic",
   "io.circe" %% "circe-parser"
-).map(_ % circeVersion % "test")
-libraryDependencies += "io.circe" %% "circe-generic-extras" % "0.13.0" % "test"
+).map(_ % circeVersion % Test)
+libraryDependencies += "io.circe" %% "circe-generic-extras" % "0.13.0" % Test
 libraryDependencies += "org.typelevel" %% "jawn-ast" % "1.0.0" // matches circe
 
-libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.0" % "test"
-libraryDependencies += "ai.x" %% "play-json-extensions" % "0.42.0" % "test"
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.0" % Test
+libraryDependencies += "ai.x" %% "play-json-extensions" % "0.42.0" % Test
 
 // scalafmtOnCompile := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,14 +20,14 @@ libraryDependencies += "com.propensive" %% "magnolia" % "0.16.0"
 libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
 
 testFrameworks += new TestFramework("scalaprops.ScalapropsFramework")
-libraryDependencies += "com.github.scalaprops" %% "scalaprops" % "0.8.0" % Test
+libraryDependencies += "com.github.scalaprops" %% "scalaprops" % "0.8.0" % "test"
 parallelExecution in Test := false // scalaprops does not support parallel execution
 
-libraryDependencies += "com.lihaoyi" %% "utest" % "0.7.2" % Test
+libraryDependencies += "com.lihaoyi" %% "utest" % "0.7.2" % "test"
 testFrameworks += new TestFramework("utest.runner.Framework")
 
-libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.5.0" % Test
-libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.5.0" % Test
+libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.5.0" % "test"
+libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.5.0" % "test"
 
 // circe is super easy to install (e_e)
 val circeVersion = "0.13.0"
@@ -35,12 +35,12 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",
   "io.circe" %% "circe-generic",
   "io.circe" %% "circe-parser"
-).map(_ % circeVersion % Test)
-libraryDependencies += "io.circe" %% "circe-generic-extras" % "0.13.0" % Test
+).map(_ % circeVersion % "test")
+libraryDependencies += "io.circe" %% "circe-generic-extras" % "0.13.0" % "test"
 libraryDependencies += "org.typelevel" %% "jawn-ast" % "1.0.0" // matches circe
 
-libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.0" % Test
-libraryDependencies += "ai.x" %% "play-json-extensions" % "0.42.0" % Test
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.0" % "test"
+libraryDependencies += "ai.x" %% "play-json-extensions" % "0.42.0" % "test"
 
 // scalafmtOnCompile := true
 

--- a/src/main/scala/zio/json/decoder.scala
+++ b/src/main/scala/zio/json/decoder.scala
@@ -235,6 +235,15 @@ object Decoder extends GeneratedTuples with DecoderLowPriority1 with DecoderLowP
       builder(trace, in, new mutable.ListBuffer[A])
   }
 
+  implicit def vector[A](implicit A: Decoder[A]): Decoder[Vector[A]] =
+    list[A].map(_.toVector)
+
+  implicit def seq[A](implicit A: Decoder[A]): Decoder[Seq[A]] =
+    list[A].map(_.toSeq)
+
+  implicit def set[A](implicit A: Decoder[A]): Decoder[Set[A]] =
+    list[A].map(_.toSet)
+
   // not implicit because this overlaps with decoders for lists of tuples
   def keylist[K, A](
     implicit

--- a/src/main/scala/zio/json/decoder.scala
+++ b/src/main/scala/zio/json/decoder.scala
@@ -235,15 +235,6 @@ object Decoder extends GeneratedTuples with DecoderLowPriority1 with DecoderLowP
       builder(trace, in, new mutable.ListBuffer[A])
   }
 
-  implicit def vector[A](implicit A: Decoder[A]): Decoder[Vector[A]] =
-    list[A].map(_.toVector)
-
-  implicit def seq[A](implicit A: Decoder[A]): Decoder[Seq[A]] =
-    list[A].map(_.toSeq)
-
-  implicit def set[A](implicit A: Decoder[A]): Decoder[Set[A]] =
-    list[A].map(_.toSet)
-
   // not implicit because this overlaps with decoders for lists of tuples
   def keylist[K, A](
     implicit

--- a/src/main/scala/zio/json/decoder.scala
+++ b/src/main/scala/zio/json/decoder.scala
@@ -6,6 +6,8 @@ import scala.util.control.NoStackTrace
 import zio.json.internal._
 import Decoder.JsonError
 
+import scala.reflect.ClassTag
+
 // convenience to match the circe api
 object parser {
 
@@ -234,6 +236,29 @@ object Decoder extends GeneratedTuples with DecoderLowPriority1 with DecoderLowP
     def unsafeDecode(trace: List[JsonError], in: RetractReader): List[A] =
       builder(trace, in, new mutable.ListBuffer[A])
   }
+
+  implicit def vector[A](implicit A: Decoder[A]): Decoder[Vector[A]] =
+    list[A].map(_.toVector)
+
+  implicit def seq[A](implicit A: Decoder[A]): Decoder[Seq[A]] =
+    list[A].map(_.toSeq)
+
+  implicit def set[A](implicit A: Decoder[A]): Decoder[Set[A]] =
+    list[A].map(_.toSet)
+
+  implicit def array[A:ClassTag](implicit A: Decoder[A]): Decoder[Array[A]] =
+    new Decoder[Array[A]] {
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): Array[A] = {
+        var builder = Array[A]()
+        Lexer.char(trace, in, '[')
+        var trace_ = trace
+        if (Lexer.firstArray(trace, in)) do {
+          trace_ = JsonError.ArrayAccess(builder.length) :: trace
+          builder = builder :+ A.unsafeDecode(trace_, in)
+        } while (Lexer.nextArray(trace_, in))
+        builder
+      }
+    }
 
   // not implicit because this overlaps with decoders for lists of tuples
   def keylist[K, A](

--- a/src/main/scala/zio/json/decoder.scala
+++ b/src/main/scala/zio/json/decoder.scala
@@ -6,8 +6,6 @@ import scala.util.control.NoStackTrace
 import zio.json.internal._
 import Decoder.JsonError
 
-import scala.reflect.ClassTag
-
 // convenience to match the circe api
 object parser {
 
@@ -245,20 +243,6 @@ object Decoder extends GeneratedTuples with DecoderLowPriority1 with DecoderLowP
 
   implicit def set[A](implicit A: Decoder[A]): Decoder[Set[A]] =
     list[A].map(_.toSet)
-
-  implicit def array[A:ClassTag](implicit A: Decoder[A]): Decoder[Array[A]] =
-    new Decoder[Array[A]] {
-      def unsafeDecode(trace: List[JsonError], in: RetractReader): Array[A] = {
-        var builder = Array[A]()
-        Lexer.char(trace, in, '[')
-        var trace_ = trace
-        if (Lexer.firstArray(trace, in)) do {
-          trace_ = JsonError.ArrayAccess(builder.length) :: trace
-          builder = builder :+ A.unsafeDecode(trace_, in)
-        } while (Lexer.nextArray(trace_, in))
-        builder
-      }
-    }
 
   // not implicit because this overlaps with decoders for lists of tuples
   def keylist[K, A](

--- a/src/main/scala/zio/json/decoder.scala
+++ b/src/main/scala/zio/json/decoder.scala
@@ -241,6 +241,8 @@ object Decoder extends GeneratedTuples with DecoderLowPriority1 with DecoderLowP
   }
 
   // FIXME compiles without seq but tests fails
+  // assertion failed: Right(Monster(List())) != Right(Monster(List(5XL, 2XL, XL)))
+  // maybe sth is off with cbf ?
   implicit def seq[A: Decoder]: Decoder[Seq[A]] = new Decoder[Seq[A]] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Seq[A] =
       builder(trace, in, new mutable.ListBuffer[A])

--- a/src/test/scala/zio/json/DecoderTest.scala
+++ b/src/test/scala/zio/json/DecoderTest.scala
@@ -227,6 +227,23 @@ object DecoderTest extends TestSuite {
       json.parser.decode[Monster](jsonStr) ==> Right(expected)
     }
 
+    test("Map") {
+      case class Monsters(population: Map[String, Int])
+
+      object Monsters {
+        implicit val decoder: json.Decoder[Monsters] = json.MagnoliaDecoder.gen
+      }
+
+      val jsonStr = """{"population":{"5XL":3,"2XL":14,"XL":159}}"""
+      val expected = Monsters(population =
+        Map(
+          "5XL" -> 3,
+          "2XL" -> 14,
+          "XL" -> 159)
+      )
+      json.parser.decode[Monsters](jsonStr) ==> Right(expected)
+    }
+
     test("jawn test data: bar") {
       testAst("bar")
     }

--- a/src/test/scala/zio/json/DecoderTest.scala
+++ b/src/test/scala/zio/json/DecoderTest.scala
@@ -191,16 +191,6 @@ object DecoderTest extends TestSuite {
       json.parser.decode[String](""""€🐵🥰"""") ==> Right("€🐵🥰")
     }
 
-    test("array") {
-      case class Cookie(count: Array[Int])
-
-      object Cookie {
-        implicit val decoder: json.Decoder[Cookie] = json.MagnoliaDecoder.gen
-      }
-      json.parser.decode[Cookie]("""{"count":[1,2,3]}""").map(_.count.toList) ==>
-        Right(Array(1,2,3).toList)
-    }
-
     test("Vector") {
       case class Monster(sizes: Vector[String])
 

--- a/src/test/scala/zio/json/DecoderTest.scala
+++ b/src/test/scala/zio/json/DecoderTest.scala
@@ -195,7 +195,6 @@ object DecoderTest extends TestSuite {
       case class Monster(sizes: Seq[String])
 
       object Monster {
-        import zio.json.Decoder._
         implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
       }
 
@@ -204,34 +203,29 @@ object DecoderTest extends TestSuite {
       json.parser.decode[Monster](jsonStr) ==> Right(expected)
     }
 
-// TODO don't work
-//
-//    test("Vector") {
-//      case class Monster(sizes: Vector[String])
-//
-//      object Monster {
-//        import zio.json.Decoder._
-//        import json.MagnoliaDecoder._
-//        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
-//      }
-//
-//      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
-//      val expected = Monster(sizes = Vector("5XL","2XL","XL"))
-//      json.parser.decode[Monster](jsonStr) ==> Right(expected)
-//    }
-//
-//    test("Set") {
-//      case class Monster(sizes: Set[String])
-//
-//      object Monster {
-//        import zio.json.Decoder._
-//        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
-//      }
-//
-//      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
-//      val expected = Monster(sizes = Set("5XL","2XL","XL"))
-//      json.parser.decode[Monster](jsonStr) ==> Right(expected)
-//    }
+    test("Vector") {
+      case class Monster(sizes: Vector[String])
+
+      object Monster {
+        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
+      }
+
+      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
+      val expected = Monster(sizes = Vector("5XL","2XL","XL"))
+      json.parser.decode[Monster](jsonStr) ==> Right(expected)
+    }
+
+    test("Set") {
+      case class Monster(sizes: Set[String])
+
+      object Monster {
+        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
+      }
+
+      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
+      val expected = Monster(sizes = Set("5XL","2XL","XL"))
+      json.parser.decode[Monster](jsonStr) ==> Right(expected)
+    }
 
     test("jawn test data: bar") {
       testAst("bar")

--- a/src/test/scala/zio/json/DecoderTest.scala
+++ b/src/test/scala/zio/json/DecoderTest.scala
@@ -191,22 +191,11 @@ object DecoderTest extends TestSuite {
       json.parser.decode[String](""""€🐵🥰"""") ==> Right("€🐵🥰")
     }
 
-    test("Vector") {
-      case class Monster(sizes: Vector[String])
-
-      object Monster {
-        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
-      }
-
-      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
-      val expected = Monster(sizes = Vector("5XL","2XL","XL"))
-      json.parser.decode[Monster](jsonStr) ==> Right(expected)
-    }
-
     test("Seq") {
       case class Monster(sizes: Seq[String])
 
       object Monster {
+        import zio.json.Decoder._
         implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
       }
 
@@ -215,17 +204,34 @@ object DecoderTest extends TestSuite {
       json.parser.decode[Monster](jsonStr) ==> Right(expected)
     }
 
-    test("Set") {
-      case class Monster(sizes: Set[String])
-
-      object Monster {
-        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
-      }
-
-      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
-      val expected = Monster(sizes = Set("5XL","2XL","XL"))
-      json.parser.decode[Monster](jsonStr) ==> Right(expected)
-    }
+// TODO don't work
+//
+//    test("Vector") {
+//      case class Monster(sizes: Vector[String])
+//
+//      object Monster {
+//        import zio.json.Decoder._
+//        import json.MagnoliaDecoder._
+//        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
+//      }
+//
+//      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
+//      val expected = Monster(sizes = Vector("5XL","2XL","XL"))
+//      json.parser.decode[Monster](jsonStr) ==> Right(expected)
+//    }
+//
+//    test("Set") {
+//      case class Monster(sizes: Set[String])
+//
+//      object Monster {
+//        import zio.json.Decoder._
+//        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
+//      }
+//
+//      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
+//      val expected = Monster(sizes = Set("5XL","2XL","XL"))
+//      json.parser.decode[Monster](jsonStr) ==> Right(expected)
+//    }
 
     test("jawn test data: bar") {
       testAst("bar")

--- a/src/test/scala/zio/json/DecoderTest.scala
+++ b/src/test/scala/zio/json/DecoderTest.scala
@@ -191,6 +191,52 @@ object DecoderTest extends TestSuite {
       json.parser.decode[String](""""€🐵🥰"""") ==> Right("€🐵🥰")
     }
 
+    test("array") {
+      case class Cookie(count: Array[Int])
+
+      object Cookie {
+        implicit val decoder: json.Decoder[Cookie] = json.MagnoliaDecoder.gen
+      }
+      json.parser.decode[Cookie]("""{"count":[1,2,3]}""").map(_.count.toList) ==>
+        Right(Array(1,2,3).toList)
+    }
+
+    test("Vector") {
+      case class Monster(sizes: Vector[String])
+
+      object Monster {
+        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
+      }
+
+      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
+      val expected = Monster(sizes = Vector("5XL","2XL","XL"))
+      json.parser.decode[Monster](jsonStr) ==> Right(expected)
+    }
+
+    test("Seq") {
+      case class Monster(sizes: Seq[String])
+
+      object Monster {
+        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
+      }
+
+      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
+      val expected = Monster(sizes = Seq("5XL","2XL","XL"))
+      json.parser.decode[Monster](jsonStr) ==> Right(expected)
+    }
+
+    test("Set") {
+      case class Monster(sizes: Set[String])
+
+      object Monster {
+        implicit val decoder: json.Decoder[Monster] = json.MagnoliaDecoder.gen
+      }
+
+      val jsonStr = """{"sizes":["5XL","2XL","XL"]}"""
+      val expected = Monster(sizes = Set("5XL","2XL","XL"))
+      json.parser.decode[Monster](jsonStr) ==> Right(expected)
+    }
+
     test("jawn test data: bar") {
       testAst("bar")
     }


### PR DESCRIPTION
Added tests and support for Set, Map, Vector.

It is a bit strange that I needed to add 

```scala
  implicit def seq[A: Decoder]: Decoder[Seq[A]] = new Decoder[Seq[A]] {
    def unsafeDecode(trace: List[JsonError], in: RetractReader): Seq[A] =
      builder(trace, in, new mutable.ListBuffer[A])
  }
```

IMHO `cbf` should be able to handle it. The compilation is ok but tests fail with

```scala
assertion failed: Right(Monster(List())) != Right(Monster(List(5XL, 2XL, XL)))
```

as if sth was wrong with `cbf`