### PR TITLE
Scala.js support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,15 +25,10 @@ inThisBuild(
 )
 
 addCommandAlias("fix", "scalafixAll")
-addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt jmh:scalafmt")
 addCommandAlias("fixCheck", "scalafixAll --check")
-addCommandAlias("fix", "all compile:scalafix test:scalafix")
 addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
-addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck jmh:scalafmtCheck")
 addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheckAll")
-addCommandAlias("fixCheck", "; compile:scalafix --check ; test:scalafix --check ")
 addCommandAlias("prepare", "fix; fmt")
-addCommandAlias("prepare", "; fix; fmt")
 addCommandAlias("testJVM", "zioJsonJVM/test")
 addCommandAlias("testJS", "zioJsonJS/test")
 
@@ -67,11 +62,11 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "com.propensive"                        %%% "magnolia"                % "0.17.0",
       "org.scalaz"                            %%% "scalaz-core"             % "7.3.2" intransitive (),
-      "eu.timepit"                            %%% "refined"                 % "0.9.19" intransitive (),
+      "eu.timepit"                            %%% "refined"                 % "0.9.20" intransitive (),
       "org.scala-lang"                          % "scala-reflect"           % scalaVersion.value % Provided,
       "dev.zio"                               %%% "zio"                     % zioVersion,
       "dev.zio"                               %%% "zio-streams"             % zioVersion,
-      "org.scala-lang.modules"                %%% "scala-collection-compat" % "2.3.1",
+      "org.scala-lang.modules"                %%% "scala-collection-compat" % "2.3.2",
       "dev.zio"                               %%% "zio-test"                % zioVersion         % "test",
       "dev.zio"                               %%% "zio-test-sbt"            % zioVersion         % "test",
       "io.circe"                              %%% "circe-core"              % circeVersion       % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -24,11 +24,18 @@ inThisBuild(
   )
 )
 
+addCommandAlias("fix", "scalafixAll")
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt jmh:scalafmt")
+addCommandAlias("fixCheck", "scalafixAll --check")
 addCommandAlias("fix", "all compile:scalafix test:scalafix")
+addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
 addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck jmh:scalafmtCheck")
+addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheckAll")
 addCommandAlias("fixCheck", "; compile:scalafix --check ; test:scalafix --check ")
+addCommandAlias("prepare", "fix; fmt")
 addCommandAlias("prepare", "; fix; fmt")
+addCommandAlias("testJVM", "zioJsonJVM/test")
+addCommandAlias("testJS", "zioJsonJS/test")
 
 val zioVersion = "1.0.3"
 
@@ -71,7 +78,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
       "io.circe"                              %%% "circe-generic"           % circeVersion       % "test",
       "io.circe"                              %%% "circe-parser"            % circeVersion       % "test",
       "io.circe"                              %%% "circe-generic-extras"    % circeVersion       % "test",
-      "com.typesafe.play"                     %%% "play-json"               % "2.9.1"            % "test",
+      "com.typesafe.play"                     %%% "play-json"               % "2.9.2"            % "test",
       "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core"     % "2.6.2"            % "test",
       "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-macros"   % "2.6.2"            % "test"
     ),
@@ -166,7 +173,7 @@ lazy val docs = project
     scalacOptions -= "-Xfatal-warnings",
     libraryDependencies ++= Seq(
       "dev.zio"    %% "zio"     % zioVersion,
-      "eu.timepit" %% "refined" % "0.9.19"
+      "eu.timepit" %% "refined" % "0.9.20"
     ),
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(root),
     target in (ScalaUnidoc, unidoc) := (baseDirectory in LocalRootProject).value / "website" / "static" / "api",

--- a/build.sbt
+++ b/build.sbt
@@ -24,13 +24,11 @@ inThisBuild(
   )
 )
 
-addCommandAlias("fix", "scalafixAll")
-addCommandAlias("fixCheck", "scalafixAll --check")
-addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
-addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheckAll")
-addCommandAlias("prepare", "fix; fmt")
-addCommandAlias("testJVM", "zioJsonJVM/test")
-addCommandAlias("testJS", "zioJsonJS/test")
+addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt jmh:scalafmt")
+addCommandAlias("fix", "all compile:scalafix test:scalafix")
+addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck jmh:scalafmtCheck")
+addCommandAlias("fixCheck", "; compile:scalafix --check ; test:scalafix --check ")
+addCommandAlias("prepare", "; fix; fmt")
 
 val zioVersion = "1.0.3"
 
@@ -60,24 +58,22 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
     scalacOptions -= "-opt:l:inline",
     scalacOptions -= "-opt-inline-from:zio.internal.**",
     libraryDependencies ++= Seq(
-      "com.propensive"                        %% "magnolia"                % "0.17.0",
-      "org.scalaz"                            %% "scalaz-core"             % "7.3.2" intransitive (),
-      "eu.timepit"                            %% "refined"                 % "0.9.20" intransitive (),
-      "org.scala-lang"                         % "scala-reflect"           % scalaVersion.value % Provided,
-      "dev.zio"                               %% "zio"                     % zioVersion,
-      "dev.zio"                               %% "zio-streams"             % zioVersion,
-      "org.scala-lang.modules"                %% "scala-collection-compat" % "2.3.2",
-      "dev.zio"                               %% "zio-test"                % zioVersion         % "test",
-      "dev.zio"                               %% "zio-test-sbt"            % zioVersion         % "test",
-      "io.circe"                              %% "circe-core"              % circeVersion       % "test",
-      "io.circe"                              %% "circe-generic"           % circeVersion       % "test",
-      "io.circe"                              %% "circe-parser"            % circeVersion       % "test",
-      "ai.x"                                  %% "play-json-extensions"    % "0.42.0"           % "test",
-      "io.circe"                              %% "circe-generic-extras"    % circeVersion       % "test",
-      "com.typesafe.play"                     %% "play-json"               % "2.9.2"            % "test",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"     % "2.6.2"            % "test",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"   % "2.6.2"            % "test",
-      "org.typelevel"                         %% "jawn-ast"                % "1.0.3"            % "test"
+      "com.propensive"                        %%% "magnolia"                % "0.17.0",
+      "org.scalaz"                            %%% "scalaz-core"             % "7.3.2" intransitive (),
+      "eu.timepit"                            %%% "refined"                 % "0.9.19" intransitive (),
+      "org.scala-lang"                          % "scala-reflect"           % scalaVersion.value % Provided,
+      "dev.zio"                               %%% "zio"                     % zioVersion,
+      "dev.zio"                               %%% "zio-streams"             % zioVersion,
+      "org.scala-lang.modules"                %%% "scala-collection-compat" % "2.3.1",
+      "dev.zio"                               %%% "zio-test"                % zioVersion         % "test",
+      "dev.zio"                               %%% "zio-test-sbt"            % zioVersion         % "test",
+      "io.circe"                              %%% "circe-core"              % circeVersion       % "test",
+      "io.circe"                              %%% "circe-generic"           % circeVersion       % "test",
+      "io.circe"                              %%% "circe-parser"            % circeVersion       % "test",
+      "io.circe"                              %%% "circe-generic-extras"    % circeVersion       % "test",
+      "com.typesafe.play"                     %%% "play-json"               % "2.9.1"            % "test",
+      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core"     % "2.6.2"            % "test",
+      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-macros"   % "2.6.2"            % "test"
     ),
     sourceGenerators in Compile += Def.task {
       val dir  = (sourceManaged in Compile).value
@@ -145,9 +141,18 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
     inConfig(Jmh)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
   )
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
+  .jvmSettings(
+    libraryDependencies ++= Seq(
+      "ai.x"          %% "play-json-extensions" % "0.42.0" % "test",
+      "org.typelevel" %% "jawn-ast"             % "1.0.3"  % "test"
+    )
+  )
 
 lazy val zioJsonJS = zioJson.js
