### PR TITLE
Added support for jsonDerive 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,7 +203,9 @@ lazy val zioJsonMacros = crossProject(JSPlatform, JVMPlatform)
   .settings(stdSettings("zio-json-macros"))
   .settings(crossProjectSettings)
   .enablePlugins(NeoJmhPlugin)
+  .settings(macroExpansionSettings)
   .settings(
+    scalacOptions -= "-Xfatal-warnings", // not quite ready.
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
       "dev.zio"      %%% "zio-test"      % zioVersion         % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ addCommandAlias("fixCheck", "scalafixAll --check")
 addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
 addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheckAll")
 addCommandAlias("prepare", "fix; fmt")
-addCommandAlias("testJVM", "zioJsonJVM/test; zioJsonYaml/test; zioJsonInteropHttp4s/test")
+addCommandAlias("testJVM", "zioJsonJVM/test; zioJsonYaml/test; zioJsonMacrosJVM/test; zioJsonInteropHttp4s/test")
 addCommandAlias("testJS", "zioJsonJS/test")
 
 val zioVersion = "1.0.5"
@@ -205,9 +205,9 @@ lazy val zioJsonMacros = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(NeoJmhPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scala-lang"                          % "scala-reflect"           % scalaVersion.value % Provided,
-      "dev.zio"       %%% "zio-test"         % zioVersion % "test",
-      "dev.zio"       %%% "zio-test-sbt"     % zioVersion % "test"
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
+      "dev.zio"      %%% "zio-test"      % zioVersion         % "test",
+      "dev.zio"      %%% "zio-test-sbt"  % zioVersion         % "test"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,8 @@ lazy val root = project
     zioJsonJVM,
     zioJsonJS,
     zioJsonYaml,
+    zioJsonMacrosJVM,
+    zioJsonMacrosJS,
     zioJsonInteropHttp4s
   )
 
@@ -195,6 +197,24 @@ lazy val zioJsonYaml = project
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
   )
   .dependsOn(zioJsonJVM)
