### PR TITLE
Add a manualSumSwitch method for hand-coded decoder

### DIFF
--- a/zio-json/jvm/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderSpec.scala
@@ -13,10 +13,8 @@ import testzio.json.data.twitter._
 
 import zio.blocking._
 import zio.duration._
-import zio.json.JsonDecoder.JsonError
 import zio.json._
 import zio.json.ast._
-import zio.json.internal.RetractReader
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.TestAspect._
@@ -342,16 +340,9 @@ object DecoderSpec extends DefaultRunnableSpec {
             assert(decoder.decodeJson("true"))(equalTo(Right(true.asInstanceOf[AnyVal])))
           },
           test("test hand-coded alternative in `orElse` comment") {
-            val decoder: JsonDecoder[AnyVal] = new JsonDecoder[AnyVal] {
-              def unsafeDecode(trace: List[JsonError], in: RetractReader): AnyVal =
-                (in.nextNonWhitespace(): @switch) match {
-                  case 't' | 'f' =>
-                    in.retract()
-                    JsonDecoder[Boolean].unsafeDecode(trace, in)
-                  case c =>
-                    in.retract()
-                    JsonDecoder[Int].unsafeDecode(trace, in)
-                }
+            val decoder: JsonDecoder[AnyVal] = JsonDecoder.manualSumSwitch[AnyVal] {
+              case 't' | 'f' => JsonDecoder[Boolean].widen
+              case c         => JsonDecoder[Int].widen
             }
             assert(decoder.decodeJson("true"))(equalTo(Right(true.asInstanceOf[AnyVal]))) &&
             assert(decoder.decodeJson("42"))(equalTo(Right(42.asInstanceOf[AnyVal]))) &&

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderSpec.scala
@@ -2,7 +2,6 @@ package testzio.json
 
 import java.nio.file.Paths
 
-import scala.annotation.switch
 import scala.collection.immutable
 
 import io.circe
@@ -340,7 +339,7 @@ object DecoderSpec extends DefaultRunnableSpec {
             assert(decoder.decodeJson("true"))(equalTo(Right(true.asInstanceOf[AnyVal])))
           },
           test("test hand-coded alternative in `orElse` comment") {
-            val decoder: JsonDecoder[AnyVal] = JsonDecoder.manualSumSwitch[AnyVal] {
+            val decoder: JsonDecoder[AnyVal] = JsonDecoder.peekChar[AnyVal] {
               case 't' | 'f' => JsonDecoder[Boolean].widen
               case c         => JsonDecoder[Int].widen
             }

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -194,7 +194,7 @@ trait JsonDecoder[A] { self =>
    * alternative would look like:
    *
    * ```
-   * val decoder: JsonDecoder[AnyVal] = JsonDecoder.manualSumSwitch[AnyVal] {
+   * val decoder: JsonDecoder[AnyVal] = JsonDecoder.peekChar[AnyVal] {
    *   case 't' | 'f' => JsonDecoder[Boolean].widen
    *   case c         => JsonDecoder[Int].widen
    * }
@@ -315,14 +315,14 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
     final case class SumType(cons: String)       extends JsonError
   }
 
-  def manualSumSwitch[A](partialFunction: PartialFunction[Char, JsonDecoder[A]]): JsonDecoder[A] = new JsonDecoder[A] {
+  def peekChar[A](partialFunction: PartialFunction[Char, JsonDecoder[A]]): JsonDecoder[A] = new JsonDecoder[A] {
     override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
       val c = in.nextNonWhitespace()
       if (partialFunction.isDefinedAt(c)) {
         in.retract()
         partialFunction(c).unsafeDecode(trace, in)
       } else {
-        throw UnsafeJson(JsonError.Message(s"missing manual sum switch case for '${c}''") :: trace)
+        throw UnsafeJson(JsonError.Message(s"missing case in `peekChar` for '${c}''") :: trace)
       }
     }
   }

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -190,20 +190,13 @@ trait JsonDecoder[A] { self =>
    * This method may be unsafe from a security perspective: it can use more memory than hand coded
    * alternative and so lead to DOS.
    *
-   * For example, in the case of an alternative between `Int` and `Boolean`, an hand coded
+   * For example, in the case of an alternative between `Int` and `Boolean`, a hand coded
    * alternative would look like:
    *
    * ```
-   * val decoder: JsonDecoder[AnyVal] = new JsonDecoder[AnyVal] {
-   *   def unsafeDecode(trace: List[JsonError], in: RetractReader): AnyVal =
-   *     (in.nextNonWhitespace(): @switch) match {
-   *       case 't' | 'f' =>
-   *         in.retract()
-   *         JsonDecoder[Boolean].unsafeDecode(JsonError.SumType("Boolean") :: trace, in).asInstanceOf[AnyVal]
-   *       case c =>
-   *         in.retract()
-   *         JsonDecoder[Int].unsafeDecode(JsonError.SumType("Int") :: trace, in).asInstanceOf[AnyVal]
-   *   }
+   * val decoder: JsonDecoder[AnyVal] = JsonDecoder.manualSumSwitch[AnyVal] {
+   *   case 't' | 'f' => JsonDecoder[Boolean].widen
+   *   case c         => JsonDecoder[Int].widen
    * }
    * ```
    */
@@ -320,6 +313,18 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
     final case class ArrayAccess(i: Int)         extends JsonError
     final case class ObjectAccess(field: String) extends JsonError
     final case class SumType(cons: String)       extends JsonError
+  }
+
+  def manualSumSwitch[A](partialFunction: PartialFunction[Char, JsonDecoder[A]]): JsonDecoder[A] = new JsonDecoder[A] {
+    override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
+      val c = in.nextNonWhitespace()
+      if (partialFunction.isDefinedAt(c)) {
+        in.retract()
+        partialFunction(c).unsafeDecode(trace, in)
+      } else {
+        throw UnsafeJson(JsonError.Message(s"missing manual sum switch case for '${c}''") :: trace)
+      }
+    }
   }
 
   implicit def string: JsonDecoder[String] = new JsonDecoder[String] {


### PR DESCRIPTION
This PR add a `manualSumSwitch[A]` that can efficiently help in decoding sum type. The typical use case is when the JSON format is fixed and it is missing type information (case class name or field with type). 

Example: 
```
JsonDecoder.manualSumSwitch[AnyVal] {
  case 't' | 'f' => JsonDecoder[Boolean].widen
  case c         => JsonDecoder[Int].widen
}
```

This PR is expecting to have #133 because it provides a better solution for the `orElse` comment added in it and it relies on `.widen` in all of its use cases. 