-  .settings(scalaJSUseMainModuleInitializer := true)
+  .settings(
+    scalaJSUseMainModuleInitializer := true,
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+  )
 
 lazy val zioJsonJVM = zioJson.jvm
 
@@ -161,7 +166,7 @@ lazy val docs = project
     scalacOptions -= "-Xfatal-warnings",
     libraryDependencies ++= Seq(
       "dev.zio"    %% "zio"     % zioVersion,
-      "eu.timepit" %% "refined" % "0.9.20"
+      "eu.timepit" %% "refined" % "0.9.19"
     ),
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(root),
     target in (ScalaUnidoc, unidoc) := (baseDirectory in LocalRootProject).value / "website" / "static" / "api",

--- a/zio-json/js/src/main/scala/zio/JsonPackagePlatformSpecific.scala
+++ b/zio-json/js/src/main/scala/zio/JsonPackagePlatformSpecific.scala
@@ -1,0 +1,3 @@
+package zio
+
+trait JsonPackagePlatformSpecific {}

--- a/zio-json/js/src/main/scala/zio/json/JsonDecoderPlatformSpecific.scala
+++ b/zio-json/js/src/main/scala/zio/json/JsonDecoderPlatformSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonDecoderPlatformSpecific[A] { self: JsonDecoder[A] => }

--- a/zio-json/js/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
+++ b/zio-json/js/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonEncoderPlatformSpecific[A] { self: JsonEncoder[A] => }

--- a/zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala
@@ -1,0 +1,93 @@
+package zio
+
+import java.io.{ File, IOException }
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Path, Paths }
+
+import zio.blocking.Blocking
+import zio.json.{ JsonDecoder, JsonEncoder, JsonStreamDelimiter, ast }
+import zio.stream._
+
+trait JsonPackagePlatformSpecific {
+  def readJsonAs(file: File): ZStream[Blocking, Throwable, ast.Json] =
+    readJsonLinesAs[ast.Json](file)
+
+  def readJsonAs(path: Path): ZStream[Blocking, Throwable, ast.Json] =
+    readJsonLinesAs[ast.Json](path)
+
+  def readJsonAs(path: String): ZStream[Blocking, Throwable, ast.Json] =
+    readJsonLinesAs[ast.Json](path)
+
+  def readJsonAs(url: URL): ZStream[Blocking, Throwable, ast.Json] =
+    readJsonLinesAs[ast.Json](url)
+
+  def readJsonLinesAs[A: JsonDecoder](file: File): ZStream[Blocking, Throwable, A] =
+    readJsonLinesAs(file.toPath)
+
+  def readJsonLinesAs[A: JsonDecoder](path: Path): ZStream[Blocking, Throwable, A] =
+    ZStream
+      .fromFile(path)
+      .transduce(
+        ZTransducer.utf8Decode >>>
+          stringToChars >>>
+          JsonDecoder[A].decodeJsonTransducer(JsonStreamDelimiter.Newline)
+      )
+
+  def readJsonLinesAs[A: JsonDecoder](path: String): ZStream[Blocking, Throwable, A] =
+    readJsonLinesAs(Paths.get(path))
+
+  def readJsonLinesAs[A: JsonDecoder](url: URL): ZStream[Blocking, Throwable, A] = {
+    val managed = ZManaged
+      .fromAutoCloseable(ZIO.effect(url.openStream()))
+      .refineToOrDie[IOException]
+
+    ZStream
+      .fromInputStreamManaged(managed)
+      .transduce(
+        ZTransducer.utf8Decode >>>
+          stringToChars >>>
+          JsonDecoder[A].decodeJsonTransducer(JsonStreamDelimiter.Newline)
+      )
+  }
+
+  def writeJsonLines[R <: Blocking](file: File, stream: ZStream[R, Throwable, ast.Json]): RIO[R, Unit] =
+    writeJsonLinesAs(file, stream)
+
+  def writeJsonLines[R <: Blocking](path: Path, stream: ZStream[R, Throwable, ast.Json]): RIO[R, Unit] =
+    writeJsonLinesAs(path, stream)
+
+  def writeJsonLines[R <: Blocking](path: String, stream: ZStream[R, Throwable, ast.Json]): RIO[R, Unit] =
+    writeJsonLinesAs(path, stream)
+
+  def writeJsonLinesAs[R <: Blocking, A: JsonEncoder](file: File, stream: ZStream[R, Throwable, A]): RIO[R, Unit] =
+    writeJsonLinesAs(file.toPath, stream)
+
+  def writeJsonLinesAs[R <: Blocking, A: JsonEncoder](path: Path, stream: ZStream[R, Throwable, A]): RIO[R, Unit] =
+    stream
+      .transduce(
+        JsonEncoder[A].encodeJsonLinesTransducer >>>
+          charsToUtf8
+      )
+      .run(ZSink.fromFile(path))
+      .unit
+
+  def writeJsonLinesAs[R <: Blocking, A: JsonEncoder](path: String, stream: ZStream[R, Throwable, A]): RIO[R, Unit] =
+    writeJsonLinesAs(Paths.get(path), stream)
+
+  private def stringToChars: ZTransducer[Any, Nothing, String, Char] =
+    ZTransducer
+      .fromFunction[String, Chunk[Char]](s => Chunk.fromArray(s.toCharArray))
+      .mapChunks(_.flatten)
+
+  private def charsToUtf8: ZTransducer[Any, Nothing, Char, Byte] =
+    ZTransducer.fromPush {
+      case None =>
+        ZIO.succeed(Chunk.empty)
+
+      case Some(xs) =>
+        ZIO.effectTotal {
+          Chunk.fromArray((new String(xs.toArray)).getBytes(StandardCharsets.UTF_8))
+        }
+    }
+}

