### PR TITLE
BigDecimal + Low Priority Codec Implicits

### DIFF
--- a/zio-json/jvm/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
@@ -1,7 +1,7 @@
 package zio.json
 
 import zio.blocking._
-import zio.json.internal.{ WriteWriter }
+import zio.json.internal.WriteWriter
 import zio.stream._
 import zio.{ Chunk, Ref, ZIO, ZManaged }
 

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -2,13 +2,11 @@ package testzio.json
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
-
 import io.circe
 import org.typelevel.jawn.{ ast => jawn }
 import testzio.json.TestUtils._
 import testzio.json.data.googlemaps._
 import testzio.json.data.twitter._
-
 import zio.blocking._
 import zio.duration._
 import zio.json._
@@ -16,12 +14,13 @@ import zio.json.ast._
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.test.environment.Live
-import zio.test.{ DefaultRunnableSpec, _ }
-import zio.{ test => _, _ }
+import zio.test.environment.TestEnvironment
+import zio.test._
+import zio._
 
 object DecoderPlatformSpecificSpec extends DefaultRunnableSpec {
-  def spec: Spec[ZEnv with Live, TestFailure[Any], TestSuccess] =
+
+  def spec: Spec[TestEnvironment, TestFailure[Any], TestSuccess] =
     suite("Decoder")(
       testM("excessively nested structures") {
         // JVM specific: getResourceAsString not yet supported
@@ -340,14 +339,18 @@ object DecoderPlatformSpecificSpec extends DefaultRunnableSpec {
 
   object exampleproducts {
     case class Parameterless()
+
     object Parameterless {
+
       implicit val decoder: JsonDecoder[Parameterless] =
         DeriveJsonDecoder.gen[Parameterless]
     }
 
     @jsonNoExtraFields
     case class OnlyString(s: String)
+
     object OnlyString {
+
       implicit val decoder: JsonDecoder[OnlyString] =
         DeriveJsonDecoder.gen[OnlyString]
     }
@@ -355,6 +358,7 @@ object DecoderPlatformSpecificSpec extends DefaultRunnableSpec {
 
   object examplesum {
     sealed abstract class Parent
+
     object Parent {
       implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
     }
@@ -363,8 +367,10 @@ object DecoderPlatformSpecificSpec extends DefaultRunnableSpec {
   }
 
   object examplealtsum {
+
     @jsonDiscriminator("hint")
     sealed abstract class Parent
+
     object Parent {
       implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
     }

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -2,11 +2,14 @@ package testzio.json
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
+
 import io.circe
 import org.typelevel.jawn.{ ast => jawn }
 import testzio.json.TestUtils._
 import testzio.json.data.googlemaps._
 import testzio.json.data.twitter._
+
+import zio._
 import zio.blocking._
 import zio.duration._
 import zio.json._
@@ -14,9 +17,8 @@ import zio.json.ast._
 import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.test.environment.TestEnvironment
 import zio.test._
-import zio._
+import zio.test.environment.TestEnvironment
 
 object DecoderPlatformSpecificSpec extends DefaultRunnableSpec {
 

--- a/zio-json/jvm/src/test/scala/zio/json/EncoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/EncoderPlatformSpecificSpec.scala
@@ -2,11 +2,14 @@ package zio.json
 
 import java.io.IOException
 import java.nio.file.Files
+
 import io.circe
 import testzio.json.TestUtils._
 import testzio.json.data.geojson.generated._
 import testzio.json.data.googlemaps._
 import testzio.json.data.twitter._
+
+import zio.Chunk
 import zio.blocking.Blocking
 import zio.json._
 import zio.json.ast.Json
@@ -14,7 +17,6 @@ import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.environment.TestEnvironment
 import zio.test.{ DefaultRunnableSpec, assert, _ }
-import zio.Chunk
 
 object EncoderPlatformSpecificSpec extends DefaultRunnableSpec {
   import testzio.json.DecoderSpec.logEvent._

--- a/zio-json/jvm/src/test/scala/zio/json/EncoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/EncoderPlatformSpecificSpec.scala
@@ -2,34 +2,24 @@ package zio.json
 
 import java.io.IOException
 import java.nio.file.Files
-
 import io.circe
 import testzio.json.TestUtils._
 import testzio.json.data.geojson.generated._
 import testzio.json.data.googlemaps._
 import testzio.json.data.twitter._
-
 import zio.blocking.Blocking
-import zio.clock.Clock
 import zio.json._
 import zio.json.ast.Json
-import zio.random.Random
 import zio.stream.ZStream
 import zio.test.Assertion._
-import zio.test.environment.{ Live, TestClock, TestConsole, TestRandom, TestSystem }
+import zio.test.environment.TestEnvironment
 import zio.test.{ DefaultRunnableSpec, assert, _ }
-import zio.{ Chunk, Has }
+import zio.Chunk
 
 object EncoderPlatformSpecificSpec extends DefaultRunnableSpec {
   import testzio.json.DecoderSpec.logEvent._
 
-  def spec: Spec[Has[Annotations.Service] with Has[Live.Service] with Has[Sized.Service] with Has[
-    TestClock.Service
-  ] with Has[TestConfig.Service] with Has[TestConsole.Service] with Has[TestRandom.Service] with Has[
-    TestSystem.Service
-  ] with Has[Clock.Service] with Has[zio.console.Console.Service] with Has[zio.system.System.Service] with Has[
-    Random.Service
-  ] with Has[Blocking.Service], TestFailure[Any], TestSuccess] =
+  def spec: Spec[TestEnvironment, TestFailure[Any], TestSuccess] =
     suite("Encoder")(
       suite("roundtrip")(
         testRoundTrip[DistanceMatrix]("google_maps_api_response"),

--- a/zio-json/jvm/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -6,8 +6,8 @@ import java.time.format.DateTimeFormatter
 import zio.blocking._
 import zio.json._
 import zio.test.Assertion._
-import zio.test.{ DefaultRunnableSpec, _ }
-import zio.{ test => _, _ }
+import zio.test._
+import zio._
 
 // zioJsonJVM/testOnly testzio.json.JavaTimeSpec
 object JavaTimeSpec extends DefaultRunnableSpec {
@@ -15,7 +15,7 @@ object JavaTimeSpec extends DefaultRunnableSpec {
 
   private def equalToStringified(expected: String) = equalTo(s""""$expected"""")
 
-  def spec: ZSpec[Has[Blocking.Service], Any] =
+  def spec: ZSpec[Blocking, Any] =
     suite("java.time")(
       suite("Encoder")(
         test("DayOfWeek") {

--- a/zio-json/jvm/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -7,7 +7,6 @@ import zio.blocking._
 import zio.json._
 import zio.test.Assertion._
 import zio.test._
-import zio._
 
 // zioJsonJVM/testOnly testzio.json.JavaTimeSpec
 object JavaTimeSpec extends DefaultRunnableSpec {

--- a/zio-json/jvm/src/test/scala/zio/json/JsonTestSuiteSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/JsonTestSuiteSpec.scala
@@ -11,6 +11,7 @@ import zio.test.TestAspect._
 import zio.test._
 
 object JsonTestSuiteSpec extends DefaultRunnableSpec {
+
   def spec: Spec[Blocking with Annotations, TestFailure[Any], TestSuccess] = suite("JsonTestSuite")(
     // Uses files from JSONTestSuite by Nicolas Seriot:
     //   https://github.com/nst/JSONTestSuite

--- a/zio-json/jvm/src/test/scala/zio/json/RoundTripSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/RoundTripSpec.scala
@@ -11,6 +11,7 @@ import zio.test.Assertion._
 import zio.test._
 
 object RoundTripSpec extends DefaultRunnableSpec {
+
   def spec: ZSpec[Environment, Failure] =
     suite("RoundTrip")(
       testM("booleans") {
@@ -78,9 +79,9 @@ object RoundTripSpec extends DefaultRunnableSpec {
           assertRoundtrips(Period.ofDays(1))
         },
         test("Year") {
-          assertRoundtrips(Year.of(1999))
-          assertRoundtrips(Year.of(10000))
-          assertRoundtrips(Year.MIN_VALUE)
+          assertRoundtrips(Year.of(1999)) &&
+          assertRoundtrips(Year.of(10000)) &&
+          assertRoundtrips(Year.MIN_VALUE) &&
           assertRoundtrips(Year.MAX_VALUE)
         },
         test("YearMonth") {

--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -44,6 +44,9 @@ object JsonCodec {
   implicit val float: JsonCodec[Float]                     = JsonCodec(JsonEncoder.float, JsonDecoder.float)
   implicit val bigDecimal: JsonCodec[java.math.BigDecimal] = JsonCodec(JsonEncoder.bigDecimal, JsonDecoder.bigDecimal)
 
+  implicit val scalaBigDecimal: JsonCodec[BigDecimal] =
+    JsonCodec(JsonEncoder.scalaBigDecimal, JsonDecoder.scalaBigDecimal)
+
   implicit def option[A](implicit c: JsonCodec[A]): JsonCodec[Option[A]] =
     JsonCodec(JsonEncoder.option(c.encoder), JsonDecoder.option(c.decoder))
 

--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -1,5 +1,8 @@
 package zio.json
 
+import scala.collection.immutable
+
+import zio.Chunk
 import zio.json.JsonDecoder.JsonError
 import zio.json.internal._
 
@@ -28,7 +31,7 @@ trait JsonCodec[A] extends JsonDecoder[A] with JsonEncoder[A] {
     JsonCodec(encoder.contramap(g), decoder.map(f))
 }
 
-object JsonCodec {
+object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 {
   def apply[A](implicit jsonCodec: JsonCodec[A]): JsonCodec[A] = jsonCodec
 
   implicit val string: JsonCodec[String]                   = JsonCodec(JsonEncoder.string, JsonDecoder.string)
@@ -78,4 +81,65 @@ object JsonCodec {
             encoder0.unsafeEncode(a, indent, out)
         }
     }
+}
+
+private[json] trait CodecLowPriority0 extends CodecLowPriority1 { this: JsonCodec.type =>
+
+  implicit def chunk[A: JsonCodec]: JsonCodec[Chunk[A]] =
+    JsonCodec(JsonEncoder.chunk[A], JsonDecoder.chunk[A])
+
+  implicit def hashSet[A: JsonCodec]: JsonCodec[immutable.HashSet[A]] =
+    JsonCodec(JsonEncoder.hashSet[A], JsonDecoder.hashSet[A])
+
+  implicit def hashMap[K: JsonFieldEncoder: JsonFieldDecoder, V: JsonCodec]: JsonEncoder[immutable.HashMap[K, V]] =
+    JsonCodec(JsonEncoder.hashMap[K, V], JsonDecoder.hashMap[K, V])
+}
+
+private[json] trait CodecLowPriority1 extends CodecLowPriority2 { this: JsonCodec.type =>
+  implicit def seq[A: JsonCodec]: JsonCodec[Seq[A]]       = JsonCodec(JsonEncoder.seq[A], JsonDecoder.seq[A])
+  implicit def list[A: JsonCodec]: JsonCodec[List[A]]     = JsonCodec(JsonEncoder.list[A], JsonDecoder.list[A])
+  implicit def vector[A: JsonCodec]: JsonCodec[Vector[A]] = JsonCodec(JsonEncoder.vector[A], JsonDecoder.vector[A])
+  implicit def set[A: JsonCodec]: JsonCodec[Set[A]]       = JsonCodec(JsonEncoder.set[A], JsonDecoder.set[A])
+
+  implicit def map[K: JsonFieldEncoder: JsonFieldDecoder, V: JsonCodec]: JsonCodec[Map[K, V]] =
+    JsonCodec(JsonEncoder.map[K, V], JsonDecoder.map[K, V])
+
+  implicit def sortedMap[
+    K: JsonFieldEncoder: JsonFieldDecoder: Ordering,
+    V: JsonCodec
+  ]: JsonCodec[collection.SortedMap[K, V]] =
+    JsonCodec(JsonEncoder.sortedMap[K, V], JsonDecoder.sortedMap[K, V])
+
+  implicit def sortedSet[A: Ordering: JsonCodec]: JsonCodec[immutable.SortedSet[A]] =
+    JsonCodec(JsonEncoder.sortedSet[A], JsonDecoder.sortedSet[A])
+}
+
+private[json] trait CodecLowPriority2 extends CodecLowPriority3 { this: JsonCodec.type =>
+
+  implicit def iterable[A: JsonCodec]: JsonCodec[Iterable[A]] =
+    JsonCodec(JsonEncoder.iterable, JsonDecoder.iterable)
+}
+
+private[json] trait CodecLowPriority3 { this: JsonCodec.type =>
+  import java.time._
+
+  implicit val dayOfWeek: JsonCodec[DayOfWeek]         = JsonCodec(JsonEncoder.dayOfWeek, JsonDecoder.dayOfWeek)
+  implicit val duration: JsonCodec[Duration]           = JsonCodec(JsonEncoder.duration, JsonDecoder.duration)
+  implicit val instant: JsonCodec[Instant]             = JsonCodec(JsonEncoder.instant, JsonDecoder.instant)
+  implicit val localDate: JsonCodec[LocalDate]         = JsonCodec(JsonEncoder.localDate, JsonDecoder.localDate)
+  implicit val localDateTime: JsonCodec[LocalDateTime] = JsonCodec(JsonEncoder.localDateTime, JsonDecoder.localDateTime)
+  implicit val localTime: JsonCodec[LocalTime]         = JsonCodec(JsonEncoder.localTime, JsonDecoder.localTime)
+  implicit val month: JsonCodec[Month]                 = JsonCodec(JsonEncoder.month, JsonDecoder.month)
+  implicit val monthDay: JsonCodec[MonthDay]           = JsonCodec(JsonEncoder.monthDay, JsonDecoder.monthDay)
+
+  implicit val offsetDateTime: JsonCodec[OffsetDateTime] =
+    JsonCodec(JsonEncoder.offsetDateTime, JsonDecoder.offsetDateTime)
+
+  implicit val offsetTime: JsonCodec[OffsetTime]       = JsonCodec(JsonEncoder.offsetTime, JsonDecoder.offsetTime)
+  implicit val period: JsonCodec[Period]               = JsonCodec(JsonEncoder.period, JsonDecoder.period)
+  implicit val year: JsonCodec[Year]                   = JsonCodec(JsonEncoder.year, JsonDecoder.year)
+  implicit val yearMonth: JsonCodec[YearMonth]         = JsonCodec(JsonEncoder.yearMonth, JsonDecoder.yearMonth)
+  implicit val zonedDateTime: JsonCodec[ZonedDateTime] = JsonCodec(JsonEncoder.zonedDateTime, JsonDecoder.zonedDateTime)
+  implicit val zoneId: JsonCodec[ZoneId]               = JsonCodec(JsonEncoder.zoneId, JsonDecoder.zoneId)
+  implicit val zoneOffset: JsonCodec[ZoneOffset]       = JsonCodec(JsonEncoder.zoneOffset, JsonDecoder.zoneOffset)
 }

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -438,6 +438,12 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 { this: Json
 private[json] trait DecoderLowPriority2 extends DecoderLowPriority3 {
   this: JsonDecoder.type =>
 
+  implicit def iterable[A: JsonDecoder]: JsonDecoder[Iterable[A]] = new JsonDecoder[Iterable[A]] {
+
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): Iterable[A] =
+      builder(trace, in, immutable.Iterable.newBuilder[A])
+  }
+
   // not implicit because this overlaps with decoders for lists of tuples
   def keyValueChunk[K, A](implicit
     K: JsonFieldDecoder[K],

--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -6,7 +6,7 @@ import java.time.temporal.ChronoField.YEAR
 import scala.annotation._
 import scala.collection.immutable
 
-import zio.{ Chunk }
+import zio.Chunk
 import zio.json.internal.{ FastStringWrite, Write }
 
 trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] { self =>
@@ -29,6 +29,7 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] { self =>
    * by the specified user-defined function.
    */
   final def contramap[B](f: B => A): JsonEncoder[B] = new JsonEncoder[B] {
+
     override def unsafeEncode(b: B, indent: Option[Int], out: Write): Unit =
       self.unsafeEncode(f(b), indent, out)
     override def isNothing(b: B): Boolean = self.isNothing(f(b))
@@ -79,6 +80,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
   def apply[A](implicit a: JsonEncoder[A]): JsonEncoder[A] = a
 
   implicit val string: JsonEncoder[String] = new JsonEncoder[String] {
+
     override def unsafeEncode(a: String, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       var i   = 0
@@ -111,23 +113,25 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
     def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write(s""""${f(a)}"""")
   }
 
-  implicit val boolean: JsonEncoder[Boolean] = explicit(_.toString)
-  implicit val char: JsonEncoder[Char]       = string.contramap(_.toString)
-  implicit val symbol: JsonEncoder[Symbol]   = string.contramap(_.name)
-
+  implicit val boolean: JsonEncoder[Boolean]                 = explicit(_.toString)
+  implicit val char: JsonEncoder[Char]                       = string.contramap(_.toString)
+  implicit val symbol: JsonEncoder[Symbol]                   = string.contramap(_.name)
   implicit val byte: JsonEncoder[Byte]                       = explicit(_.toString)
   implicit val short: JsonEncoder[Short]                     = explicit(_.toString)
   implicit val int: JsonEncoder[Int]                         = explicit(_.toString)
   implicit val long: JsonEncoder[Long]                       = explicit(_.toString)
   implicit val bigInteger: JsonEncoder[java.math.BigInteger] = explicit(_.toString)
+
   implicit val double: JsonEncoder[Double] = explicit { n =>
     if (n.isNaN || n.isInfinite) s""""$n""""
     else n.toString
   }
   implicit val float: JsonEncoder[Float]                     = double.contramap(_.toDouble)
   implicit val bigDecimal: JsonEncoder[java.math.BigDecimal] = explicit(_.toString)
+  implicit val scalaBigDecimal: JsonEncoder[BigDecimal]      = explicit(_.toString)
 
   implicit def option[A](implicit A: JsonEncoder[A]): JsonEncoder[Option[A]] = new JsonEncoder[Option[A]] {
+
     def unsafeEncode(oa: Option[A], indent: Option[Int], out: Write): Unit = oa match {
       case None    => out.write("null")
       case Some(a) => A.unsafeEncode(a, indent, out)
@@ -139,11 +143,13 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
     case None    => None
     case Some(i) => Some(i + 1)
   }
+
   def pad(indent: Option[Int], out: Write): Unit =
     indent.foreach(i => out.write("\n" + (" " * 2 * i)))
 
   implicit def either[A, B](implicit A: JsonEncoder[A], B: JsonEncoder[B]): JsonEncoder[Either[A, B]] =
     new JsonEncoder[Either[A, B]] {
+
       def unsafeEncode(eab: Either[A, B], indent: Option[Int], out: Write): Unit = {
         out.write('{')
         val indent_ = bump(indent)
@@ -193,8 +199,10 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 { this: Json
 }
 
 private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 { this: JsonEncoder.type =>
+
   implicit def iterable[A, T[X] <: Iterable[X]](implicit A: JsonEncoder[A]): JsonEncoder[T[A]] =
     new JsonEncoder[T[A]] {
+
       def unsafeEncode(as: T[A], indent: Option[Int], out: Write): Unit = {
         out.write('[')
         var first = true
@@ -213,6 +221,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 { this: Json
     K: JsonFieldEncoder[K],
     A: JsonEncoder[A]
   ): JsonEncoder[T[K, A]] = new JsonEncoder[T[K, A]] {
+
     def unsafeEncode(kvs: T[K, A], indent: Option[Int], out: Write): Unit = {
       if (kvs.isEmpty) return out.write("{}")
 
@@ -256,28 +265,35 @@ private[json] trait EncoderLowPriority3 { this: JsonEncoder.type =>
   implicit val dayOfWeek: JsonEncoder[DayOfWeek] = stringify(_.toString)
   implicit val duration: JsonEncoder[Duration]   = stringify(_.toString)
   implicit val instant: JsonEncoder[Instant]     = stringify(_.toString)
+
   implicit val localDate: JsonEncoder[LocalDate] = stringify(
     _.format(DateTimeFormatter.ISO_LOCAL_DATE)
   )
+
   implicit val localDateTime: JsonEncoder[LocalDateTime] = stringify(
     _.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
   )
+
   implicit val localTime: JsonEncoder[LocalTime] = stringify(
     _.format(DateTimeFormatter.ISO_LOCAL_TIME)
   )
   implicit val month: JsonEncoder[Month]       = stringify(_.toString)
   implicit val monthDay: JsonEncoder[MonthDay] = stringify(_.toString)
+
   implicit val offsetDateTime: JsonEncoder[OffsetDateTime] = stringify(
     _.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
   )
+
   implicit val offsetTime: JsonEncoder[OffsetTime] = stringify(
     _.format(DateTimeFormatter.ISO_OFFSET_TIME)
   )
   implicit val period: JsonEncoder[Period] = stringify(_.toString)
+
   private val yearFormatter =
     new DateTimeFormatterBuilder().appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD).toFormatter
   implicit val year: JsonEncoder[Year]           = stringify(_.format(yearFormatter))
   implicit val yearMonth: JsonEncoder[YearMonth] = stringify(_.toString)
+
   implicit val zonedDateTime: JsonEncoder[ZonedDateTime] = stringify(
     _.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
   )
@@ -294,7 +310,9 @@ trait JsonFieldEncoder[-A] { self =>
 
   def unsafeEncodeField(in: A): String
 }
+
 object JsonFieldEncoder {
+
   implicit val string: JsonFieldEncoder[String] = new JsonFieldEncoder[String] {
     def unsafeEncodeField(in: String): String = in
   }

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -45,6 +45,7 @@ object Lexer {
         in.retract()
         true
     }
+
   def nextArrayElement(trace: List[JsonError], in: OneCharReader): Boolean =
     (in.nextNonWhitespace(): @switch) match {
       case ',' => true
@@ -90,6 +91,7 @@ object Lexer {
   private[this] val ull: Array[Char]  = "ull".toCharArray
   private[this] val alse: Array[Char] = "alse".toCharArray
   private[this] val rue: Array[Char]  = "rue".toCharArray
+
   def skipValue(trace: List[JsonError], in: RetractReader): Unit =
     (in.nextNonWhitespace(): @switch) match {
       case 'n' => readChars(trace, in, ull, "null")
@@ -391,6 +393,7 @@ final class StringMatrix(val xs: Array[String]) {
   val height: Int         = xs.map(_.length).max
   val lengths: Array[Int] = xs.map(_.length)
   val initial: Long       = (0 until width).foldLeft(0L)((bs, r) => bs | (1L << r))
+
   private val matrix: Array[Int] = {
     val m           = Array.fill[Int](width * height)(-1)
     var string: Int = 0

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -2,15 +2,15 @@ package testzio.json
 
 import scala.collection.immutable
 
+import zio._
 import zio.json._
 import zio.test.Assertion._
-import zio.test.environment.Live
-import zio.test.{ DefaultRunnableSpec, assert, _ }
-import zio.{ test => _, _ }
+import zio.test._
+import zio.test.environment.TestEnvironment
 
 object CodecSpec extends DefaultRunnableSpec {
 
-  def spec: Spec[ZEnv with Live, TestFailure[Any], TestSuccess] =
+  def spec: Spec[TestEnvironment, TestFailure[Any], TestSuccess] =
     suite("Codec")(
       suite("Decoding")(
         test("empty") {
@@ -164,7 +164,7 @@ object CodecSpec extends DefaultRunnableSpec {
   }
 
   object logEvent {
-    case class Event(at: Long, message: String)
+    case class Event(at: Long, message: String, a: Seq[String] = Nil)
     implicit val codec: JsonCodec[Event] = DeriveJsonCodec.gen[Event]
   }
 }

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -20,10 +20,11 @@ object CodecSpec extends DefaultRunnableSpec {
           )
         },
         test("primitives") {
+          val exampleBDString = "234234.234"
           // this big integer consumes more than 128 bits
           assert("170141183460469231731687303715884105728".fromJson[java.math.BigInteger])(
             isLeft(equalTo("(expected a 128 bit BigInteger)"))
-          )
+          ) && assert(exampleBDString.fromJson[BigDecimal])(isRight(equalTo(BigDecimal(exampleBDString))))
         },
         test("eithers") {
           val bernies = List("""{"a":1}""", """{"left":1}""", """{"Left":1}""")

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -9,9 +9,13 @@ import zio.test.{ DefaultRunnableSpec, _ }
 import zio.{ test => _, _ }
 
 object DecoderSpec extends DefaultRunnableSpec {
+
   def spec: Spec[ZEnv with Live, TestFailure[Any], TestSuccess] =
     suite("Decoder")(
-      test("primitives") {
+      test("BigDecimal") {
+        assert("123".fromJson[BigDecimal])(isRight(equalTo(BigDecimal(123))))
+      },
+      test("BigInteger too large") {
         // this big integer consumes more than 128 bits
         assert("170141183460469231731687303715884105728".fromJson[java.math.BigInteger])(
           isLeft(equalTo("(expected a 128 bit BigInteger)"))
@@ -106,14 +110,18 @@ object DecoderSpec extends DefaultRunnableSpec {
 
   object exampleproducts {
     case class Parameterless()
+
     object Parameterless {
+
       implicit val decoder: JsonDecoder[Parameterless] =
         DeriveJsonDecoder.gen[Parameterless]
     }
 
     @jsonNoExtraFields
     case class OnlyString(s: String)
+
     object OnlyString {
+
       implicit val decoder: JsonDecoder[OnlyString] =
         DeriveJsonDecoder.gen[OnlyString]
     }
@@ -121,6 +129,7 @@ object DecoderSpec extends DefaultRunnableSpec {
 
   object examplesum {
     sealed abstract class Parent
+
     object Parent {
       implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
     }
@@ -129,8 +138,10 @@ object DecoderSpec extends DefaultRunnableSpec {
   }
 
   object examplealtsum {
+
     @jsonDiscriminator("hint")
     sealed abstract class Parent
+
     object Parent {
       implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
     }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -2,11 +2,11 @@ package testzio.json
 
 import scala.collection.immutable
 
+import zio._
 import zio.json._
 import zio.test.Assertion._
-import zio.test.environment.Live
 import zio.test._
-import zio._
+import zio.test.environment.Live
 
 object DecoderSpec extends DefaultRunnableSpec {
 

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -5,8 +5,8 @@ import scala.collection.immutable
 import zio.json._
 import zio.test.Assertion._
 import zio.test.environment.Live
-import zio.test.{ DefaultRunnableSpec, _ }
-import zio.{ test => _, _ }
+import zio.test._
+import zio._
 
 object DecoderSpec extends DefaultRunnableSpec {
 

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -3,7 +3,7 @@ package testzio.json
 import zio.json._
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.test.{ DefaultRunnableSpec, assert, _ }
+import zio.test._
 
 // zioJsonJVM/testOnly testzio.json.EncoderSpec
 object EncoderSpec extends DefaultRunnableSpec {
@@ -26,16 +26,17 @@ object EncoderSpec extends DefaultRunnableSpec {
           assert(Symbol("c").toJson)(equalTo("\"c\""))
         },
         test("numerics") {
+          val exampleBigIntStr     = "170141183460469231731687303715884105728"
+          val exampleBigDecimalStr = "170141183460469231731687303715884105728.4433"
           assert((1: Byte).toJson)(equalTo("1")) &&
           assert((1: Short).toJson)(equalTo("1")) &&
           assert((1: Int).toJson)(equalTo("1")) &&
-          assert((1L).toJson)(equalTo("1")) &&
-          assert((new java.math.BigInteger("1")).toJson)(equalTo("1")) &&
-          assert((new java.math.BigInteger("170141183460469231731687303715884105728")).toJson)(
-            equalTo("170141183460469231731687303715884105728")
-          ) &&
-          assert((1.0f).toJson)(equalTo("1.0")) &&
-          assert((1.0d).toJson)(equalTo("1.0"))
+          assert(1L.toJson)(equalTo("1")) &&
+          assert(new java.math.BigInteger("1").toJson)(equalTo("1")) &&
+          assert(new java.math.BigInteger(exampleBigIntStr).toJson)(equalTo(exampleBigIntStr)) &&
+          assert(BigDecimal(exampleBigDecimalStr).toJson)(equalTo(exampleBigDecimalStr)) &&
+          assert(1.0f.toJson)(equalTo("1.0")) &&
+          assert(1.0d.toJson)(equalTo("1.0"))
         } @@ jvmOnly,
         test("NaN / Infinity") {
           assert(Float.NaN.toJson)(equalTo("\"NaN\"")) &&


### PR DESCRIPTION
As of right now, there is only a `java.math.BigDecimal` encoder and decoder. This PR adds the encoder and decoder for Scala's BigDecimal. I've also added the other low-priority implicits for codecs.

