### PR TITLE
Add separate char codec to handle control characters 

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -130,8 +130,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
     def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write(s""""${f(a)}"""")
   }
 
-  implicit val boolean: JsonEncoder[Boolean] = explicit(_.toString)
-//  implicit val char: JsonEncoder[Char]                       = string.contramap(_.toString)
+  implicit val boolean: JsonEncoder[Boolean]                 = explicit(_.toString)
   implicit val symbol: JsonEncoder[Symbol]                   = string.contramap(_.name)
   implicit val byte: JsonEncoder[Byte]                       = explicit(_.toString)
   implicit val short: JsonEncoder[Short]                     = explicit(_.toString)

--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -106,6 +106,22 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
 
   }
 
+  implicit val char: JsonEncoder[Char] = new JsonEncoder[Char] {
+
+    override def unsafeEncode(a: Char, indent: Option[Int], out: Write): Unit = {
+      out.write('"')
+      a match {
+        case '"'  => out.write("\\\"")
+        case '\\' => out.write("\\\\")
+        case c =>
+          if (c < ' ') out.write("\\u%04x".format(c.toInt))
+          else out.write(c.toString)
+      }
+      out.write('"')
+    }
+
+  }
+
   private[json] def explicit[A](f: A => String): JsonEncoder[A] = new JsonEncoder[A] {
     def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write(f(a))
   }
@@ -114,8 +130,8 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
     def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write(s""""${f(a)}"""")
   }
 
-  implicit val boolean: JsonEncoder[Boolean]                 = explicit(_.toString)
-  implicit val char: JsonEncoder[Char]                       = string.contramap(_.toString)
+  implicit val boolean: JsonEncoder[Boolean] = explicit(_.toString)
+//  implicit val char: JsonEncoder[Char]                       = string.contramap(_.toString)
   implicit val symbol: JsonEncoder[Symbol]                   = string.contramap(_.name)
   implicit val byte: JsonEncoder[Byte]                       = explicit(_.toString)
   implicit val short: JsonEncoder[Short]                     = explicit(_.toString)

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -111,7 +111,17 @@ object CodecSpec extends DefaultRunnableSpec {
 
           assert(jsonStr.fromJson[Chunk[String]])(isRight(equalTo(expected)))
         }
+      ),
+      suite("Encode -> Decode")(
+        test("char") {
+          assert(encodeDecode(JsonCodec.char, '\u0009'))(isRight(equalTo('\u0009')))
+        }
       )
+    )
+
+  private def encodeDecode[A](codec: JsonCodec[A], value: A): Either[String, A] =
+    codec.decodeJson(
+      codec.encodeJson(value, None)
     )
 
   object exampleproducts {

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -113,9 +113,29 @@ object CodecSpec extends DefaultRunnableSpec {
         }
       ),
       suite("Encode -> Decode")(
-        test("char") {
-          assert(encodeDecode(JsonCodec.char, '\u0009'))(isRight(equalTo('\u0009')))
-        }
+        suite("control chars")(
+          test("tab") {
+            assert(encodeDecode(JsonCodec.char, '\t'))(isRight(equalTo('\t')))
+          },
+          test("carriage return") {
+            assert(encodeDecode(JsonCodec.char, '\r'))(isRight(equalTo('\r')))
+          },
+          test("newline") {
+            assert(encodeDecode(JsonCodec.char, '\n'))(isRight(equalTo('\n')))
+          },
+          test("form feed") {
+            assert(encodeDecode(JsonCodec.char, '\f'))(isRight(equalTo('\f')))
+          },
+          test("backspace") {
+            assert(encodeDecode(JsonCodec.char, '\b'))(isRight(equalTo('\b')))
+          },
+          test("escape") {
+            assert(encodeDecode(JsonCodec.char, '\\'))(isRight(equalTo('\\')))
+          },
+          test("quote") {
+            assert(encodeDecode(JsonCodec.char, '"'))(isRight(equalTo('"')))
+          }
+        )
       )
     )
 


### PR DESCRIPTION
Current encoding/decoding is broken for control characters (\t, \n, etc). Need to handle those characters differently for string and single char encoding to be able to successfully decode. 