### PR TITLE
decodeJsonTransducer

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonStreamDelimiter.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonStreamDelimiter.scala
@@ -1,0 +1,8 @@
+package zio.json
+
+sealed trait JsonStreamDelimiter
+
+object JsonStreamDelimiter {
+  case object Newline extends JsonStreamDelimiter
+  case object Array   extends JsonStreamDelimiter
+}

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -7,8 +7,8 @@ import scala.util.control.NoStackTrace
 import zio.blocking._
 import zio.json.JsonDecoder.JsonError
 import zio.json.internal._
-import zio.stream.ZStream
-import zio.{ Chunk, ZIO }
+import zio.stream.{ Take, ZStream, ZTransducer }
+import zio.{ Chunk, IO, Queue, Ref, ZIO, ZManaged }
 
 /**
  * A `JsonDecoder[A]` instance has the ability to decode JSON to values of type `A`, potentially
@@ -69,6 +69,113 @@ trait JsonDecoder[A] { self =>
           case _: internal.UnexpectedEnd     => throw new Exception("unexpected end of input")
         }
       }
+    }
+
+  final def decodeJsonTransducer(
+    delimiter: JsonStreamDelimiter = JsonStreamDelimiter.Array
+  ): ZTransducer[Blocking, Throwable, Char, A] =
+    ZTransducer {
+      for {
+        // format: off
+        runtime    <- ZIO.runtime[Any].toManaged_
+        inQueue    <- Queue.unbounded[Take[Nothing, Char]].toManaged_
+        outQueue   <- Queue.unbounded[Take[Throwable, A]].toManaged_
+        ended      <- Ref.makeManaged(false)
+        reader     <- ZManaged.fromAutoCloseable {
+                        ZIO.effectTotal {
+                          def readPull: Iterator[Chunk[Char]] =
+                            runtime.unsafeRun(inQueue.take)
+                              .fold(
+                                end   = Iterator.empty,
+                                error = _ => Iterator.empty, // impossible
+                                value = v => Iterator.single(v) ++ readPull
+                              )
+
+                          new zio.stream.internal.ZReader(Iterator.empty ++ readPull)
+                        }
+                      }
+        jsonReader <- ZManaged.fromAutoCloseable(ZIO.effectTotal(new WithRetractReader(reader)))
+        process    <- effectBlockingInterrupt {
+                        // Exceptions fall through and are pushed into the queue
+                        @tailrec def loop(atBeginning: Boolean): Unit = {
+                          val nextElem = try {
+                            if (atBeginning && delimiter == JsonStreamDelimiter.Array)  {
+                              Lexer.char(Nil, jsonReader, '[')
+                            } else {
+                              delimiter match {
+                                case JsonStreamDelimiter.Newline =>
+                                  jsonReader.readChar() match {
+                                    case '\r' =>
+                                      jsonReader.readChar() match {
+                                        case '\n' => ()
+                                        case _    => jsonReader.retract()
+                                      }
+                                    case '\n' => ()
+                                    case _    => jsonReader.retract()
+                                  }
+
+                               case JsonStreamDelimiter.Array =>
+                                  jsonReader.nextNonWhitespace() match {
+                                    case ',' | ']' => ()
+                                    case _         => jsonReader.retract()
+                                  }
+                              }
+                            }
+
+                            unsafeDecode(Nil, jsonReader)
+                          } catch {
+                            case t @ JsonDecoder.UnsafeJson(trace) =>
+                              throw new Exception(JsonError.render(trace))
+                          }
+
+                          runtime.unsafeRun(outQueue.offer(Take.single(nextElem)))
+
+                          loop(false)
+                        }
+
+                        loop(true)
+                      }
+                      .catchAll {
+                        case t: internal.UnexpectedEnd =>
+                          // swallow if stream ended
+                          ZIO.unlessM(ended.get) {
+                            outQueue.offer(Take.fail(t))
+                          }
+
+                        case t: Throwable =>
+                          outQueue.offer(Take.fail(t))
+                      }
+                      .interruptible
+                      .forkManaged
+        push = { is: Option[Chunk[Char]] =>
+          val pollElements: IO[Throwable, Chunk[A]] =
+            outQueue
+              .takeUpTo(ZStream.DefaultChunkSize)
+              .flatMap { takes =>
+                ZIO.foldLeft(takes)(Chunk[A]()) { case (acc, take) =>
+                  take.fold(ZIO.succeedNow(acc), e => ZIO.fail(e.squash), c => ZIO.succeedNow(acc ++ c))
+                }
+              }
+
+          val pullRest =
+            outQueue
+              .takeAll
+              .flatMap { takes =>
+                ZIO.foldLeft(takes)(Chunk[A]()) { case (acc, take) =>
+                  take.fold(ZIO.succeedNow(acc), e => ZIO.fail(e.squash), c => ZIO.succeedNow(acc ++ c))
+                }
+              }
+
+          is match {
+            case Some(c) =>
+              inQueue.offer(Take.chunk(c)) *> pollElements
+
+            case None =>
+              ended.set(true) *> inQueue.offer(Take.end) *> process.join *> pullRest
+          }
+        }
+      } yield push
+      // format: on
     }
 
   /**

--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -104,7 +104,7 @@ private[zio] final class FastStringReader(s: CharSequence) extends RetractReader
 
 // this tends to be a bit slower than creating an implementation that implements
 // all Reader interfaces that are required.
-final class WithRetractReader(in: java.io.Reader) extends RetractReader {
+final class WithRetractReader(in: java.io.Reader) extends RetractReader with AutoCloseable {
   private[this] var last   = -2
   private[this] var replay = false
 


### PR DESCRIPTION
Closes #10

This is more complex than I'd like because of the blocking readers.
Interested to see if you see some opportunity for simplification.

- On a push incoming characters are pushed into a queue
  - a worker repeatedly pull from the queue, decodes elements, and pushes elements
- On each push already decoded elements (from prior pulls) are pushed

Because we don't know how many chars we need to push to yield elements, we don't have back-pressure.
Unless I'm missing something obvious `ZTranscoder.splitLines` suffers from the same issue (Akka Streams require to specify a maximumFrameLength argument).

I've manually formatted the method for readability, but happy to remove the `//format: off` post review.