### PR TITLE
Fix issue with codecs

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -65,8 +65,8 @@ object JsonCodec {
 
           override def decoder: JsonDecoder[A] = decoder0
 
-//          override def unsafeDecodeMissing(trace: List[JsonError]): A =
-//            decoder0.unsafeDecodeMissing(trace)
+          override def unsafeDecodeMissing(trace: List[JsonError]): A =
+            decoder0.unsafeDecodeMissing(trace)
 
           override def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
             decoder0.unsafeDecode(trace, in)

--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -27,8 +27,28 @@ trait JsonCodec[A] extends JsonDecoder[A] with JsonEncoder[A] {
   override def xmap[B](f: A => B, g: B => A): JsonCodec[B] =
     JsonCodec(encoder.contramap(g), decoder.map(f))
 }
+
 object JsonCodec {
   def apply[A](implicit jsonCodec: JsonCodec[A]): JsonCodec[A] = jsonCodec
+
+  implicit val string: JsonCodec[String]                   = JsonCodec(JsonEncoder.string, JsonDecoder.string)
+  implicit val boolean: JsonCodec[Boolean]                 = JsonCodec(JsonEncoder.boolean, JsonDecoder.boolean)
+  implicit val char: JsonCodec[Char]                       = JsonCodec(JsonEncoder.char, JsonDecoder.char)
+  implicit val long: JsonCodec[Long]                       = JsonCodec(JsonEncoder.long, JsonDecoder.long)
+  implicit val symbol: JsonCodec[Symbol]                   = JsonCodec(JsonEncoder.symbol, JsonDecoder.symbol)
+  implicit val byte: JsonCodec[Byte]                       = JsonCodec(JsonEncoder.byte, JsonDecoder.byte)
+  implicit val short: JsonCodec[Short]                     = JsonCodec(JsonEncoder.short, JsonDecoder.short)
+  implicit val int: JsonCodec[Int]                         = JsonCodec(JsonEncoder.int, JsonDecoder.int)
+  implicit val bigInteger: JsonCodec[java.math.BigInteger] = JsonCodec(JsonEncoder.bigInteger, JsonDecoder.bigInteger)
+  implicit val double: JsonCodec[Double]                   = JsonCodec(JsonEncoder.double, JsonDecoder.double)
+  implicit val float: JsonCodec[Float]                     = JsonCodec(JsonEncoder.float, JsonDecoder.float)
+  implicit val bigDecimal: JsonCodec[java.math.BigDecimal] = JsonCodec(JsonEncoder.bigDecimal, JsonDecoder.bigDecimal)
+
+  implicit def option[A](implicit c: JsonCodec[A]): JsonCodec[Option[A]] =
+    JsonCodec(JsonEncoder.option(c.encoder), JsonDecoder.option(c.decoder))
+
+  implicit def either[A, B](implicit ac: JsonCodec[A], bc: JsonCodec[B]): JsonCodec[Either[A, B]] =
+    JsonCodec(JsonEncoder.either(ac.encoder, bc.encoder), JsonDecoder.either(ac.decoder, bc.decoder))
 
   /**
    * Derives a `JsonCodec[A]` from an encoder and a decoder.
@@ -41,14 +61,17 @@ object JsonCodec {
         e
       case other =>
         new JsonCodec[A] {
-          def encoder: JsonEncoder[A] = encoder0
+          override def encoder: JsonEncoder[A] = encoder0
 
-          def decoder: JsonDecoder[A] = decoder0
+          override def decoder: JsonDecoder[A] = decoder0
 
-          def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
+//          override def unsafeDecodeMissing(trace: List[JsonError]): A =
+//            decoder0.unsafeDecodeMissing(trace)
+
+          override def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
             decoder0.unsafeDecode(trace, in)
 
-          def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit =
+          override def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit =
             encoder0.unsafeEncode(a, indent, out)
         }
     }

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -1,0 +1,170 @@
+package testzio.json
+
+import scala.collection.immutable
+
+import zio.json._
+import zio.test.Assertion._
+import zio.test.environment.Live
+import zio.test.{ DefaultRunnableSpec, assert, _ }
+import zio.{ test => _, _ }
+
+object CodecSpec extends DefaultRunnableSpec {
+
+  def spec: Spec[ZEnv with Live, TestFailure[Any], TestSuccess] =
+    suite("Codec")(
+      suite("Decoding")(
+        test("empty") {
+          import exampleempty._
+          // this big integer consumes more than 128 bits
+          assert("{}".fromJson[Empty])(
+            isRight(equalTo(Empty(None)))
+          )
+        },
+        test("primitives") {
+          // this big integer consumes more than 128 bits
+          assert("170141183460469231731687303715884105728".fromJson[java.math.BigInteger])(
+            isLeft(equalTo("(expected a 128 bit BigInteger)"))
+          )
+        },
+        test("eithers") {
+          val bernies = List("""{"a":1}""", """{"left":1}""", """{"Left":1}""")
+          val trumps  = List("""{"b":2}""", """{"right":2}""", """{"Right":2}""")
+
+          assert(bernies.map(_.fromJson[Either[Int, Int]]))(
+            forall(isRight(isLeft(equalTo(1))))
+          ) && assert(trumps.map(_.fromJson[Either[Int, Int]]))(
+            forall(isRight(isRight(equalTo(2))))
+          )
+        },
+        test("parameterless products") {
+          import exampleproducts._
+
+          // actually anything works... consider this a canary test because if only
+          // the empty object is supported that's fine.
+          assert("""{}""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+          assert("""null""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+          assert("""{"field":"value"}""".fromJson[Parameterless])(isRight(equalTo(Parameterless())))
+        },
+        test("no extra fields") {
+          import exampleproducts._
+
+          assert("""{"s":""}""".fromJson[OnlyString])(isRight(equalTo(OnlyString("")))) &&
+          assert("""{"s":"","t":""}""".fromJson[OnlyString])(isLeft(equalTo("(invalid extra field)")))
+        },
+        test("sum encoding") {
+          import examplesum._
+
+          assert("""{"Child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
+        },
+        test("sum alternative encoding") {
+          import examplealtsum._
+
+          assert("""{"hint":"Cain"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+          assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
+        },
+        test("unicode") {
+          assert(""""€🐵🥰"""".fromJson[String])(isRight(equalTo("€🐵🥰")))
+        },
+        test("Seq") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = Seq("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[Seq[String]])(isRight(equalTo(expected)))
+        },
+        test("Vector") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = Vector("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[Vector[String]])(isRight(equalTo(expected)))
+        },
+        test("SortedSet") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = immutable.SortedSet("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[immutable.SortedSet[String]])(isRight(equalTo(expected)))
+        },
+        test("HashSet") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = immutable.HashSet("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[immutable.HashSet[String]])(isRight(equalTo(expected)))
+        },
+        test("Set") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = Set("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[Set[String]])(isRight(equalTo(expected)))
+        },
+        test("Map") {
+          val jsonStr  = """{"5XL":3,"2XL":14,"XL":159}"""
+          val expected = Map("5XL" -> 3, "2XL" -> 14, "XL" -> 159)
+
+          assert(jsonStr.fromJson[Map[String, Int]])(isRight(equalTo(expected)))
+        },
+        test("zio.Chunk") {
+          val jsonStr  = """["5XL","2XL","XL"]"""
+          val expected = Chunk("5XL", "2XL", "XL")
+
+          assert(jsonStr.fromJson[Chunk[String]])(isRight(equalTo(expected)))
+        }
+      )
+    )
+
+  object exampleproducts {
+    case class Parameterless()
+
+    object Parameterless {
+      implicit val codec: JsonCodec[Parameterless] = DeriveJsonCodec.gen[Parameterless]
+    }
+
+    @jsonNoExtraFields
+    case class OnlyString(s: String)
+
+    object OnlyString {
+      implicit val codec: JsonCodec[OnlyString] = DeriveJsonCodec.gen[OnlyString]
+    }
+  }
+
+  object examplesum {
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val codec: JsonCodec[Parent] = DeriveJsonCodec.gen[Parent]
+    }
+    case class Child1() extends Parent
+    case class Child2() extends Parent
+  }
+
+  object exampleempty {
+    case class Empty(a: Option[String])
+
+    object Empty {
+      implicit val codec: JsonCodec[Empty] = DeriveJsonCodec.gen[Empty]
+    }
+  }
+
+  object examplealtsum {
+
+    @jsonDiscriminator("hint")
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val codec: JsonCodec[Parent] = DeriveJsonCodec.gen[Parent]
+    }
+
+    @jsonHint("Cain")
+    case class Child1() extends Parent
+
+    @jsonHint("Abel")
+    case class Child2() extends Parent
+  }
+
+  object logEvent {
+    case class Event(at: Long, message: String)
+    implicit val codec: JsonCodec[Event] = DeriveJsonCodec.gen[Event]
+  }
+}

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -15,7 +15,6 @@ object CodecSpec extends DefaultRunnableSpec {
       suite("Decoding")(
         test("empty") {
           import exampleempty._
-          // this big integer consumes more than 128 bits
           assert("{}".fromJson[Empty])(
             isRight(equalTo(Empty(None)))
           )

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -7,6 +7,7 @@ import zio.test.{ DefaultRunnableSpec, assert, _ }
 
 // zioJsonJVM/testOnly testzio.json.EncoderSpec
 object EncoderSpec extends DefaultRunnableSpec {
+
   def spec: Spec[Annotations, TestFailure[Any], TestSuccess] =
     suite("Encoder")(
       suite("primitives")(
@@ -119,24 +120,32 @@ object EncoderSpec extends DefaultRunnableSpec {
 
   object exampleproducts {
     case class Parameterless()
+
     object Parameterless {
+
       implicit val encoder: JsonEncoder[Parameterless] =
         DeriveJsonEncoder.gen[Parameterless]
     }
 
     case class OnlyString(s: String)
+
     object OnlyString {
+
       implicit val encoder: JsonEncoder[OnlyString] =
         DeriveJsonEncoder.gen[OnlyString]
     }
 
     case class CoupleOfThings(@jsonField("j") i: Int, f: Option[Float], b: Boolean)
+
     object CoupleOfThings {
+
       implicit val encoder: JsonEncoder[CoupleOfThings] =
         DeriveJsonEncoder.gen[CoupleOfThings]
     }
     case class OptionalAndRequired(i: Option[Int], s: String)
+
     object OptionalAndRequired {
+
       implicit val encoder: JsonEncoder[OptionalAndRequired] =
         DeriveJsonEncoder.gen[OptionalAndRequired]
     }
@@ -145,22 +154,27 @@ object EncoderSpec extends DefaultRunnableSpec {
   object examplesum {
 
     sealed abstract class Parent
+
     object Parent {
       implicit val encoder: JsonEncoder[Parent] = DeriveJsonEncoder.gen[Parent]
     }
     case class Child1() extends Parent
+
     @jsonHint("Cain")
     case class Child2() extends Parent
   }
 
   object examplealtsum {
+
     @jsonDiscriminator("hint")
     sealed abstract class Parent
+
     object Parent {
       implicit val encoder: JsonEncoder[Parent] = DeriveJsonEncoder.gen[Parent]
     }
 
     case class Child1() extends Parent
+
     @jsonHint("Abel")
     case class Child2(s: Option[String]) extends Parent
   }


### PR DESCRIPTION
@fommil -- This PR fixes the issue that you and Derander were talking about in Discord the other day. The commit `Red` creates a spec for codecs that mirrors the decoder spec, and introduces a new test, `empty`, that fails the build. The commit `Green` fixes the spec by overriding `unsafeDecodeMissing`. To make the test compile, I create several missing codecs on `JsonCodec` by using the analogous values found on JsonEncoder and JsonDecoder, which should make using `DeriveJsonCodec` much easier in general.