### PR TITLE
[JsonFieldEncoder] [JsonFieldDecoder] Add method `apply` for coherence with `JsonEncoder` and `JsonDecoder` api

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -692,6 +692,7 @@ trait JsonFieldDecoder[+A] {
 }
 
 object JsonFieldDecoder {
+  def apply[A](implicit a: JsonFieldDecoder[A]): JsonFieldDecoder[A] = a
 
   implicit val string: JsonFieldDecoder[String] = new JsonFieldDecoder[String] {
     def unsafeDecodeField(trace: List[JsonError], in: String): String = in

--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -405,6 +405,7 @@ trait JsonFieldEncoder[-A] {
 }
 
 object JsonFieldEncoder {
+  def apply[A](implicit a: JsonFieldEncoder[A]): JsonFieldEncoder[A] = a
 
   implicit val string: JsonFieldEncoder[String] = new JsonFieldEncoder[String] {
     def unsafeEncodeField(in: String): String = in


### PR DESCRIPTION
I got caught by this missing method in the API.

Having an. apply allow such code to exist `implicit val decoder: JsonFieldDecoder[Int] = JsonFieldDecoder[String].map(_.toInt)` to parse a `Map` from a `Json`