### PR TITLE
Remove silencer, update scala-collection-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
       "org.scala-lang"                          % "scala-reflect"           % scalaVersion.value % Provided,
       "dev.zio"                               %%% "zio"                     % zioVersion,
       "dev.zio"                               %%% "zio-streams"             % zioVersion,
-      "org.scala-lang.modules"                %%% "scala-collection-compat" % "2.3.2",
+      "org.scala-lang.modules"                %%% "scala-collection-compat" % "2.4.2",
       "dev.zio"                               %%% "zio-test"                % zioVersion         % "test",
       "dev.zio"                               %%% "zio-test-sbt"            % zioVersion         % "test",
       "io.circe"                              %%% "circe-core"              % circeVersion       % "test",

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -197,11 +197,7 @@ object BuildHelper {
       if (isDotty.value)
         Seq("com.github.ghik" % "silencer-lib_2.13.1" % "1.6.0" % Provided)
       else
-        Seq(
-          "com.github.ghik" % "silencer-lib" % "1.7.1" % Provided cross CrossVersion.full,
-          compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.1" cross CrossVersion.full),
-          compilerPlugin(scalafixSemanticdb)
-        )
+        Seq(compilerPlugin(scalafixSemanticdb))
     },
     semanticdbEnabled := !isDotty.value,              // enable SemanticDB
     semanticdbVersion := scalafixSemanticdb.revision, // use Scalafix compatible version


### PR DESCRIPTION
`@nowarn` was added to Scala 2.13.3, so the silencer plugin is no longer necessary.
It breaks scala-collection-compat (see #160)

Closes #160 