### PR TITLE
Fix #263: Decoder instances for String and Long

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -238,7 +238,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
     }
   }
 
-  implicit def string: JsonDecoder[String] = new JsonDecoder[String] {
+  implicit val string: JsonDecoder[String] = new JsonDecoder[String] {
 
     def unsafeDecode(trace: List[JsonError], in: RetractReader): String =
       Lexer.string(trace, in).toString
@@ -268,12 +268,10 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
   }
   implicit val symbol: JsonDecoder[Symbol] = string.map(Symbol(_))
 
-  implicit val byte: JsonDecoder[Byte]   = number(Lexer.byte, _.byteValueExact())
-  implicit val short: JsonDecoder[Short] = number(Lexer.short, _.shortValueExact())
-  implicit val int: JsonDecoder[Int]     = number(Lexer.int, _.intValueExact())
-
-  implicit def long: JsonDecoder[Long] = number(Lexer.long, _.longValueExact())
-
+  implicit val byte: JsonDecoder[Byte]                       = number(Lexer.byte, _.byteValueExact())
+  implicit val short: JsonDecoder[Short]                     = number(Lexer.short, _.shortValueExact())
+  implicit val int: JsonDecoder[Int]                         = number(Lexer.int, _.intValueExact())
+  implicit val long: JsonDecoder[Long]                       = number(Lexer.long, _.longValueExact())
   implicit val bigInteger: JsonDecoder[java.math.BigInteger] = number(Lexer.bigInteger, _.toBigIntegerExact)
   implicit val scalaBigInt: JsonDecoder[BigInt]              = bigInteger.map(x => x)
   implicit val float: JsonDecoder[Float]                     = number(Lexer.float, _.floatValue())
@@ -446,6 +444,18 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
     builder.result()
   }
 
