### PR TITLE
Fix lexer handling of escaped control chars

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -334,8 +334,13 @@ private final class EscapedString(trace: List[JsonError], in: OneCharReader) ext
     if (escaped) {
       escaped = false
       (c: @switch) match {
-        case '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' => c.toInt
-        case 'u'                                            => nextHex4()
+        case '"' | '\\' | '/' => c.toInt
+        case 'b'              => '\b'.toInt
+        case 'f'              => '\f'.toInt
+        case 'n'              => '\n'.toInt
+        case 'r'              => '\r'.toInt
+        case 't'              => '\t'.toInt
+        case 'u'              => nextHex4()
         case _ =>
           throw UnsafeJson(
             JsonError.Message(s"invalid '\\${c.toChar}' in string") :: trace

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -134,7 +134,7 @@ object DecoderSpec extends DefaultRunnableSpec {
       },
       test("Map with unicode keys") {
         val expected = Map(new String(Array('\u0007', '\n')) -> "value")
-        val jsonStr = JsonEncoder[Map[String,String]].encodeJson(expected,None)
+        val jsonStr  = JsonEncoder[Map[String, String]].encodeJson(expected, None)
         assert(jsonStr.fromJson[Map[String, String]])(isRight(equalTo(expected)))
       },
       test("zio.Chunk") {

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -132,6 +132,11 @@ object DecoderSpec extends DefaultRunnableSpec {
 
         assert(jsonStr.fromJson[Map[String, Int]])(isRight(equalTo(expected)))
       },
+      test("Map with unicode keys") {
+        val expected = Map(new String(Array('\u0007', '\n')) -> "value")
+        val jsonStr = JsonEncoder[Map[String,String]].encodeJson(expected,None)
+        assert(jsonStr.fromJson[Map[String, String]])(isRight(equalTo(expected)))
+      },
       test("zio.Chunk") {
         val jsonStr  = """["5XL","2XL","XL"]"""
         val expected = Chunk("5XL", "2XL", "XL")


### PR DESCRIPTION
Current Lexer is not handling escaped control characters correctly. This PR adds a minimal test case and fix (I think). 

Found while debugging test failures in https://github.com/zio/zio-schema/pull/28