+
+lazy val zioJsonMacros = crossProject(JSPlatform, JVMPlatform)
+  .in(file("zio-json-macros"))
+  .settings(stdSettings("zio-json-macros"))
+  .settings(crossProjectSettings)
+  .enablePlugins(NeoJmhPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.scala-lang"                          % "scala-reflect"           % scalaVersion.value % Provided,
+      "dev.zio"       %%% "zio-test"         % zioVersion % "test",
+      "dev.zio"       %%% "zio-test-sbt"     % zioVersion % "test"
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+  )
+
+lazy val zioJsonMacrosJVM = zioJsonMacros.jvm.dependsOn(zioJsonJVM)
+
+lazy val zioJsonMacrosJS = zioJsonMacros.js.dependsOn(zioJsonJS)
 
 lazy val zioJsonInteropHttp4s = project
   .in(file("zio-json-interop-http4s"))

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -70,3 +70,63 @@ object Watermelon {
 ```scala mdoc
 """{ "pips": 32, "color": "yellow" }""".fromJson[Watermelon]
 ```
+
+## jsonDerive
+
+**Requires zio-json-macros**
+
+The jsonDerive allows to reduce that needs to be written using an annotation macro to generate JsonDecoder/JsonEncoder at build-time.
+
+For generating both Encoder and Decoder, simply use jsonDerive
+
+For example: 
+
+```scala mdoc
+@jsonDerive case class Watermelon(pips: Int)
+```
+It is equivalent to:
+
+```scala mdoc
+case class Watermelon(pips: Int)
+
+object Watermelon {
+  implicit val codec: JsonCodec[Watermelon] =
+    DeriveJsonCodec.gen[Watermelon]
+}
+```
+
+To generate only an encoder, we can set it as config parameter:
+
+For example:
+
+```scala mdoc
+@jsonDerive(JsonDeriveConfig.Encoder) case class Watermelon(pips: Int)
+```
+It is equivalent to:
+
+```scala mdoc
+case class Watermelon(pips: Int)
+
+object Watermelon {
+  implicit val encorder: JsonEncoder[Watermelon] =
+    DeriveJsonEncoder.gen[Watermelon]
+}
+```
+
+To generate only a decoder, we can set it as config parameter:
+
+For example:
+
+```scala mdoc
+@jsonDerive(JsonDeriveConfig.Decoder) case class Watermelon(pips: Int)
+```
+It is equivalent to:
+
+```scala mdoc
+case class Watermelon(pips: Int)
+
+object Watermelon {
+  implicit val decoder: JsonDecoder[Watermelon] =
+    DeriveJsonDecoder.gen[Watermelon]
+}
+```

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -76,7 +76,8 @@ object BuildHelper {
         )
       case Some((2, 13)) =>
         Seq(
-          "-Ywarn-unused:params,-implicits"
+          "-Ywarn-unused:params,-implicits",
+          "-Ymacro-annotations"
         ) ++ std2xOptions ++ optimizerOptions(optimize) ++ warningOptions
       case Some((2, 12)) =>
         Seq(
@@ -272,7 +273,7 @@ object BuildHelper {
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 13)) => Seq("-Ymacro-annotations")
-        case _             => Seq.empty
+        case _             => Seq("-language:experimental.macros")
       }
     },
     libraryDependencies ++= {

--- a/zio-json-macros/shared/src/main/scala/zio/json/jsonDerive.scala
+++ b/zio-json-macros/shared/src/main/scala/zio/json/jsonDerive.scala
@@ -1,0 +1,174 @@
+package zio.json
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+/**
+  * Define a config for derivation macro
+  */
+sealed abstract class JsonDeriveConfig
+
+object JsonDeriveConfig{
+    // Derive a JsonCodec
+    case object Codec extends JsonDeriveConfig
+    
+    // Derive only a JsonEncoder
+    case object Encoder extends JsonDeriveConfig
+    
+    // Derive only a JsonDecoder
+    case object Decoder extends JsonDeriveConfig
+}
+
+class  jsonDerive(
+  val config: JsonDeriveConfig = JsonDeriveConfig.Codec
+) extends scala.annotation.StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro DeriveCodecMacros.jsonCodecAnnotationMacro
+}
+
+// TODO aparo: Restore when it will be possible to define functions to transform object keys
+//class snakeCaseJsonDerive(
+//  config: JsonDeriveConfig = JsonDeriveConfig.Codec
+//) extends scala.annotation.StaticAnnotation {
+//  def macroTransform(annottees: Any*): Any = macro DeriveCodecMacros.jsonCodecAnnotationMacro
+//}
+//
+//class kebabCaseJsonDerive(
+//  config: JsonDeriveConfig = JsonDeriveConfig.Codec
+//) extends scala.annotation.StaticAnnotation {
+//  def macroTransform(annottees: Any*): Any = macro DeriveCodecMacros.jsonCodecAnnotationMacro
+//}
+
+private[json] final class DeriveCodecMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  def jsonCodecAnnotationMacro(annottees: Tree*): Tree = constructJsonCodec(annottees: _*)
+
+  private[this] def isSealed(clsDef: ClassDef): Boolean = clsDef.mods.hasFlag(Flag.SEALED)
+
+  private[this] def isCaseClassOrSealed(clsDef: ClassDef) =
+    clsDef.mods.hasFlag(Flag.CASE) || isSealed(clsDef)
+
+  private[this] final def constructJsonCodec(annottees: Tree*): Tree = annottees match {
+    case List(clsDef: ClassDef) if isCaseClassOrSealed(clsDef) =>
+      q"""
+       $clsDef
+       object ${clsDef.name.toTermName} {
+         ${codec(clsDef)}
+       }
+       """
+    case List(
+          clsDef: ClassDef,
+          q"object $objName extends { ..$objEarlyDefs } with ..$objParents { $objSelf => ..$objDefs }"
+        ) if isCaseClassOrSealed(clsDef) =>
+      q"""
+       $clsDef
+       object $objName extends { ..$objEarlyDefs } with ..$objParents { $objSelf =>
+         ..$objDefs
+         ${codec(clsDef)}
+       }
+       """
+    case _ => c.abort(c.enclosingPosition, "Invalid annotation target: must be a case class or a sealed trait/class")
+  }
+
+  private[this] val DecoderClass = typeOf[JsonDecoder[_]].typeSymbol.asType
+  private[this] val EncoderClass = typeOf[JsonEncoder[_]].typeSymbol.asType
+  private[this] val CodecClass = typeOf[JsonCodec[_]].typeSymbol.asType
+
+  private[this] val macroName: Tree = {
+    c.prefix.tree match {
+      case Apply(Select(New(name), _), _) => name
+      case _                              => c.abort(c.enclosingPosition, "Unexpected macro application")
+    }
+  }
+
+  private[this] val (codecStyle: JsonCodecStyle, codecType: JsonCodecType) = {
+    val style:JsonCodecStyle=macroName match {
+      case Ident(TypeName("snakeCaseJsonDerive")) => JsonCodecStyle.SnakeCaseJsonCodec
+      case Ident(TypeName("kebabCaseJsonDerive")) => JsonCodecStyle.KebabCaseJsonCodec
+      case Ident(TypeName("jsonDerive")) => JsonCodecStyle.DefaultJsonCodec
+      case _ => c.abort(c.enclosingPosition, s"Unsupported macroname supplied to @$macroName")
+    }
+
+      c.prefix.tree match {
+        case q"new ${`macroName`}()"              => (style, JsonCodecType.Codec)
+        case q"new ${`macroName`}(config = $cfg)" => (style, codecFrom(c.typecheck(cfg)))
+        case q"new ${`macroName`}($cfg)"          => (style, codecFrom(c.typecheck(cfg)))
+        case _                                    => c.abort(c.enclosingPosition, s"Unsupported arguments supplied to @$macroName")
+      }
+  }
+
+  private[this] def codecFrom(tree: Tree): JsonCodecType = {
+    tree.tpe.dealias match {
+      case t if t.toString=="zio.json.JsonDeriveConfig.Codec.type" =>
+        JsonCodecType.Codec
+      case t if t.toString=="zio.json.JsonDeriveConfig.Decoder.type" =>
+        JsonCodecType.DecodeOnly
+      case t if t.toString=="zio.json.JsonDeriveConfig.Encoder.type" =>
+        JsonCodecType.EncodeOnly
+      case t =>
+        c.warning(
+          c.enclosingPosition,
+          s"Couldn't determine type of configuration $t; will produce both encoder and decoder"
+        )
+        JsonCodecType.Codec
+    }
+  }
+
+
+  private[this] def codec(clsDef: ClassDef): Tree = {
+    val tpname = clsDef.name
+    val tparams = clsDef.tparams
+    val decoderName = TermName("decode" + tpname.decodedName)
+    val encoderName = TermName("encode" + tpname.decodedName)
+    val codecName = TermName("codecFor" + tpname.decodedName)
+    val (decoder, encoder, codec) = if (tparams.isEmpty) {
+      val Type = tpname
+      (
+        q"""implicit val $decoderName: $DecoderClass[$Type] = _root_.zio.json.DeriveJsonDecoder.gen[$Type]""",
+        q"""implicit val $encoderName: $EncoderClass[$Type] = _root_.zio.json.DeriveJsonEncoder.gen[$Type]""",
+        q"""implicit val $codecName: $CodecClass[$Type] = _root_.zio.json.DeriveJsonCodec.gen[$Type]"""
+      )
+    } else {
+      val tparamNames = tparams.map(_.name)
+      def mkImplicitParams(prefix: String, typeSymbol: TypeSymbol) =
+        tparamNames.zipWithIndex.map {
+          case (tparamName, i) =>
+            val paramName = TermName(s"$prefix$i")
+            val paramType = tq"$typeSymbol[$tparamName]"
+            q"$paramName: $paramType"
+        }
+      val decodeParams = mkImplicitParams("decode", DecoderClass)
+      val encodeParams = mkImplicitParams("encode", EncoderClass)
+      val Type = tq"$tpname[..$tparamNames]"
+      (
+        q"""implicit def $decoderName[..$tparams](implicit ..$decodeParams): $DecoderClass[$Type] =
+           _root_.zio.json.DeriveJsonDecoder.gen[$Type]""",
+        q"""implicit def $encoderName[..$tparams](implicit ..$encodeParams): $EncoderClass[$Type] =
+           _root_.zio.json.DeriveJsonEncoder.gen[$Type]""",
+        q"""implicit def $codecName[..$tparams](implicit
+            ..${decodeParams ++ encodeParams}
+          ): $CodecClass[$Type] =
+            _root_.zio.json.DeriveJsonCodec.gen[$Type]"""
+      )
+    }
+    codecType match {
+      case JsonCodecType.Codec               => codec
+      case JsonCodecType.DecodeOnly         => decoder
+      case JsonCodecType.EncodeOnly         => encoder
+    }
+  }
+}
+
+private sealed trait JsonCodecStyle
+private object JsonCodecStyle {
+  case object DefaultJsonCodec extends JsonCodecStyle
+  case object SnakeCaseJsonCodec extends JsonCodecStyle
+  case object KebabCaseJsonCodec extends JsonCodecStyle
+}
+
+private sealed trait JsonCodecType
+private object JsonCodecType {
+  case object Codec extends JsonCodecType
+  case object DecodeOnly extends JsonCodecType
+  case object EncodeOnly extends JsonCodecType
+}

