### PR TITLE
Fix / silence warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
       "org.scala-lang"                        % "scala-reflect"          % scalaVersion.value % Provided,
       "dev.zio"                               %% "zio"                   % zioVersion,
       "dev.zio"                               %% "zio-streams"           % zioVersion,
+      "org.scala-lang.modules"                %% "scala-collection-compat" % "2.2.0",
       "dev.zio"                               %% "zio-test"              % zioVersion % "test",
       "dev.zio"                               %% "zio-test-sbt"          % zioVersion % "test",
       "io.circe"                              %% "circe-core"            % circeVersion % "test",
@@ -101,7 +102,6 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
         file,
         s"""package zio.json
            |
-           |import zio.Chunk
            |import zio.json.internal._
            |
            |private[json] trait GeneratedTupleDecoders { this: JsonDecoder.type =>

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -41,6 +41,14 @@ object BuildHelper {
     "-Ywarn-value-discard"
   ) ++ customOptions
 
+  /**
+   * @see https://github.com/scala/scala/pull/8373
+   */
+  private val warningOptions = Seq(
+    // Many libraries use byName implicits. The warnings would turn up at the call site.
+    "-Wconf:cat=lint-byname-implicit:silent"
+  )
+
   private def propertyFlag(property: String, default: Boolean) =
     sys.props.get(property).map(_.toBoolean).getOrElse(default)
 
@@ -69,7 +77,7 @@ object BuildHelper {
       case Some((2, 13)) =>
         Seq(
           "-Ywarn-unused:params,-implicits"
-        ) ++ std2xOptions ++ optimizerOptions(optimize)
+        ) ++ std2xOptions ++ optimizerOptions(optimize) ++ warningOptions
       case Some((2, 12)) =>
         Seq(
           "-opt-warnings",

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderSpec.scala
@@ -241,10 +241,12 @@ object DecoderSpec extends DefaultRunnableSpec {
     ast match {
       case Json.Obj(values) =>
         Json.Obj(
-          Chunk.fromIterable(values
-            .groupBy(_._1)
-            .map(_._2.head)
-          )
+          Chunk
+            .fromIterable(
+              values
+                .groupBy(_._1)
+                .map(_._2.head)
+            )
             .map { case (k, v) => (k, normalize(v)) }
             .sortBy(_._1)
         )

--- a/zio-json/jvm/src/test/scala/zio/json/RoundTripSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/RoundTripSpec.scala
@@ -52,7 +52,7 @@ object RoundTripSpec extends DefaultRunnableSpec {
       val num   = genBigDecimal.map(Json.Num(_))
       val nul   = Gen.const(Json.Null)
 
-      Gen.oneOf(obj, arr, boo, str, num)
+      Gen.oneOf(obj, arr, boo, str, num, nul)
     }
 
   private def assertRoundtrips[A: JsonEncoder: JsonDecoder](a: A) =

--- a/zio-json/jvm/src/test/scala/zio/json/compat/RefinedSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/compat/RefinedSpec.scala
@@ -1,7 +1,6 @@
 package testzio.json.compat
 
 import zio.json._
-import zio.test._
 
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty

--- a/zio-json/jvm/src/test/scala/zio/json/data/GeoJSON.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/data/GeoJSON.scala
@@ -7,7 +7,6 @@ import ai.x.play.json.Encoders.encoder
 
 import zio.json._
 import zio.json.ast._
-import zio.Chunk
 
 object playtuples extends Play.GeneratedReads with Play.GeneratedWrites
 import playtuples._
@@ -220,7 +219,7 @@ package handrolled {
             throw UnsafeJson(
               JsonError.Message("missing 'coordinates' field") :: trace
             )
-          var trace_ = spans(1) :: trace
+          val trace_ = spans(1) :: trace
           (subtype: @switch) match {
             case 0 => Point(coordinates0(trace_, coordinates))
             case 1 => MultiPoint(coordinates1(trace_, coordinates))

--- a/zio-json/jvm/src/test/scala/zio/json/internal/SafeNumbersSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/internal/SafeNumbersSpec.scala
@@ -101,7 +101,7 @@ object SafeNumbersSpec extends DefaultRunnableSpec {
           }
         },
         testM("valid (from Int)") {
-          check(Gen.anyInt)(i => assert(SafeNumbers.double(i.toString))(equalTo(DoubleSome(i))))
+          check(Gen.anyInt)(i => assert(SafeNumbers.double(i.toString))(equalTo(DoubleSome(i.toDouble))))
         },
         testM("valid (from Long)") {
           check(Gen.anyLong)(i => assert(SafeNumbers.double(i.toString))(equalTo(DoubleSome(i.toDouble))))

--- a/zio-json/jvm/src/test/scala/zio/json/internal/StringMatrixSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/internal/StringMatrixSpec.scala
@@ -16,16 +16,12 @@ object StringMatrixSpec extends DefaultRunnableSpec {
     },
     testM("negative fails") {
       check(genTestStrings.filterNot(_.startsWith("wibble"))) { xs =>
-        val asserts = xs.map(s => matcher(xs, "wibble"))
-
-        assert(asserts)(forall(isEmpty))
+        assert(matcher(xs, "wibble"))(isEmpty)
       }
     },
     testM("substring fails") {
       check(genTestStrings.filter(_.length > 1)) { xs =>
-        val asserts = xs.map(s => matcher(xs, xs.mkString))
-
-        assert(asserts)(forall(isEmpty))
+        assert(matcher(xs, xs.mkString))(isEmpty)
       }
     },
     testM("trivial") {
@@ -53,7 +49,7 @@ object StringMatrixSpec extends DefaultRunnableSpec {
   private def matcher(xs: List[String], test: String): List[String] = {
     val m = new StringMatrix(xs.toArray)
     var bs = test.zipWithIndex.foldLeft(m.initial) {
-      case (bs, (c, i)) => m.update(bs, i, c)
+      case (bs, (c, i)) => m.update(bs, i, c.toInt)
     }
     bs = m.exact(bs, test.length)
     matches(xs, bs)

--- a/zio-json/jvm/src/test/scala/zio/json/internal/StringMatrixSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/internal/StringMatrixSpec.scala
@@ -15,14 +15,10 @@ object StringMatrixSpec extends DefaultRunnableSpec {
       }
     },
     testM("negative fails") {
-      check(genTestStrings.filterNot(_.startsWith("wibble"))) { xs =>
-        assert(matcher(xs, "wibble"))(isEmpty)
-      }
+      check(genTestStrings.filterNot(_.startsWith("wibble")))(xs => assert(matcher(xs, "wibble"))(isEmpty))
     },
     testM("substring fails") {
-      check(genTestStrings.filter(_.length > 1)) { xs =>
-        assert(matcher(xs, xs.mkString))(isEmpty)
-      }
+      check(genTestStrings.filter(_.length > 1))(xs => assert(matcher(xs, xs.mkString))(isEmpty))
     },
     testM("trivial") {
       check(genNonEmptyString)(s => assert(matcher(List(s), s))(equalTo(List(s))))

--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -1,6 +1,5 @@
 package zio.json
 
-import zio.Chunk
 import zio.json.internal._
 
 import JsonDecoder.JsonError

--- a/zio-json/shared/src/main/scala/zio/json/compat/scalaz.scala
+++ b/zio-json/shared/src/main/scala/zio/json/compat/scalaz.scala
@@ -1,6 +1,6 @@
 package zio.json.compat
 
-import _root_.scalaz._, Scalaz._
+import _root_.scalaz._
 import zio.json._
 
 object scalaz {

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -125,6 +125,7 @@ trait JsonDecoder[A] { self =>
         }
     }
 
+  @nowarn("msg=is never used")
   def xmap[B](f: A => B, g: B => A): JsonDecoder[B] = map(f)
 
   /**
@@ -203,7 +204,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
 
   implicit val char: JsonDecoder[Char] = string.mapOrFail {
     case str if str.length == 1 => Right(str(0))
-    case other                  => Left("expected one character")
+    case _                      => Left("expected one character")
   }
   implicit val symbol: JsonDecoder[Symbol] = string.map(Symbol(_))
 
@@ -315,7 +316,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
   )(implicit A: JsonDecoder[A]): T[A] = {
     Lexer.char(trace, in, '[')
     var i: Int = 0
-    if (Lexer.firstArrayElement(trace, in)) do {
+    if (Lexer.firstArrayElement(in)) do {
       val trace_ = JsonError.ArrayAccess(i) :: trace
       builder += A.unsafeDecode(trace_, in)
       i += 1

--- a/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
@@ -353,12 +353,6 @@ object UnsafeNumbers {
     var dot: Int                    = 0    // counts from the right
     var exp: Int                    = 0    // implied
 
-    def read(): Int = {
-      current = in.read()
-      if (current == -1) throw UnsafeNumber
-      current
-    }
-
     def advance(): Boolean = {
       current = in.read()
       current != -1
@@ -386,7 +380,7 @@ object UnsafeNumbers {
           .valueOf(sig)
           .multiply(java.math.BigInteger.TEN)
           .add(bigIntegers(c))
-      else if (sig < 0) sig = c
+      else if (sig < 0) sig = c.toLong
       else sig = sig * 10 + c
     }
 

--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -80,7 +80,7 @@ private[zio] final class FastStringReader(s: CharSequence) extends RetractReader
   override def read(): Int = {
     i += 1
     if (i > len) -1
-    else history(i - 1) // -1 is faster than assigning a temp value
+    else history(i - 1).toInt // -1 is faster than assigning a temp value
   }
   override def readChar(): Char = {
     i += 1

--- a/zio-json/shared/src/main/scala/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala/zio/json/macros.scala
@@ -1,12 +1,10 @@
 package zio.json
 
 import scala.annotation._
-import scala.reflect.macros.whitebox
 import scala.language.experimental.macros
 
 import magnolia._
 
-import zio.Chunk
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 import zio.json.internal.{ Lexer, RetractReader, StringMatrix }
 
@@ -104,7 +102,6 @@ object DeriveJsonDecoder {
               var trace_ = trace
               val field  = Lexer.field(trace, in, matrix)
               if (field != -1) {
-                val field_ = names(field)
                 trace_ = spans(field) :: trace
                 if (ps(field) != null)
                   throw UnsafeJson(JsonError.Message("duplicate") :: trace)
@@ -135,7 +132,6 @@ object DeriveJsonDecoder {
         case jsonHint(name) => name
       }.getOrElse(p.typeName.short)
     }.toArray
-    val len: Int             = names.length
     val matrix: StringMatrix = new StringMatrix(names)
     lazy val tcs: Array[JsonDecoder[Any]] =
       ctx.subtypes.map(_.typeclass).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
@@ -150,7 +146,6 @@ object DeriveJsonDecoder {
           if (Lexer.firstField(trace, in)) {
             val field = Lexer.field(trace, in, matrix)
             if (field != -1) {
-              val field_ = names(field)
               val trace_ = spans(field) :: trace
               val a      = tcs(field).unsafeDecode(trace_, in).asInstanceOf[A]
               Lexer.char(trace, in, '}')


### PR DESCRIPTION
Closes #22 

Most warnings were genuine.

* `scala-collection-compat` provides the `@nowarn` annotation, which the Silencer SBT plugin is picking up  under Scala 2.12, allowing us to support the new syntax under 2.12.

* Usage of Circe emits warnings like 'Block result was adapted via implicit conversion (method apply) taking a by-name parameter' under Scala 2.13. This changeset sets up warning options to silence all of these.