### PR TITLE
annotation to hide case class field from encoder #253

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala/zio/json/macros.scala
@@ -57,11 +57,6 @@ final case class jsonHint(name: String) extends Annotation
 final class jsonNoExtraFields extends Annotation
 
 /**
- * If used on a case class, will exclude fields from the resulting JSON.
- */
-final case class jsonExcludeFields(fields: List[String]) extends Annotation
-
-/**
  * If used on a case class field, will exclude it from the resulting JSON.
  */
 final class jsonExclude extends Annotation
@@ -319,16 +314,11 @@ object DeriveJsonEncoder {
       }
     else
       new JsonEncoder[A] {
-        val excluded = ctx.annotations.collectFirst { case x: jsonExcludeFields =>
-          x.fields
-        }
-        val params = ctx.parameters.filter(p =>
-          (!excluded.isDefined|| !excluded.get.contains(p.label)) &&
-          p.annotations.collectFirst { case _: jsonExclude => () }.isDefined == false).toArray
+        val params = ctx.parameters
+          .filter(p => p.annotations.collectFirst { case _: jsonExclude => () }.isDefined == false)
+          .toArray
 
-        val names: Array[String] = params
-          .filter { p=> p.annotations.collectFirst { case _: jsonExclude => () }.isDefined == false }
-          .map { p =>
+        val names: Array[String] = params.map { p =>
           p.annotations.collectFirst { case jsonField(name) =>
             name
           }.getOrElse(p.label)

--- a/zio-json/shared/src/main/scala/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala/zio/json/macros.scala
@@ -56,6 +56,9 @@ final case class jsonHint(name: String) extends Annotation
  */
 final class jsonNoExtraFields extends Annotation
 
+/**
+ * If used on a case class, will exclude fields from the resulting JSON.
+ */
 final case class jsonExcludeFields(fields: List[String]) extends Annotation
 
 object DeriveJsonDecoder {

--- a/zio-json/shared/src/main/scala/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala/zio/json/macros.scala
@@ -56,6 +56,8 @@ final case class jsonHint(name: String) extends Annotation
  */
 final class jsonNoExtraFields extends Annotation
 
+final case class jsonExcludeFields(fields: List[String]) extends Annotation
+
 object DeriveJsonDecoder {
   type Typeclass[A] = JsonDecoder[A]
 
@@ -309,7 +311,10 @@ object DeriveJsonEncoder {
       }
     else
       new JsonEncoder[A] {
-        val params = ctx.parameters.toArray
+        val excluded = ctx.annotations.collectFirst { case x: jsonExcludeFields =>
+          x.fields
+        }
+        val params = ctx.parameters.filter(p => !excluded.isDefined || !excluded.get.contains(p.label)).toArray
         val names: Array[String] = params.map { p =>
           p.annotations.collectFirst { case jsonField(name) =>
             name

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -137,6 +137,10 @@ object EncoderSpec extends DefaultRunnableSpec {
             equalTo("{\n  \"hint\" : \"Abel\",\n  \"s\" : \"hello\"\n}")
           )
         },
+        test("exclude field") {
+          import exampleexcludefield._
+          assert(Person("Peter", 20).toJson)(equalTo("""{"name":"Peter"}"""))
+        },
         test("exclude fields") {
           import exampleexcludefields._
           assert(Person("Peter", 20).toJson)(equalTo("""{"name":"Peter"}"""))
@@ -266,6 +270,16 @@ object EncoderSpec extends DefaultRunnableSpec {
   }
 
   object exampleexcludefields {
+
+    case class Person(name: String, @jsonExclude age: Int)
+
+    object Person {
+      implicit val encoder: JsonEncoder[Person] = DeriveJsonEncoder.gen[Person]
+    }
+
+  }
+
+  object exampleexcludefield {
 
     @jsonExcludeFields(List("age"))
     case class Person(name: String, age: Int)

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -137,12 +137,8 @@ object EncoderSpec extends DefaultRunnableSpec {
             equalTo("{\n  \"hint\" : \"Abel\",\n  \"s\" : \"hello\"\n}")
           )
         },
-        test("exclude field") {
-          import exampleexcludefield._
-          assert(Person("Peter", 20).toJson)(equalTo("""{"name":"Peter"}"""))
-        },
         test("exclude fields") {
-          import exampleexcludefields._
+          import exampleexcludefield._
           assert(Person("Peter", 20).toJson)(equalTo("""{"name":"Peter"}"""))
         }
       ),
@@ -269,20 +265,9 @@ object EncoderSpec extends DefaultRunnableSpec {
 
   }
 
-  object exampleexcludefields {
-
-    case class Person(name: String, @jsonExclude age: Int)
-
-    object Person {
-      implicit val encoder: JsonEncoder[Person] = DeriveJsonEncoder.gen[Person]
-    }
-
-  }
-
   object exampleexcludefield {
 
-    @jsonExcludeFields(List("age"))
-    case class Person(name: String, age: Int)
+    case class Person(name: String, @jsonExclude age: Int)
 
     object Person {
       implicit val encoder: JsonEncoder[Person] = DeriveJsonEncoder.gen[Person]

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -136,6 +136,10 @@ object EncoderSpec extends DefaultRunnableSpec {
           assert((Child2(Some("hello")): Parent).toJsonPretty)(
             equalTo("{\n  \"hint\" : \"Abel\",\n  \"s\" : \"hello\"\n}")
           )
+        },
+        test("exclude fields") {
+          import exampleexcludefields._
+          assert(Person("Peter", 20).toJson)(equalTo("""{"name":"Peter"}"""))
         }
       ),
       suite("toJsonAST")(
@@ -257,6 +261,17 @@ object EncoderSpec extends DefaultRunnableSpec {
 
       implicit val encoder: JsonEncoder[OptionalAndRequired] =
         DeriveJsonEncoder.gen[OptionalAndRequired]
+    }
+
+  }
+
+  object exampleexcludefields {
+
+    @jsonExcludeFields(List("age"))
+    case class Person(name: String, age: Int)
+
+    object Person {
+      implicit val encoder: JsonEncoder[Person] = DeriveJsonEncoder.gen[Person]
     }
 
   }


### PR DESCRIPTION
Define jsonExcludeFields annotation to exclude fields from the encoding JSON.
Added "exclude fields" test case.

`final case class jsonExcludeFields(fields: List[String]) extends Annotation`