+  // use this instead of `string.mapOrFail` in supertypes (to prevent class initialization error at runtime)
+  private[json] def mapStringOrFail[A](f: String => Either[String, A]): JsonDecoder[A] =
+    new JsonDecoder[A] {
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
+        f(string.unsafeDecode(trace, in)) match {
+          case Left(err)    => throw UnsafeJson(JsonError.Message(err) :: trace)
+          case Right(value) => value
+        }
+
+      override def fromJsonAST(json: Json): Either[String, A] =
+        string.fromJsonAST(json).flatMap(f)
+    }
 }
 
 private[json] trait DecoderLowPriority0 extends DecoderLowPriority1 {
@@ -611,39 +621,38 @@ private[json] trait DecoderLowPriority3 {
   import java.time.format.{ DateTimeFormatter, DateTimeParseException }
   import java.time.zone.ZoneRulesException
 
-  implicit val dayOfWeek: JsonDecoder[DayOfWeek] =
-    string.mapOrFail(s => parseJavaTime(DayOfWeek.valueOf, s.toUpperCase))
-  implicit val duration: JsonDecoder[Duration] = string.mapOrFail(parseJavaTime(Duration.parse, _))
-  implicit val instant: JsonDecoder[Instant]   = string.mapOrFail(parseJavaTime(Instant.parse, _))
+  implicit val dayOfWeek: JsonDecoder[DayOfWeek] = mapStringOrFail(s => parseJavaTime(DayOfWeek.valueOf, s.toUpperCase))
+  implicit val duration: JsonDecoder[Duration]   = mapStringOrFail(parseJavaTime(Duration.parse, _))
+  implicit val instant: JsonDecoder[Instant]     = mapStringOrFail(parseJavaTime(Instant.parse, _))
 
   implicit val localDate: JsonDecoder[LocalDate] =
-    string.mapOrFail(parseJavaTime(LocalDate.parse(_, DateTimeFormatter.ISO_LOCAL_DATE), _))
+    mapStringOrFail(parseJavaTime(LocalDate.parse(_, DateTimeFormatter.ISO_LOCAL_DATE), _))
 
   implicit val localDateTime: JsonDecoder[LocalDateTime] =
-    string.mapOrFail(parseJavaTime(LocalDateTime.parse(_, DateTimeFormatter.ISO_LOCAL_DATE_TIME), _))
+    mapStringOrFail(parseJavaTime(LocalDateTime.parse(_, DateTimeFormatter.ISO_LOCAL_DATE_TIME), _))
 
   implicit val localTime: JsonDecoder[LocalTime] =
-    string.mapOrFail(parseJavaTime(LocalTime.parse(_, DateTimeFormatter.ISO_LOCAL_TIME), _))
-  implicit val month: JsonDecoder[Month]       = string.mapOrFail(s => parseJavaTime(Month.valueOf, s.toUpperCase))
-  implicit val monthDay: JsonDecoder[MonthDay] = string.mapOrFail(parseJavaTime(MonthDay.parse, _))
+    mapStringOrFail(parseJavaTime(LocalTime.parse(_, DateTimeFormatter.ISO_LOCAL_TIME), _))
+  implicit val month: JsonDecoder[Month]       = mapStringOrFail(s => parseJavaTime(Month.valueOf, s.toUpperCase))
+  implicit val monthDay: JsonDecoder[MonthDay] = mapStringOrFail(parseJavaTime(MonthDay.parse, _))
 
   implicit val offsetDateTime: JsonDecoder[OffsetDateTime] =
-    string.mapOrFail(parseJavaTime(OffsetDateTime.parse(_, DateTimeFormatter.ISO_OFFSET_DATE_TIME), _))
+    mapStringOrFail(parseJavaTime(OffsetDateTime.parse(_, DateTimeFormatter.ISO_OFFSET_DATE_TIME), _))
 
   implicit val offsetTime: JsonDecoder[OffsetTime] =
-    string.mapOrFail(parseJavaTime(OffsetTime.parse(_, DateTimeFormatter.ISO_OFFSET_TIME), _))
-  implicit val period: JsonDecoder[Period] = string.mapOrFail(parseJavaTime(Period.parse, _))
-  implicit val year: JsonDecoder[Year]     = string.mapOrFail(parseJavaTime(Year.parse(_), _))
+    mapStringOrFail(parseJavaTime(OffsetTime.parse(_, DateTimeFormatter.ISO_OFFSET_TIME), _))
+  implicit val period: JsonDecoder[Period] = mapStringOrFail(parseJavaTime(Period.parse, _))
+  implicit val year: JsonDecoder[Year]     = mapStringOrFail(parseJavaTime(Year.parse(_), _))
 
   implicit val yearMonth: JsonDecoder[YearMonth] =
-    string.mapOrFail(parseJavaTime(YearMonth.parse, _))
+    mapStringOrFail(parseJavaTime(YearMonth.parse, _))
 
   implicit val zonedDateTime: JsonDecoder[ZonedDateTime] =
-    string.mapOrFail(parseJavaTime(ZonedDateTime.parse(_, DateTimeFormatter.ISO_ZONED_DATE_TIME), _))
-  implicit val zoneId: JsonDecoder[ZoneId] = string.mapOrFail(parseJavaTime(ZoneId.of, _))
+    mapStringOrFail(parseJavaTime(ZonedDateTime.parse(_, DateTimeFormatter.ISO_ZONED_DATE_TIME), _))
+  implicit val zoneId: JsonDecoder[ZoneId] = mapStringOrFail(parseJavaTime(ZoneId.of, _))
 
   implicit val zoneOffset: JsonDecoder[ZoneOffset] =
-    string.mapOrFail(parseJavaTime(ZoneOffset.of, _))
+    mapStringOrFail(parseJavaTime(ZoneOffset.of, _))
 
   // Commonized handling for decoding from string to java.time Class
   private[json] def parseJavaTime[A](f: String => A, s: String): Either[String, A] =
@@ -657,7 +666,7 @@ private[json] trait DecoderLowPriority3 {
     }
 
   implicit val uuid: JsonDecoder[UUID] =
-    string.mapOrFail { str =>
+    mapStringOrFail { str =>
       try {
         Right(UUID.fromString(str))
       } catch {


### PR DESCRIPTION
Fixes #263,
1. Redefined instances as `val`s.
2. Updated `String` instance dependencies to use `mapStringOrFail`.