--- a/zio-json/jvm/src/main/scala/zio/json/JsonDecoderPlatfomSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/JsonDecoderPlatfomSpecific.scala
@@ -1,0 +1,137 @@
+package zio.json
+
+import scala.annotation.tailrec
+
+import zio._
+import zio.blocking._
+import zio.json.JsonDecoder.JsonError
+import zio.json.internal
+import zio.json.internal._
+import zio.stream.{ Take, ZStream, ZTransducer }
+
+trait JsonDecoderPlatformSpecific[A] { self: JsonDecoder[A] =>
+
+  /**
+   * Attempts to decode a stream of characters into a single value of type `A`, but may fail with
+   * a human-readable exception if the stream does not encode a value of this type.
+   *
+   * Note: This method may not consume the full string.
+   */
+  final def decodeJsonStream[R <: Blocking](stream: ZStream[R, Throwable, Char]): ZIO[R, Throwable, A] =
+    stream.toReader.use { reader =>
+      effectBlocking {
+        try unsafeDecode(Nil, new zio.json.internal.WithRetractReader(reader))
+        catch {
+          case JsonDecoder.UnsafeJson(trace)      => throw new Exception(JsonError.render(trace))
+          case _: zio.json.internal.UnexpectedEnd => throw new Exception("unexpected end of input")
+        }
+      }
+    }
+
+  final def decodeJsonTransducer(
+    delimiter: JsonStreamDelimiter = JsonStreamDelimiter.Array
+  ): ZTransducer[Blocking, Throwable, Char, A] =
+    ZTransducer {
+      for {
+        // format: off
+        runtime    <- ZIO.runtime[Any].toManaged_
+        inQueue    <- Queue.unbounded[Take[Nothing, Char]].toManaged_
+        outQueue   <- Queue.unbounded[Take[Throwable, A]].toManaged_
+        ended      <- Ref.makeManaged(false)
+        reader     <- ZManaged.fromAutoCloseable {
+                        ZIO.effectTotal {
+                          def readPull: Iterator[Chunk[Char]] =
+                            runtime.unsafeRun(inQueue.take)
+                              .fold(
+                                end   = Iterator.empty,
+                                error = _ => Iterator.empty, // impossible
+                                value = v => Iterator.single(v) ++ readPull
+                              )
+
+                          new zio.stream.internal.ZReader(Iterator.empty ++ readPull)
+                        }
+                      }
+        jsonReader <- ZManaged.fromAutoCloseable(ZIO.effectTotal(new WithRetractReader(reader)))
+        process    <- effectBlockingInterrupt {
+                        // Exceptions fall through and are pushed into the queue
+                        @tailrec def loop(atBeginning: Boolean): Unit = {
+                          val nextElem = try {
+                            if (atBeginning && delimiter == JsonStreamDelimiter.Array)  {
+                              Lexer.char(Nil, jsonReader, '[')
+                            } else {
+                              delimiter match {
+                                case JsonStreamDelimiter.Newline =>
+                                  jsonReader.readChar() match {
+                                    case '\r' =>
+                                      jsonReader.readChar() match {
+                                        case '\n' => ()
+                                        case _    => jsonReader.retract()
+                                      }
+                                    case '\n' => ()
+                                    case _    => jsonReader.retract()
+                                  }
+
+                               case JsonStreamDelimiter.Array =>
+                                  jsonReader.nextNonWhitespace() match {
+                                    case ',' | ']' => ()
+                                    case _         => jsonReader.retract()
+                                  }
+                              }
+                            }
+
+                            unsafeDecode(Nil, jsonReader)
+                          } catch {
+                            case t @ JsonDecoder.UnsafeJson(trace) =>
+                              throw new Exception(JsonError.render(trace))
+                          }
+
+                          runtime.unsafeRun(outQueue.offer(Take.single(nextElem)))
+
+                          loop(false)
+                        }
+
+                        loop(true)
+                      }
+                      .catchAll {
+                        case t: internal.UnexpectedEnd =>
+                          // swallow if stream ended
+                          ZIO.unlessM(ended.get) {
+                            outQueue.offer(Take.fail(t))
+                          }
+
+                        case t: Throwable =>
+                          outQueue.offer(Take.fail(t))
+                      }
+                      .interruptible
+                      .forkManaged
+        push = { is: Option[Chunk[Char]] =>
+          val pollElements: IO[Throwable, Chunk[A]] =
+            outQueue
+              .takeUpTo(ZStream.DefaultChunkSize)
+              .flatMap { takes =>
+                ZIO.foldLeft(takes)(Chunk[A]()) { case (acc, take) =>
+                  take.fold(ZIO.succeedNow(acc), e => ZIO.fail(e.squash), c => ZIO.succeedNow(acc ++ c))
+                }
+              }
+
+          val pullRest =
+            outQueue
+              .takeAll
+              .flatMap { takes =>
+                ZIO.foldLeft(takes)(Chunk[A]()) { case (acc, take) =>
+                  take.fold(ZIO.succeedNow(acc), e => ZIO.fail(e.squash), c => ZIO.succeedNow(acc ++ c))
+                }
+              }
+
+          is match {
+            case Some(c) =>
+              inQueue.offer(Take.chunk(c)) *> pollElements
+
+            case None =>
+              ended.set(true) *> inQueue.offer(Take.end) *> process.join *> pullRest
+          }
+        }
+      } yield push
+      // format: on
+    }
+}

--- a/zio-json/jvm/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
@@ -1,0 +1,76 @@
+package zio.json
+
+import zio.blocking._
+import zio.json.internal.{ WriteWriter }
+import zio.stream._
+import zio.{ Chunk, Ref, ZIO, ZManaged }
+
+trait JsonEncoderPlatformSpecific[A] { self: JsonEncoder[A] =>
+
+  /**
+   * Encodes the specified value into a character stream.
+   */
+  final def encodeJsonStream(a: A, indent: Option[Int]): ZStream[Blocking, Throwable, Char] =
+    ZStream(a).transduce(encodeJsonDelimitedTransducer(None, None, None))
+
+  final private def encodeJsonDelimitedTransducer(
+    startWith: Option[Char],
+    delimiter: Option[Char],
+    endWith: Option[Char]
+  ): ZTransducer[Blocking, Throwable, A, Char] =
+    ZTransducer {
+      for {
+        runtime     <- ZIO.runtime[Any].toManaged_
+        chunkBuffer <- Ref.makeManaged(Chunk.fromIterable(startWith.toIterable))
+        writer <- ZManaged.fromAutoCloseable {
+                    ZIO.effectTotal {
+                      new java.io.BufferedWriter(
+                        new java.io.Writer {
+                          override def write(buffer: Array[Char], offset: Int, len: Int): Unit = {
+                            val copy = new Array[Char](len)
+                            System.arraycopy(buffer, offset, copy, 0, len)
+
+                            val chunk = Chunk.fromArray(copy).drop(offset).take(len)
+                            runtime.unsafeRun(chunkBuffer.update(_ ++ chunk))
+                          }
+
+                          override def close(): Unit = ()
+                          override def flush(): Unit = ()
+                        },
+                        ZStream.DefaultChunkSize
+                      )
+                    }
+                  }
+        writeWriter <- ZManaged.succeed(new WriteWriter(writer))
+        push = { is: Option[Chunk[A]] =>
+          val pushChars = chunkBuffer.getAndUpdate(c => if (c.isEmpty) c else Chunk())
+
+          is match {
+            case None =>
+              effectBlocking(writer.close()) *> pushChars.map { terminal =>
+                endWith.fold(terminal) { last =>
+                  // Chop off terminal deliminator
+                  (if (delimiter.isDefined) terminal.dropRight(1) else terminal) :+ last
+                }
+              }
+
+            case Some(xs) =>
+              effectBlocking {
+                for (x <- xs) {
+                  unsafeEncode(x, indent = None, writeWriter)
+
+                  for (s <- delimiter)
+                    writeWriter.write(s)
+                }
+              } *> pushChars
+          }
+        }
+      } yield push
+    }
+
+  final val encodeJsonLinesTransducer: ZTransducer[Blocking, Throwable, A, Char] =
+    encodeJsonDelimitedTransducer(None, Some('\n'), None)
+
+  final val encodeJsonArrayTransducer: ZTransducer[Blocking, Throwable, A, Char] =
+    encodeJsonDelimitedTransducer(Some('['), Some(','), Some(']'))
+}

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -2,8 +2,6 @@ package testzio.json
 
 import java.nio.file.Paths
 