--- a/zio-json-macros/shared/src/main/scala/zio/json/jsonDerive.scala
+++ b/zio-json-macros/shared/src/main/scala/zio/json/jsonDerive.scala
@@ -4,22 +4,22 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 /**
-  * Define a config for derivation macro
-  */
+ * Define a config for derivation macro
+ */
 sealed abstract class JsonDeriveConfig
 
-object JsonDeriveConfig{
-    // Derive a JsonCodec
-    case object Codec extends JsonDeriveConfig
-    
-    // Derive only a JsonEncoder
-    case object Encoder extends JsonDeriveConfig
-    
-    // Derive only a JsonDecoder
-    case object Decoder extends JsonDeriveConfig
+object JsonDeriveConfig {
+  // Derive a JsonCodec
+  case object Codec extends JsonDeriveConfig
+
+  // Derive only a JsonEncoder
+  case object Encoder extends JsonDeriveConfig
+
+  // Derive only a JsonDecoder
+  case object Decoder extends JsonDeriveConfig
 }
 
-class  jsonDerive(
+class jsonDerive(
   val config: JsonDeriveConfig = JsonDeriveConfig.Codec
 ) extends scala.annotation.StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro DeriveCodecMacros.jsonCodecAnnotationMacro
@@ -72,7 +72,7 @@ private[json] final class DeriveCodecMacros(val c: blackbox.Context) {
 
   private[this] val DecoderClass = typeOf[JsonDecoder[_]].typeSymbol.asType
   private[this] val EncoderClass = typeOf[JsonEncoder[_]].typeSymbol.asType
-  private[this] val CodecClass = typeOf[JsonCodec[_]].typeSymbol.asType
+  private[this] val CodecClass   = typeOf[JsonCodec[_]].typeSymbol.asType
 
   private[this] val macroName: Tree = {
     c.prefix.tree match {
@@ -82,28 +82,28 @@ private[json] final class DeriveCodecMacros(val c: blackbox.Context) {
   }
 
   private[this] val (codecStyle: JsonCodecStyle, codecType: JsonCodecType) = {
-    val style:JsonCodecStyle=macroName match {
+    val style: JsonCodecStyle = macroName match {
       case Ident(TypeName("snakeCaseJsonDerive")) => JsonCodecStyle.SnakeCaseJsonCodec
       case Ident(TypeName("kebabCaseJsonDerive")) => JsonCodecStyle.KebabCaseJsonCodec
-      case Ident(TypeName("jsonDerive")) => JsonCodecStyle.DefaultJsonCodec
-      case _ => c.abort(c.enclosingPosition, s"Unsupported macroname supplied to @$macroName")
+      case Ident(TypeName("jsonDerive"))          => JsonCodecStyle.DefaultJsonCodec
+      case _                                      => c.abort(c.enclosingPosition, s"Unsupported macroname supplied to @$macroName")
     }
 
-      c.prefix.tree match {
-        case q"new ${`macroName`}()"              => (style, JsonCodecType.Codec)
-        case q"new ${`macroName`}(config = $cfg)" => (style, codecFrom(c.typecheck(cfg)))
-        case q"new ${`macroName`}($cfg)"          => (style, codecFrom(c.typecheck(cfg)))
-        case _                                    => c.abort(c.enclosingPosition, s"Unsupported arguments supplied to @$macroName")
-      }
+    c.prefix.tree match {
+      case q"new ${`macroName`}()"              => (style, JsonCodecType.Codec)
+      case q"new ${`macroName`}(config = $cfg)" => (style, codecFrom(c.typecheck(cfg)))
+      case q"new ${`macroName`}($cfg)"          => (style, codecFrom(c.typecheck(cfg)))
+      case _                                    => c.abort(c.enclosingPosition, s"Unsupported arguments supplied to @$macroName")
+    }
   }
 
-  private[this] def codecFrom(tree: Tree): JsonCodecType = {
+  private[this] def codecFrom(tree: Tree): JsonCodecType =
     tree.tpe.dealias match {
-      case t if t.toString=="zio.json.JsonDeriveConfig.Codec.type" =>
+      case t if t.toString == "zio.json.JsonDeriveConfig.Codec.type" =>
         JsonCodecType.Codec
-      case t if t.toString=="zio.json.JsonDeriveConfig.Decoder.type" =>
+      case t if t.toString == "zio.json.JsonDeriveConfig.Decoder.type" =>
         JsonCodecType.DecodeOnly
-      case t if t.toString=="zio.json.JsonDeriveConfig.Encoder.type" =>
+      case t if t.toString == "zio.json.JsonDeriveConfig.Encoder.type" =>
         JsonCodecType.EncodeOnly
       case t =>
         c.warning(
@@ -112,15 +112,13 @@ private[json] final class DeriveCodecMacros(val c: blackbox.Context) {
         )
         JsonCodecType.Codec
     }
-  }
-
 
   private[this] def codec(clsDef: ClassDef): Tree = {
-    val tpname = clsDef.name
-    val tparams = clsDef.tparams
+    val tpname      = clsDef.name
+    val tparams     = clsDef.tparams
     val decoderName = TermName("decode" + tpname.decodedName)
     val encoderName = TermName("encode" + tpname.decodedName)
-    val codecName = TermName("codecFor" + tpname.decodedName)
+    val codecName   = TermName("codecFor" + tpname.decodedName)
     val (decoder, encoder, codec) = if (tparams.isEmpty) {
       val Type = tpname
       (
@@ -131,15 +129,14 @@ private[json] final class DeriveCodecMacros(val c: blackbox.Context) {
     } else {
       val tparamNames = tparams.map(_.name)
       def mkImplicitParams(prefix: String, typeSymbol: TypeSymbol) =
-        tparamNames.zipWithIndex.map {
-          case (tparamName, i) =>
-            val paramName = TermName(s"$prefix$i")
-            val paramType = tq"$typeSymbol[$tparamName]"
-            q"$paramName: $paramType"
+        tparamNames.zipWithIndex.map { case (tparamName, i) =>
+          val paramName = TermName(s"$prefix$i")
+          val paramType = tq"$typeSymbol[$tparamName]"
+          q"$paramName: $paramType"
         }
       val decodeParams = mkImplicitParams("decode", DecoderClass)
       val encodeParams = mkImplicitParams("encode", EncoderClass)
-      val Type = tq"$tpname[..$tparamNames]"
+      val Type         = tq"$tpname[..$tparamNames]"
       (
         q"""implicit def $decoderName[..$tparams](implicit ..$decodeParams): $DecoderClass[$Type] =
            _root_.zio.json.DeriveJsonDecoder.gen[$Type]""",
@@ -152,23 +149,23 @@ private[json] final class DeriveCodecMacros(val c: blackbox.Context) {
       )
     }
     codecType match {
-      case JsonCodecType.Codec               => codec
-      case JsonCodecType.DecodeOnly         => decoder
-      case JsonCodecType.EncodeOnly         => encoder
+      case JsonCodecType.Codec      => codec
+      case JsonCodecType.DecodeOnly => decoder
+      case JsonCodecType.EncodeOnly => encoder
     }
   }
 }
 
 private sealed trait JsonCodecStyle
 private object JsonCodecStyle {
-  case object DefaultJsonCodec extends JsonCodecStyle
+  case object DefaultJsonCodec   extends JsonCodecStyle
   case object SnakeCaseJsonCodec extends JsonCodecStyle
   case object KebabCaseJsonCodec extends JsonCodecStyle
 }
 
 private sealed trait JsonCodecType
 private object JsonCodecType {
-  case object Codec extends JsonCodecType
+  case object Codec      extends JsonCodecType
   case object DecodeOnly extends JsonCodecType
   case object EncodeOnly extends JsonCodecType
 }

--- a/zio-json-macros/shared/src/test/scala/zio/json/DeriveSpec.scala
+++ b/zio-json-macros/shared/src/test/scala/zio/json/DeriveSpec.scala
@@ -16,31 +16,32 @@ object DeriveSpec extends DefaultRunnableSpec {
           // actually anything works... consider this a canary test because if only
           // the empty object is supported that's fine.
           assert("""{}""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
-            assert("""null""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
-            assert("""{"field":"value"}""".fromJson[Parameterless])(isRight(equalTo(Parameterless())))
+          assert("""null""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+          assert("""{"field":"value"}""".fromJson[Parameterless])(isRight(equalTo(Parameterless())))
         },
         test("no extra fields") {
           import exampleproducts._
 
           assert("""{"s":""}""".fromJson[OnlyString])(isRight(equalTo(OnlyString("")))) &&
-            assert("""{"s":"","t":""}""".fromJson[OnlyString])(isLeft(equalTo("(invalid extra field)")))
+          assert("""{"s":"","t":""}""".fromJson[OnlyString])(isLeft(equalTo("(invalid extra field)")))
         },
         test("sum encoding") {
           import examplesum._
 
           assert("""{"Child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
-            assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
-            assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
+          assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
         },
         test("sum alternative encoding") {
           import examplealtsum._
 
           assert("""{"hint":"Cain"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
-            assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
-            assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
-            assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
+          assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+          assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
         }
-    ))
+      )
+    )
 
   object exampleproducts {
     @jsonDerive
@@ -71,7 +72,6 @@ object DeriveSpec extends DefaultRunnableSpec {
     @jsonDiscriminator("hint")
     sealed abstract class Parent
 
-
     @jsonHint("Cain")
     case class Child1() extends Parent
 
@@ -83,6 +83,5 @@ object DeriveSpec extends DefaultRunnableSpec {
     @jsonDerive(JsonDeriveConfig.Decoder)
     case class Event(at: Long, message: String, a: Seq[String] = Nil)
   }
-
 
 }

--- a/zio-json-macros/shared/src/test/scala/zio/json/DeriveSpec.scala
+++ b/zio-json-macros/shared/src/test/scala/zio/json/DeriveSpec.scala
@@ -1,0 +1,88 @@
+package testzio.json
+
+import zio.json._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+object DeriveSpec extends DefaultRunnableSpec {
+
+  def spec: Spec[TestEnvironment, TestFailure[Any], TestSuccess] =
+    suite("DeriveCodec")(
+      suite("Decoding")(
+        test("parameterless products") {
+          import exampleproducts._
+
+          // actually anything works... consider this a canary test because if only
+          // the empty object is supported that's fine.
+          assert("""{}""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+            assert("""null""".fromJson[Parameterless])(isRight(equalTo(Parameterless()))) &&
+            assert("""{"field":"value"}""".fromJson[Parameterless])(isRight(equalTo(Parameterless())))
+        },
+        test("no extra fields") {
+          import exampleproducts._
+
+          assert("""{"s":""}""".fromJson[OnlyString])(isRight(equalTo(OnlyString("")))) &&
+            assert("""{"s":"","t":""}""".fromJson[OnlyString])(isLeft(equalTo("(invalid extra field)")))
+        },
+        test("sum encoding") {
+          import examplesum._
+
+          assert("""{"Child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+            assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+            assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
+        },
+        test("sum alternative encoding") {
+          import examplealtsum._
+
+          assert("""{"hint":"Cain"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+            assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+            assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+            assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
+        }
+    ))
+
+  object exampleproducts {
+    @jsonDerive
+    case class Parameterless()
+
+    @jsonDerive
+    @jsonNoExtraFields
+    case class OnlyString(s: String)
+  }
+
+  object examplesum {
+    @jsonDerive
+    sealed abstract class Parent
+
+    case class Child1() extends Parent
+    case class Child2() extends Parent
+  }
+
+  object exampleempty {
+    @jsonDerive
+    case class Empty(a: Option[String])
+
+  }
+
+  object examplealtsum {
+
+    @jsonDerive
+    @jsonDiscriminator("hint")
+    sealed abstract class Parent
+
+
+    @jsonHint("Cain")
+    case class Child1() extends Parent
+
+    @jsonHint("Abel")
+    case class Child2() extends Parent
+  }
+
+  object logEvent {
+    @jsonDerive(JsonDeriveConfig.Decoder)
+    case class Event(at: Long, message: String, a: Seq[String] = Nil)
+  }
+
+
+}

--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -65,7 +65,7 @@ object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 {
         // protects against cycles in implicit resolution, unfortunately the
         // instantiation of decoder0 could have been wasteful.
         e
-      case other =>
+      case _ =>
         new JsonCodec[A] {
           override def encoder: JsonEncoder[A] = encoder0
 


### PR DESCRIPTION
This implementation add a new module zio-json-macro to be able to reduce boilerplate and have a similar behaviour of circe generic/derivation JsonCodec.
It add support for both JVM/JS