-import scala.collection.immutable
-
 import io.circe
 import org.typelevel.jawn.{ ast => jawn }
 import testzio.json.TestUtils._
@@ -21,26 +19,11 @@ import zio.test.environment.Live
 import zio.test.{ DefaultRunnableSpec, _ }
 import zio.{ test => _, _ }
 
-object DecoderSpec extends DefaultRunnableSpec {
+object DecoderPlatformSpecificSpec extends DefaultRunnableSpec {
   def spec: Spec[ZEnv with Live, TestFailure[Any], TestSuccess] =
     suite("Decoder")(
-      test("primitives") {
-        // this big integer consumes more than 128 bits
-        assert("170141183460469231731687303715884105728".fromJson[java.math.BigInteger])(
-          isLeft(equalTo("(expected a 128 bit BigInteger)"))
-        )
-      },
-      test("eithers") {
-        val bernies = List("""{"a":1}""", """{"left":1}""", """{"Left":1}""")
-        val trumps  = List("""{"b":2}""", """{"right":2}""", """{"Right":2}""")
-
-        assert(bernies.map(_.fromJson[Either[Int, Int]]))(
-          forall(isRight(isLeft(equalTo(1))))
-        ) && assert(trumps.map(_.fromJson[Either[Int, Int]]))(
-          forall(isRight(isRight(equalTo(2))))
-        )
-      },
       testM("excessively nested structures") {
+        // JVM specific: getResourceAsString not yet supported
         val testFile = "json_test_suite/n_structure_open_array_object.json"
 
         for {
@@ -49,36 +32,6 @@ object DecoderSpec extends DefaultRunnableSpec {
         } yield {
           assert(r)(fails(equalTo("Unexpected structure")))
         }
-      },
-      test("parameterless products") {
-        import exampleproducts._
-
-        // actually anything works... consider this a canary test because if only
-        // the empty object is supported that's fine.
-        assert("""{}""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
-        assert("""null""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
-        assert("""{"field":"value"}""".fromJson[Parameterless])(isRight(equalTo(Parameterless())))
-      },
-      test("no extra fields") {
-        import exampleproducts._
-
-        assert("""{"s":""}""".fromJson[OnlyString])(isRight(equalTo(OnlyString("")))) &&
-        assert("""{"s":"","t":""}""".fromJson[OnlyString])(isLeft(equalTo("(invalid extra field)")))
-      },
-      test("sum encoding") {
-        import examplesum._
-
-        assert("""{"Child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
-        assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
-        assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
-      },
-      test("sum alternative encoding") {
-        import examplealtsum._
-
-        assert("""{"hint":"Cain"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
-        assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
-        assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
-        assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
       },
       testM("googleMapsNormal") {
         getResourceAsStringM("google_maps_api_response.json").map { str =>
@@ -149,51 +102,6 @@ object DecoderSpec extends DefaultRunnableSpec {
             }
           }
         }
-      },
-      test("unicode") {
-        assert(""""€🐵🥰"""".fromJson[String])(isRight(equalTo("€🐵🥰")))
-      },
-      test("Seq") {
-        val jsonStr  = """["5XL","2XL","XL"]"""
-        val expected = Seq("5XL", "2XL", "XL")
-
-        assert(jsonStr.fromJson[Seq[String]])(isRight(equalTo(expected)))
-      },
-      test("Vector") {
-        val jsonStr  = """["5XL","2XL","XL"]"""
-        val expected = Vector("5XL", "2XL", "XL")
-
-        assert(jsonStr.fromJson[Vector[String]])(isRight(equalTo(expected)))
-      },
-      test("SortedSet") {
-        val jsonStr  = """["5XL","2XL","XL"]"""
-        val expected = immutable.SortedSet("5XL", "2XL", "XL")
-
-        assert(jsonStr.fromJson[immutable.SortedSet[String]])(isRight(equalTo(expected)))
-      },
-      test("HashSet") {
-        val jsonStr  = """["5XL","2XL","XL"]"""
-        val expected = immutable.HashSet("5XL", "2XL", "XL")
-
-        assert(jsonStr.fromJson[immutable.HashSet[String]])(isRight(equalTo(expected)))
-      },
-      test("Set") {
-        val jsonStr  = """["5XL","2XL","XL"]"""
-        val expected = Set("5XL", "2XL", "XL")
-
-        assert(jsonStr.fromJson[Set[String]])(isRight(equalTo(expected)))
-      },
-      test("Map") {
-        val jsonStr  = """{"5XL":3,"2XL":14,"XL":159}"""
-        val expected = Map("5XL" -> 3, "2XL" -> 14, "XL" -> 159)
-
-        assert(jsonStr.fromJson[Map[String, Int]])(isRight(equalTo(expected)))
-      },
-      test("zio.Chunk") {
-        val jsonStr  = """["5XL","2XL","XL"]"""
-        val expected = Chunk("5XL", "2XL", "XL")
-
-        assert(jsonStr.fromJson[Chunk[String]])(isRight(equalTo(expected)))
       },
       suite("jawn")(
         testAst("bar"),

--- a/zio-json/jvm/src/test/scala/zio/json/EncoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/EncoderPlatformSpecificSpec.scala
@@ -1,0 +1,121 @@
+package zio.json
+
+import java.io.IOException
+import java.nio.file.Files
+
+import io.circe
+import testzio.json.TestUtils._
+import testzio.json.data.geojson.generated._
+import testzio.json.data.googlemaps._
+import testzio.json.data.twitter._
+
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.json._
+import zio.json.ast.Json
+import zio.random.Random
+import zio.stream.ZStream
+import zio.test.Assertion._
+import zio.test.environment.{ Live, TestClock, TestConsole, TestRandom, TestSystem }
+import zio.test.{ DefaultRunnableSpec, assert, _ }
+import zio.{ Chunk, Has }
+
+object EncoderPlatformSpecificSpec extends DefaultRunnableSpec {
+  import testzio.json.DecoderSpec.logEvent._
+
+  def spec: Spec[Has[Annotations.Service] with Has[Live.Service] with Has[Sized.Service] with Has[
+    TestClock.Service
+  ] with Has[TestConfig.Service] with Has[TestConsole.Service] with Has[TestRandom.Service] with Has[
+    TestSystem.Service
+  ] with Has[Clock.Service] with Has[zio.console.Console.Service] with Has[zio.system.System.Service] with Has[
+    Random.Service
+  ] with Has[Blocking.Service], TestFailure[Any], TestSuccess] =
+    suite("Encoder")(
+      suite("roundtrip")(
+        testRoundTrip[DistanceMatrix]("google_maps_api_response"),
+        testRoundTrip[List[Tweet]]("twitter_api_response"),
+        testRoundTrip[GeoJSON]("che.geo")
+      ),
+      suite("ZIO Streams integration")(
+        testM("encodes into a ZStream of Char") {
+          val intEncoder = JsonEncoder[Int]
+          val value      = 1234
+
+          for {
+            chars <- intEncoder.encodeJsonStream(value, indent = None).runCollect
+          } yield {
+            assert(chars.mkString)(equalTo("1234"))
+          }
+        },
+        testM("encodes values that yield a result of length > DefaultChunkSize") {
+          val longString = List.fill(ZStream.DefaultChunkSize * 2)('x').mkString
+
+          for {
+            chars <- JsonEncoder[String].encodeJsonStream(longString, indent = None).runCollect
+          } yield {
+            assert(chars)(hasSize(equalTo(ZStream.DefaultChunkSize * 2 + 2))) &&
+            assert(chars.mkString(""))(equalTo("\"" ++ longString ++ "\""))
+          }
+        },
+        testM("encodeJsonLinesTransducer") {
+          val ints = ZStream(1, 2, 3, 4)
+
+          for {
+            xs <- ints.transduce(JsonEncoder[Int].encodeJsonLinesTransducer).runCollect
+          } yield {
+            assert(xs.mkString)(equalTo("1\n2\n3\n4\n"))
+          }
+        },
+        testM("encodeJsonLinesTransducer handles elements which take up > DefaultChunkSize to encode") {
+          val longString = List.fill(5000)('x').mkString
+
+          val ints    = ZStream(longString, longString)
+          val encoder = JsonEncoder[String]
+
+          for {
+            xs <- ints.transduce(encoder.encodeJsonLinesTransducer).runCollect
+          } yield {
+            // leading `"`, trailing `"` and `\n` = 3
+            assert(xs.size)(equalTo((5000 + 3) * 2))
+          }
+        },
+        testM("encodeJsonArrayTransducer") {
+          val ints = ZStream(1, 2, 3).map(n => Json.Obj(Chunk("id" -> Json.Num(BigDecimal(n).bigDecimal))))
+
+          for {
+            xs <- ints.transduce(JsonEncoder[Json].encodeJsonArrayTransducer).runCollect
+          } yield {
+            assert(xs.mkString)(equalTo("""[{"id":1},{"id":2},{"id":3}]"""))
+          }
+        }
+      ),
+      suite("helpers in zio.json")(
+        testM("writeJsonLines writes JSON lines") {
+          val path = Files.createTempFile("log", "json")
+          val events = Chunk(
+            Event(1603669876, "hello"),
+            Event(1603669875, "world")
+          )
+
+          for {
+            _  <- writeJsonLinesAs(path, ZStream.fromIterable(events))
+            xs <- readJsonLinesAs[Event](path).runCollect
+          } yield {
+            assert(xs)(equalTo(events))
+          }
+        }
+      )
+    )
+
+  def testRoundTrip[A: circe.Decoder: JsonEncoder](label: String): ZSpec[Blocking, IOException] =
+    testM(label) {
+      getResourceAsStringM(s"$label.json").map { input =>
+        val circeDecoded  = circe.parser.decode[A](input)
+        val circeRecoded  = circeDecoded.toOption.get.toJson
+        val recodedPretty = circeDecoded.toOption.get.toJson
+
+        assert(circe.parser.decode[A](circeRecoded))(equalTo(circeDecoded)) &&
+        assert(circe.parser.decode[A](recodedPretty))(equalTo(circeDecoded))
+      }
+    }
+}

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -4,17 +4,15 @@ import scala.annotation._
 import scala.collection.{ immutable, mutable }
 import scala.util.control.NoStackTrace
 
-import zio.blocking._
+import zio.Chunk
 import zio.json.JsonDecoder.JsonError
 import zio.json.internal._
-import zio.stream.{ Take, ZStream, ZTransducer }
-import zio.{ Chunk, IO, Queue, Ref, ZIO, ZManaged }
 
 /**
  * A `JsonDecoder[A]` instance has the ability to decode JSON to values of type `A`, potentially
  * failing with an error if the JSON content does not encode a value of the given type.
  */
-trait JsonDecoder[A] { self =>
+trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] { self =>
 
   /**
    * An alias for [[JsonDecoder#orElse]].
@@ -53,130 +51,6 @@ trait JsonDecoder[A] { self =>
       case JsonDecoder.UnsafeJson(trace) => Left(JsonError.render(trace))
       case _: internal.UnexpectedEnd     => Left("Unexpected end of input")
       case _: StackOverflowError         => Left("Unexpected structure")
-    }
-
-  /**
-   * Attempts to decode a stream of characters into a single value of type `A`, but may fail with
-   * a human-readable exception if the stream does not encode a value of this type.
-   *
-   * Note: This method may not consume the full string.
-   */
-  final def decodeJsonStream[R <: Blocking](stream: ZStream[R, Throwable, Char]): ZIO[R, Throwable, A] =
-    stream.toReader.use { reader =>
-      effectBlocking {
-        try unsafeDecode(Nil, new zio.json.internal.WithRetractReader(reader))
-        catch {
-          case JsonDecoder.UnsafeJson(trace) => throw new Exception(JsonError.render(trace))
-          case _: internal.UnexpectedEnd     => throw new Exception("unexpected end of input")
-        }
-      }
-    }
-
-  final def decodeJsonTransducer(
-    delimiter: JsonStreamDelimiter = JsonStreamDelimiter.Array
-  ): ZTransducer[Blocking, Throwable, Char, A] =
-    ZTransducer {
-      for {
-        // format: off
-        runtime    <- ZIO.runtime[Any].toManaged_
-        inQueue    <- Queue.unbounded[Take[Nothing, Char]].toManaged_
-        outQueue   <- Queue.unbounded[Take[Throwable, A]].toManaged_
-        ended      <- Ref.makeManaged(false)
-        reader     <- ZManaged.fromAutoCloseable {
-                        ZIO.effectTotal {
-                          def readPull: Iterator[Chunk[Char]] =
-                            runtime.unsafeRun(inQueue.take)
-                              .fold(
-                                end   = Iterator.empty,
-                                error = _ => Iterator.empty, // impossible
-                                value = v => Iterator.single(v) ++ readPull
-                              )
-
-                          new zio.stream.internal.ZReader(Iterator.empty ++ readPull)
-                        }
-                      }
-        jsonReader <- ZManaged.fromAutoCloseable(ZIO.effectTotal(new WithRetractReader(reader)))
-        process    <- effectBlockingInterrupt {
-                        // Exceptions fall through and are pushed into the queue
-                        @tailrec def loop(atBeginning: Boolean): Unit = {
-                          val nextElem = try {
-                            if (atBeginning && delimiter == JsonStreamDelimiter.Array)  {
-                              Lexer.char(Nil, jsonReader, '[')
-                            } else {
-                              delimiter match {
-                                case JsonStreamDelimiter.Newline =>
-                                  jsonReader.readChar() match {
-                                    case '\r' =>
-                                      jsonReader.readChar() match {
-                                        case '\n' => ()
-                                        case _    => jsonReader.retract()
-                                      }
-                                    case '\n' => ()
-                                    case _    => jsonReader.retract()
-                                  }
-
-                               case JsonStreamDelimiter.Array =>
-                                  jsonReader.nextNonWhitespace() match {
-                                    case ',' | ']' => ()
-                                    case _         => jsonReader.retract()
-                                  }
-                              }
-                            }
-
-                            unsafeDecode(Nil, jsonReader)
-                          } catch {
-                            case t @ JsonDecoder.UnsafeJson(trace) =>
-                              throw new Exception(JsonError.render(trace))
-                          }
-
-                          runtime.unsafeRun(outQueue.offer(Take.single(nextElem)))
-
-                          loop(false)
-                        }
-
-                        loop(true)
-                      }
-                      .catchAll {
-                        case t: internal.UnexpectedEnd =>
-                          // swallow if stream ended
-                          ZIO.unlessM(ended.get) {
-                            outQueue.offer(Take.fail(t))
-                          }
-
-                        case t: Throwable =>
-                          outQueue.offer(Take.fail(t))
-                      }
-                      .interruptible
-                      .forkManaged
-        push = { is: Option[Chunk[Char]] =>
-          val pollElements: IO[Throwable, Chunk[A]] =
-            outQueue
-              .takeUpTo(ZStream.DefaultChunkSize)
-              .flatMap { takes =>
-                ZIO.foldLeft(takes)(Chunk[A]()) { case (acc, take) =>
-                  take.fold(ZIO.succeedNow(acc), e => ZIO.fail(e.squash), c => ZIO.succeedNow(acc ++ c))
-                }
-              }
-
-          val pullRest =
-            outQueue
-              .takeAll
-              .flatMap { takes =>
-                ZIO.foldLeft(takes)(Chunk[A]()) { case (acc, take) =>
-                  take.fold(ZIO.succeedNow(acc), e => ZIO.fail(e.squash), c => ZIO.succeedNow(acc ++ c))
-                }
-              }
-
-          is match {
-            case Some(c) =>
-              inQueue.offer(Take.chunk(c)) *> pollElements
-
-            case None =>
-              ended.set(true) *> inQueue.offer(Take.end) *> process.join *> pullRest
-          }
-        }
-      } yield push
-      // format: on
     }
 
   /**

--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -6,12 +6,10 @@ import java.time.temporal.ChronoField.YEAR
 import scala.annotation._
 import scala.collection.immutable
 
-import zio.blocking._
-import zio.json.internal.{ FastStringWrite, Write, WriteWriter }
-import zio.stream._
-import zio.{ Chunk, Ref, ZIO, ZManaged }
+import zio.{ Chunk }
+import zio.json.internal.{ FastStringWrite, Write }
 
-trait JsonEncoder[A] { self =>
+trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] { self =>
 
   /**
    * Returns a new encoder that is capable of encoding a tuple containing the values of this
@@ -58,73 +56,6 @@ trait JsonEncoder[A] { self =>
     unsafeEncode(a, indent, writer)
     writer.buffer
   }
-
-  /**
-   * Encodes the specified value into a character stream.
-   */
-  final def encodeJsonStream(a: A, indent: Option[Int]): ZStream[Blocking, Throwable, Char] =
-    ZStream(a).transduce(encodeJsonDelimitedTransducer(None, None, None))
-
-  final private def encodeJsonDelimitedTransducer(
-    startWith: Option[Char],
-    delimiter: Option[Char],
-    endWith: Option[Char]
-  ): ZTransducer[Blocking, Throwable, A, Char] =
-    ZTransducer {
-      for {
-        runtime     <- ZIO.runtime[Any].toManaged_
-        chunkBuffer <- Ref.makeManaged(Chunk.fromIterable(startWith.toIterable))
-        writer <- ZManaged.fromAutoCloseable {
-                    ZIO.effectTotal {
-                      new java.io.BufferedWriter(
-                        new java.io.Writer {
-                          override def write(buffer: Array[Char], offset: Int, len: Int): Unit = {
-                            val copy = new Array[Char](len)
-                            System.arraycopy(buffer, offset, copy, 0, len)
-
-                            val chunk = Chunk.fromArray(copy).drop(offset).take(len)
-                            runtime.unsafeRun(chunkBuffer.update(_ ++ chunk))
-                          }
-
-                          override def close(): Unit = ()
-                          override def flush(): Unit = ()
-                        },
-                        ZStream.DefaultChunkSize
-                      )
-                    }
-                  }
-        writeWriter <- ZManaged.succeed(new WriteWriter(writer))
-        push = { is: Option[Chunk[A]] =>
-          val pushChars = chunkBuffer.getAndUpdate(c => if (c.isEmpty) c else Chunk())
-
-          is match {
-            case None =>
-              effectBlocking(writer.close()) *> pushChars.map { terminal =>
-                endWith.fold(terminal) { last =>
-                  // Chop off terminal deliminator
-                  (if (delimiter.isDefined) terminal.dropRight(1) else terminal) :+ last
-                }
-              }
-
-            case Some(xs) =>
-              effectBlocking {
-                for (x <- xs) {
-                  unsafeEncode(x, indent = None, writeWriter)
-
-                  for (s <- delimiter)
-                    writeWriter.write(s)
-                }
-              } *> pushChars
-          }
-        }
-      } yield push
-    }
-
-  final val encodeJsonLinesTransducer: ZTransducer[Blocking, Throwable, A, Char] =
-    encodeJsonDelimitedTransducer(None, Some('\n'), None)
-
-  final val encodeJsonArrayTransducer: ZTransducer[Blocking, Throwable, A, Char] =
-    encodeJsonDelimitedTransducer(Some('['), Some(','), Some(']'))
 
   /**
    * This default may be overriden when this value may be missing within a JSON object and still

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -1,7 +1,6 @@
 package zio.json.internal
 
 import scala.annotation._
-import scala.util.Properties.propOrNone
 
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 
@@ -12,7 +11,7 @@ object Lexer {
   // TODO need a variant that doesn't skip whitespace, so that attack vectors
   // consisting of an infinite stream of space can exit early.
 
-  val NumberMaxBits: Int = propOrNone("zio.json.number.bits").getOrElse("128").toInt
+  val NumberMaxBits: Int = 128
 
   // True if we got a string (implies a retraction), False for }
   def firstField(trace: List[JsonError], in: RetractReader): Boolean =

--- a/zio-json/shared/src/main/scala/zio/json/package.scala
+++ b/zio-json/shared/src/main/scala/zio/json/package.scala
@@ -1,14 +1,6 @@
 package zio
 
-import java.io.{ File, IOException }
-import java.net.URL
-import java.nio.charset.StandardCharsets
-import java.nio.file.{ Path, Paths }
-
-import zio.blocking.Blocking
-import zio.stream._
-
-package object json {
+package object json extends JsonPackagePlatformSpecific {
   implicit final class EncoderOps[A](private val a: A) extends AnyVal {
     def toJson(implicit A: JsonEncoder[A]): String = A.encodeJson(a, None).toString
 
@@ -31,85 +23,4 @@ package object json {
      */
     def fromJson[A](implicit A: JsonDecoder[A]): Either[String, A] = A.decodeJson(json)
   }
-
-  def readJsonAs(file: File): ZStream[Blocking, Throwable, ast.Json] =
-    readJsonLinesAs[ast.Json](file)
-
-  def readJsonAs(path: Path): ZStream[Blocking, Throwable, ast.Json] =
-    readJsonLinesAs[ast.Json](path)
-
-  def readJsonAs(path: String): ZStream[Blocking, Throwable, ast.Json] =
-    readJsonLinesAs[ast.Json](path)
-
-  def readJsonAs(url: URL): ZStream[Blocking, Throwable, ast.Json] =
-    readJsonLinesAs[ast.Json](url)
-
-  def readJsonLinesAs[A: JsonDecoder](file: File): ZStream[Blocking, Throwable, A] =
-    readJsonLinesAs(file.toPath)
-
-  def readJsonLinesAs[A: JsonDecoder](path: Path): ZStream[Blocking, Throwable, A] =
-    ZStream
-      .fromFile(path)
-      .transduce(
-        ZTransducer.utf8Decode >>>
-          stringToChars >>>
-          JsonDecoder[A].decodeJsonTransducer(JsonStreamDelimiter.Newline)
-      )
-
-  def readJsonLinesAs[A: JsonDecoder](path: String): ZStream[Blocking, Throwable, A] =
-    readJsonLinesAs(Paths.get(path))
-
-  def readJsonLinesAs[A: JsonDecoder](url: URL): ZStream[Blocking, Throwable, A] = {
-    val managed = ZManaged
-      .fromAutoCloseable(ZIO.effect(url.openStream()))
-      .refineToOrDie[IOException]
-
-    ZStream
-      .fromInputStreamManaged(managed)
-      .transduce(
-        ZTransducer.utf8Decode >>>
-          stringToChars >>>
-          JsonDecoder[A].decodeJsonTransducer(JsonStreamDelimiter.Newline)
-      )
-  }
-
-  def writeJsonLines[R <: Blocking](file: File, stream: ZStream[R, Throwable, ast.Json]): RIO[R, Unit] =
-    writeJsonLinesAs(file, stream)
-
-  def writeJsonLines[R <: Blocking](path: Path, stream: ZStream[R, Throwable, ast.Json]): RIO[R, Unit] =
-    writeJsonLinesAs(path, stream)
-
-  def writeJsonLines[R <: Blocking](path: String, stream: ZStream[R, Throwable, ast.Json]): RIO[R, Unit] =
-    writeJsonLinesAs(path, stream)
-
-  def writeJsonLinesAs[R <: Blocking, A: JsonEncoder](file: File, stream: ZStream[R, Throwable, A]): RIO[R, Unit] =
-    writeJsonLinesAs(file.toPath, stream)
-
-  def writeJsonLinesAs[R <: Blocking, A: JsonEncoder](path: Path, stream: ZStream[R, Throwable, A]): RIO[R, Unit] =
-    stream
-      .transduce(
-        JsonEncoder[A].encodeJsonLinesTransducer >>>
-          charsToUtf8
-      )
-      .run(ZSink.fromFile(path))
-      .unit
-
-  def writeJsonLinesAs[R <: Blocking, A: JsonEncoder](path: String, stream: ZStream[R, Throwable, A]): RIO[R, Unit] =
-    writeJsonLinesAs(Paths.get(path), stream)
-
-  private def stringToChars: ZTransducer[Any, Nothing, String, Char] =
-    ZTransducer
-      .fromFunction[String, Chunk[Char]](s => Chunk.fromArray(s.toCharArray))
-      .mapChunks(_.flatten)
-
-  private def charsToUtf8: ZTransducer[Any, Nothing, Char, Byte] =
-    ZTransducer.fromPush {
-      case None =>
-        ZIO.succeed(Chunk.empty)
-
-      case Some(xs) =>
-        ZIO.effectTotal {
-          Chunk.fromArray((new String(xs.toArray)).getBytes(StandardCharsets.UTF_8))
-        }
-    }
 }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -1,0 +1,151 @@
+package testzio.json
+
+import scala.collection.immutable
+
+import zio.json._
+import zio.test.Assertion._
+import zio.test.environment.Live
+import zio.test.{ DefaultRunnableSpec, _ }
+import zio.{ test => _, _ }
+
+object DecoderSpec extends DefaultRunnableSpec {
+  def spec: Spec[ZEnv with Live, TestFailure[Any], TestSuccess] =
+    suite("Decoder")(
+      test("primitives") {
+        // this big integer consumes more than 128 bits
+        assert("170141183460469231731687303715884105728".fromJson[java.math.BigInteger])(
+          isLeft(equalTo("(expected a 128 bit BigInteger)"))
+        )
+      },
+      test("eithers") {
+        val bernies = List("""{"a":1}""", """{"left":1}""", """{"Left":1}""")
+        val trumps  = List("""{"b":2}""", """{"right":2}""", """{"Right":2}""")
+
+        assert(bernies.map(_.fromJson[Either[Int, Int]]))(
+          forall(isRight(isLeft(equalTo(1))))
+        ) && assert(trumps.map(_.fromJson[Either[Int, Int]]))(
+          forall(isRight(isRight(equalTo(2))))
+        )
+      },
+      test("parameterless products") {
+        import exampleproducts._
+
+        // actually anything works... consider this a canary test because if only
+        // the empty object is supported that's fine.
+        assert("""{}""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+        assert("""null""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+        assert("""{"field":"value"}""".fromJson[Parameterless])(isRight(equalTo(Parameterless())))
+      },
+      test("no extra fields") {
+        import exampleproducts._
+
+        assert("""{"s":""}""".fromJson[OnlyString])(isRight(equalTo(OnlyString("")))) &&
+        assert("""{"s":"","t":""}""".fromJson[OnlyString])(isLeft(equalTo("(invalid extra field)")))
+      },
+      test("sum encoding") {
+        import examplesum._
+
+        assert("""{"Child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+        assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+        assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
+      },
+      test("sum alternative encoding") {
+        import examplealtsum._
+
+        assert("""{"hint":"Cain"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+        assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+        assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+        assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
+      },
+      test("unicode") {
+        assert(""""€🐵🥰"""".fromJson[String])(isRight(equalTo("€🐵🥰")))
+      },
+      test("Seq") {
+        val jsonStr  = """["5XL","2XL","XL"]"""
+        val expected = Seq("5XL", "2XL", "XL")
+
+        assert(jsonStr.fromJson[Seq[String]])(isRight(equalTo(expected)))
+      },
+      test("Vector") {
+        val jsonStr  = """["5XL","2XL","XL"]"""
+        val expected = Vector("5XL", "2XL", "XL")
+
+        assert(jsonStr.fromJson[Vector[String]])(isRight(equalTo(expected)))
+      },
+      test("SortedSet") {
+        val jsonStr  = """["5XL","2XL","XL"]"""
+        val expected = immutable.SortedSet("5XL", "2XL", "XL")
+
+        assert(jsonStr.fromJson[immutable.SortedSet[String]])(isRight(equalTo(expected)))
+      },
+      test("HashSet") {
+        val jsonStr  = """["5XL","2XL","XL"]"""
+        val expected = immutable.HashSet("5XL", "2XL", "XL")
+
+        assert(jsonStr.fromJson[immutable.HashSet[String]])(isRight(equalTo(expected)))
+      },
+      test("Set") {
+        val jsonStr  = """["5XL","2XL","XL"]"""
+        val expected = Set("5XL", "2XL", "XL")
+
+        assert(jsonStr.fromJson[Set[String]])(isRight(equalTo(expected)))
+      },
+      test("Map") {
+        val jsonStr  = """{"5XL":3,"2XL":14,"XL":159}"""
+        val expected = Map("5XL" -> 3, "2XL" -> 14, "XL" -> 159)
+
+        assert(jsonStr.fromJson[Map[String, Int]])(isRight(equalTo(expected)))
+      },
+      test("zio.Chunk") {
+        val jsonStr  = """["5XL","2XL","XL"]"""
+        val expected = Chunk("5XL", "2XL", "XL")
+
+        assert(jsonStr.fromJson[Chunk[String]])(isRight(equalTo(expected)))
+      }
+    )
+
+  object exampleproducts {
+    case class Parameterless()
+    object Parameterless {
+      implicit val decoder: JsonDecoder[Parameterless] =
+        DeriveJsonDecoder.gen[Parameterless]
+    }
+
+    @jsonNoExtraFields
+    case class OnlyString(s: String)
+    object OnlyString {
+      implicit val decoder: JsonDecoder[OnlyString] =
+        DeriveJsonDecoder.gen[OnlyString]
+    }
+  }
+
+  object examplesum {
+    sealed abstract class Parent
+    object Parent {
+      implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
+    }
+    case class Child1() extends Parent
+    case class Child2() extends Parent
+  }
+
+  object examplealtsum {
+    @jsonDiscriminator("hint")
+    sealed abstract class Parent
+    object Parent {
+      implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
+    }
+
+    @jsonHint("Cain")
+    case class Child1() extends Parent
+
+    @jsonHint("Abel")
+    case class Child2() extends Parent
+  }
+
+  object logEvent {
+    case class Event(at: Long, message: String)
+
+    implicit val eventDecoder: JsonDecoder[Event] = DeriveJsonDecoder.gen[Event]
+    implicit val eventEncoder: JsonEncoder[Event] = DeriveJsonEncoder.gen[Event]
+  }
+}

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -1,25 +1,13 @@
 package testzio.json
 
-import java.io.IOException
-import java.nio.file.Files
-
-import io.circe
-import testzio.json.TestUtils._
-import testzio.json.data.geojson.generated._
-import testzio.json.data.googlemaps._
-import testzio.json.data.twitter._
-
-import zio.{ Chunk }
-import zio.blocking.Blocking
 import zio.json._
-import zio.json.ast.Json
-import zio.stream.ZStream
 import zio.test.Assertion._
+import zio.test.TestAspect._
 import zio.test.{ DefaultRunnableSpec, assert, _ }
 
 // zioJsonJVM/testOnly testzio.json.EncoderSpec
 object EncoderSpec extends DefaultRunnableSpec {
-  def spec: Spec[Blocking, TestFailure[Throwable], TestSuccess] =
+  def spec: Spec[Annotations, TestFailure[Any], TestSuccess] =
     suite("Encoder")(
       suite("primitives")(
         test("strings") {
@@ -47,7 +35,7 @@ object EncoderSpec extends DefaultRunnableSpec {
           ) &&
           assert((1.0f).toJson)(equalTo("1.0")) &&
           assert((1.0d).toJson)(equalTo("1.0"))
-        },
+        } @@ jvmOnly,
         test("NaN / Infinity") {
           assert(Float.NaN.toJson)(equalTo("\"NaN\"")) &&
           assert(Float.PositiveInfinity.toJson)(equalTo("\"Infinity\"")) &&
@@ -105,7 +93,7 @@ object EncoderSpec extends DefaultRunnableSpec {
         ) &&
         assert(CoupleOfThings(0, None, true).toJsonPretty)(equalTo("{\n  \"j\" : 0,\n  \"b\" : true\n}")) &&
         assert(OptionalAndRequired(None, "foo").toJson)(equalTo("""{"s":"foo"}"""))
-      },
+      } @@ jvmOnly,
       test("sum encoding") {
         import examplesum._
 
@@ -126,96 +114,8 @@ object EncoderSpec extends DefaultRunnableSpec {
         assert((Child2(Some("hello")): Parent).toJsonPretty)(
           equalTo("{\n  \"hint\" : \"Abel\",\n  \"s\" : \"hello\"\n}")
         )
-      },
-      suite("roundtrip")(
-        testRoundTrip[DistanceMatrix]("google_maps_api_response"),
-        testRoundTrip[List[Tweet]]("twitter_api_response"),
-        testRoundTrip[GeoJSON]("che.geo")
-      ),
-      suite("ZIO Streams integration")(
-        testM("encodes into a ZStream of Char") {
-          val intEncoder = JsonEncoder[Int]
-          val value      = 1234
-
-          for {
-            chars <- intEncoder.encodeJsonStream(value, indent = None).runCollect
-          } yield {
-            assert(chars.mkString)(equalTo("1234"))
-          }
-        },
-        testM("encodes values that yield a result of length > DefaultChunkSize") {
-          val longString = List.fill(ZStream.DefaultChunkSize * 2)('x').mkString
-
-          for {
-            chars <- JsonEncoder[String].encodeJsonStream(longString, indent = None).runCollect
-          } yield {
-            assert(chars)(hasSize(equalTo(ZStream.DefaultChunkSize * 2 + 2))) &&
-            assert(chars.mkString(""))(equalTo("\"" ++ longString ++ "\""))
-          }
-        },
-        testM("encodeJsonLinesTransducer") {
-          val ints = ZStream(1, 2, 3, 4)
-
-          for {
-            xs <- ints.transduce(JsonEncoder[Int].encodeJsonLinesTransducer).runCollect
-          } yield {
-            assert(xs.mkString)(equalTo("1\n2\n3\n4\n"))
-          }
-        },
-        testM("encodeJsonLinesTransducer handles elements which take up > DefaultChunkSize to encode") {
-          val longString = List.fill(5000)('x').mkString
-
-          val ints    = ZStream(longString, longString)
-          val encoder = JsonEncoder[String]
-
-          for {
-            xs <- ints.transduce(encoder.encodeJsonLinesTransducer).runCollect
-          } yield {
-            // leading `"`, trailing `"` and `\n` = 3
-            assert(xs.size)(equalTo((5000 + 3) * 2))
-          }
-        },
-        testM("encodeJsonArrayTransducer") {
-          val ints = ZStream(1, 2, 3).map(n => Json.Obj(Chunk("id" -> Json.Num(BigDecimal(n).bigDecimal))))
-
-          for {
-            xs <- ints.transduce(JsonEncoder[Json].encodeJsonArrayTransducer).runCollect
-          } yield {
-            assert(xs.mkString)(equalTo("""[{"id":1},{"id":2},{"id":3}]"""))
-          }
-        }
-      ),
-      suite("helpers in zio.json")(
-        testM("writeJsonLines writes JSON lines") {
-          import DecoderSpec.logEvent._
-
-          val path = Files.createTempFile("log", "json")
-          val events = Chunk(
-            Event(1603669876, "hello"),
-            Event(1603669875, "world")
-          )
-
-          for {
-            _  <- writeJsonLinesAs(path, ZStream.fromIterable(events))
-            xs <- readJsonLinesAs[Event](path).runCollect
-          } yield {
-            assert(xs)(equalTo(events))
-          }
-        }
-      )
-    )
-
-  def testRoundTrip[A: circe.Decoder: JsonEncoder](label: String): ZSpec[Blocking, IOException] =
-    testM(label) {
-      getResourceAsStringM(s"$label.json").map { input =>
-        val circeDecoded  = circe.parser.decode[A](input)
-        val circeRecoded  = circeDecoded.toOption.get.toJson
-        val recodedPretty = circeDecoded.toOption.get.toJson
-
-        assert(circe.parser.decode[A](circeRecoded))(equalTo(circeDecoded)) &&
-        assert(circe.parser.decode[A](recodedPretty))(equalTo(circeDecoded))
       }
-    }
+    )
 
   object exampleproducts {
     case class Parameterless()


### PR DESCRIPTION
Closes #50

Moves platform specific implementations (and tests) to `*PlatformSpecific`.
Core API, derivation, and AST is working, ZStream support moves to JVM only for now.