### PR TITLE
Account for JDK8 bugs around `ZonedDateTime.parse`

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -10,8 +10,8 @@ import zio.Chunk
 import zio.json.JsonDecoder.JsonError
 import zio.json.ast.Json
 import zio.json.internal._
-import zio.json.javatime.DurationParser
 import zio.json.javatime.DurationParser.DurationParseException
+import zio.json.javatime.{ DurationParser, ZonedDateTimeParser }
 
 /**
  * A `JsonDecoder[A]` instance has the ability to decode JSON to values of type `A`, potentially
@@ -648,7 +648,8 @@ private[json] trait DecoderLowPriority3 {
     mapStringOrFail(parseJavaTime(YearMonth.parse, _))
 
   implicit val zonedDateTime: JsonDecoder[ZonedDateTime] =
-    mapStringOrFail(parseJavaTime(ZonedDateTime.parse(_, DateTimeFormatter.ISO_ZONED_DATE_TIME), _))
+    mapStringOrFail(parseJavaTime(ZonedDateTimeParser.unsafeParse, _))
+
   implicit val zoneId: JsonDecoder[ZoneId] = mapStringOrFail(parseJavaTime(ZoneId.of, _))
 
   implicit val zoneOffset: JsonDecoder[ZoneOffset] =
@@ -662,7 +663,7 @@ private[json] trait DecoderLowPriority3 {
       case zre: ZoneRulesException      => Left(s"$s is not a valid ISO-8601 format, ${zre.getMessage}")
       case dtpe: DateTimeParseException => Left(s"$s is not a valid ISO-8601 format, ${dtpe.getMessage}")
       case dte: DateTimeException       => Left(s"$s is not a valid ISO-8601 format, ${dte.getMessage}")
-      case dpe: DurationParseException  => Left(s"$s is not a valid ISO-8601 format, ${dpe.message}")
+      case dpe: DurationParseException  => Left(s"$s is not a valid ISO-8601 format, ${dpe.getMessage}")
       case ex: Exception                => Left(ex.getMessage)
     }
 

--- a/zio-json/shared/src/main/scala/zio/json/javatime/DurationParser.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/DurationParser.scala
@@ -1,0 +1,138 @@
+package zio.json.javatime
+
+import java.time.{ Duration => JDuration }
+import java.util.regex.Pattern
+
+// The code in DurationParser is a more Scala-friendly port of the Duration.parse method from JDK 16 to cope with
+// a bug resulting in incorrect durations in JDK 8 (see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8054978)
+private[json] object DurationParser {
+  // We are not allowed to instantiate java.time.format Exceptions as we cross-compile for JavaScript
+  final case class DurationParseException(message: String, parsed: CharSequence, errorIndex: Int)
+      extends RuntimeException
+
+  private val DurationPattern: Pattern =
+    "([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?".r.pattern
+
+  private val HOURS_PER_DAY      = 24
+  private val MINUTES_PER_HOUR   = 60
+  private val SECONDS_PER_MINUTE = 60
+  private val SECONDS_PER_HOUR   = SECONDS_PER_MINUTE * MINUTES_PER_HOUR
+  private val SECONDS_PER_DAY    = SECONDS_PER_HOUR * HOURS_PER_DAY
+  private val NANOS_PER_SECOND   = 1000000000L
+
+  /**
+   * Takes a text duration and turns it into a java.time.Duration
+   * WARNING: unsafeParse throws exceptions
+   *
+   * @param text is the text input representation of a Duration
+   * @return java.time.Duration
+   */
+  def unsafeParse(text: CharSequence): JDuration =
+    if (text == null) throw new NullPointerException("text is null")
+    else {
+      val matcher = DurationPattern.matcher(text)
+      if (matcher.matches()) {
+        val negate = charMatch(text, matcher.start(1), matcher.end(1), '-')
+
+        val dayStart = matcher.start(2)
+        val dayEnd   = matcher.end(2)
+
+        val hourStart = matcher.start(4)
+        val hourEnd   = matcher.end(4)
+
+        val minuteStart = matcher.start(5)
+        val minuteEnd   = matcher.end(5)
+
+        val secondStart = matcher.start(6)
+        val secondEnd   = matcher.end(6)
+
+        val fractionStart = matcher.start(7)
+        val fractionEnd   = matcher.end(7)
+
+        if (dayStart >= 0 || hourStart >= 0 || minuteStart >= 0 || secondStart >= 0) {
+          val daysAsSecs   = parseNumber(text, dayStart, dayEnd, SECONDS_PER_DAY, "days")
+          val hoursAsSecs  = parseNumber(text, hourStart, hourEnd, SECONDS_PER_HOUR, "hours")
+          val minsAsSecs   = parseNumber(text, minuteStart, minuteEnd, SECONDS_PER_MINUTE, "minutes")
+          val seconds      = parseNumber(text, secondStart, secondEnd, 1, "seconds")
+          val negativeSecs = secondStart >= 0 && text.charAt(secondStart) == '-'
+          val nanos        = parseFraction(text, fractionStart, fractionEnd, if (negativeSecs) -1 else 1)
+          createDuration(negate, daysAsSecs, hoursAsSecs, minsAsSecs, seconds, nanos)
+        } else
+          throw DurationParseException(
+            "text matched pattern for Duration but day/hour/minute/second fraction was less than 0",
+            text,
+            0
+          )
+      } else throw DurationParseException("text cannot be parsed to a Duration", text, 0)
+    }
+
+  private def charMatch(text: CharSequence, start: Int, end: Int, c: Char): Boolean =
+    start >= 0 && end == start + 1 && text.charAt(start) == c
+
+  private def parseNumber(
+    text: CharSequence,
+    start: Int,
+    end: Int,
+    multiplier: Int,
+    errorText: String
+  ): Long =
+    // regex limits to [-+]?[0-9]+
+    if (start < 0 || end < 0) 0L
+    else
+      try {
+        val long = java.lang.Long.parseLong(text.subSequence(start, end).toString, 10)
+        Math.multiplyExact(long, multiplier)
+      } catch {
+        case _: NumberFormatException =>
+          throw DurationParseException(
+            s"text cannot be parsed to a number whilst parsing a Duration: " + errorText,
+            text,
+            0
+          )
+
+        case _: ArithmeticException =>
+          throw DurationParseException(
+            s"text cannot be parsed to a number whilst parsing a Duration: " + errorText,
+            text,
+            0
+          )
+      }
+
+  private def parseFraction(text: CharSequence, start: Int, end: Int, negate: Int): Int =
+    // regex limits to [0-9]{0,9}
+    if (start < 0 || end < 0 || end - start == 0) 0
+    else
+      try {
+        var fraction = text.subSequence(start, end).toString.toInt
+        // for number strings smaller than 9 digits, interpret as if there were trailing zeros
+        (end - start).until(9).foreach(_ => fraction *= 10)
+        fraction * negate
+      } catch {
+        case _: NumberFormatException =>
+          throw DurationParseException("Text cannot be parsed to a Duration: fraction", text, 0)
+
+        case _: ArithmeticException =>
+          throw DurationParseException("Text cannot be parsed to a Duration: fraction", text, 0)
+      }
+
+  private def createDuration(
+    negate: Boolean,
+    daysAsSecs: Long,
+    hoursAsSecs: Long,
+    minsAsSecs: Long,
+    secs: Long,
+    nanos: Long
+  ): JDuration = {
+    val seconds  = Math.addExact(daysAsSecs, Math.addExact(hoursAsSecs, Math.addExact(minsAsSecs, secs)))
+    val duration = ofSecondsAndNanos(seconds, nanos)
+    if (negate) duration.negated()
+    else duration
+  }
+
+  private def ofSecondsAndNanos(seconds: Long, nanoAdjustment: Long): JDuration = {
+    val secs = Math.addExact(seconds, Math.floorDiv(nanoAdjustment, NANOS_PER_SECOND))
+    val nos  = Math.floorMod(nanoAdjustment, NANOS_PER_SECOND).toInt
+    if ((secs | nos) == 0) JDuration.ZERO
+    else JDuration.ofSeconds(seconds, nanoAdjustment)
+  }
+}

--- a/zio-json/shared/src/main/scala/zio/json/javatime/DurationParser.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/DurationParser.scala
@@ -8,7 +8,7 @@ import java.util.regex.Pattern
 private[json] object DurationParser {
   // We are not allowed to instantiate java.time.format Exceptions as we cross-compile for JavaScript
   final case class DurationParseException(message: String, parsed: CharSequence, errorIndex: Int)
-      extends RuntimeException
+      extends RuntimeException(message)
 
   private val DurationPattern: Pattern =
     "([-+]?)P(?:([-+]?[0-9]+)D)?(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?".r.pattern

--- a/zio-json/shared/src/main/scala/zio/json/javatime/ZonedDateTimeParser.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/ZonedDateTimeParser.scala
@@ -1,0 +1,23 @@
+package zio.json.javatime
+
+import java.time.format.DateTimeFormatter
+import java.time.{ OffsetDateTime, ZoneId, ZonedDateTime }
+
+// ZonedDateTimeParser copes with a bug resulting in incorrect ZoneDateTimes in JDK 8
+// (see https://bugs.openjdk.java.net/browse/JDK-8066982)
+private[json] object ZonedDateTimeParser {
+  def unsafeParse(input: String): ZonedDateTime =
+    if (hasZone(input)) {
+      val zoneId = extractZone(input)
+      val odt    = OffsetDateTime.parse(input, DateTimeFormatter.ISO_ZONED_DATE_TIME)
+      odt.atZoneSameInstant(zoneId)
+    } else ZonedDateTime.parse(input)
+
+  private def hasZone(isoTime: String): Boolean =
+    isoTime.lastIndexOf("]") != -1
+
+  private def extractZone(isoTime: String): ZoneId = {
+    val begin = isoTime.lastIndexOf("[")
+    ZoneId.of(isoTime.substring(begin + 1, isoTime.length - 1))
+  }
+}

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -1,6 +1,5 @@
 package testzio.json
 
-import java.time.{ Duration => JDuration }
 import java.util.UUID
 
 import scala.collection.{ immutable, mutable }
@@ -163,12 +162,6 @@ object DecoderSpec extends DefaultRunnableSpec {
 
           assert(ok.fromJson[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4004-9832-4e700fe400f8")))) &&
           assert(bad.fromJson[UUID])(isLeft(containsString("Invalid UUID")))
-        },
-        test("java.time.Duration") {
-          // We simulate a failure scenario if we used Duration.parse directly (https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8054978)
-          // But our workaround fixes this and we have the correct duration
-          assert(""""PT-0.5S"""".fromJson[JDuration].map(_.toString))(isRight(equalTo("PT-0.5S"))) &&
-          assert(""""INVALID"""".fromJson[JDuration])(isLeft(containsString("text cannot be parsed to a Duration")))
         }
       ),
       suite("fromJsonAST")(

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -167,7 +167,8 @@ object DecoderSpec extends DefaultRunnableSpec {
         test("java.time.Duration") {
           // We simulate a failure scenario if we used Duration.parse directly (https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8054978)
           // But our workaround fixes this and we have the correct duration
-          assert(""""PT-0.5S"""".fromJson[JDuration].map(_.toString))(isRight(equalTo("PT-0.5S")))
+          assert(""""PT-0.5S"""".fromJson[JDuration].map(_.toString))(isRight(equalTo("PT-0.5S"))) &&
+          assert(""""INVALID"""".fromJson[JDuration])(isLeft(containsString("text cannot be parsed to a Duration")))
         }
       ),
       suite("fromJsonAST")(


### PR DESCRIPTION
- Isolate workarounds for `Duration` and `ZonedDateTime` into a separate package
- Avoid using Eithers and throw Exceptions to reduce memory allocations in `DurationParser`
- Add ZDT test cases that would fail with ZonedDateTime.parse but parse with the workaround 

Fixes https://github.com/zio/zio-json/issues/278

## Benchmark

```scala
package zio.json.javatime

import org.openjdk.jmh.annotations._
import zio.Chunk

import java.time.ZonedDateTime
import java.time.format.DateTimeFormatter
import java.util.concurrent.TimeUnit

@State(Scope.Thread)
@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Fork(value = 1)
class JavaTimeBenchmarks {
  private[this] var unparsedDatesChunk: Chunk[String] = null

  @Setup
  def setup(): Unit = {
    val now = ZonedDateTime.now()
    unparsedDatesChunk = Chunk.fromIterable(Range(1, 1000).map(step => now.minusMinutes(step.toLong).toString))
  }

  @Benchmark
  def parseAsZdt: Chunk[ZonedDateTime] = {
    val fmt = DateTimeFormatter.ISO_ZONED_DATE_TIME
    unparsedDatesChunk.map(ZonedDateTime.parse(_, fmt))
  }

  @Benchmark
  def parseCustom: Chunk[ZonedDateTime] =
    unparsedDatesChunk.map(ZonedDateTimeParser.unsafeParse)
}
```

### Results

```
Benchmark                                                        Mode  Cnt         Score         Error   Units
JavaTimeBenchmarks.parseAsZdt                                   thrpt    5         0.063 ±       0.016  ops/ms    
JavaTimeBenchmarks.parseAsZdt:·gc.alloc.rate                    thrpt    5           NaN                MB/sec    
JavaTimeBenchmarks.parseAsZdt:·gc.churn.JIT_code_cache          thrpt    5         0.035 ±       0.260  MB/sec    
JavaTimeBenchmarks.parseAsZdt:·gc.churn.JIT_code_cache.norm     thrpt    5       973.507 ±    7403.048    B/op    
JavaTimeBenchmarks.parseAsZdt:·gc.churn.nursery-allocate        thrpt    5       820.212 ±     318.714  MB/sec    
JavaTimeBenchmarks.parseAsZdt:·gc.churn.nursery-allocate.norm   thrpt    5  20475001.448 ± 7741013.463    B/op    
JavaTimeBenchmarks.parseAsZdt:·gc.count                         thrpt    5        27.000                counts    
JavaTimeBenchmarks.parseAsZdt:·gc.time                          thrpt    5        25.000                    ms    
JavaTimeBenchmarks.parseCustom                                  thrpt    5         0.065 ±       0.008  ops/ms    
JavaTimeBenchmarks.parseCustom:·gc.alloc.rate                   thrpt    5           NaN                MB/sec    
JavaTimeBenchmarks.parseCustom:·gc.churn.JIT_code_cache         thrpt    5         0.038 ±       0.273  MB/sec    
JavaTimeBenchmarks.parseCustom:·gc.churn.JIT_code_cache.norm    thrpt    5       952.938 ±    6959.982    B/op    
JavaTimeBenchmarks.parseCustom:·gc.churn.nursery-allocate       thrpt    5       882.807 ±     268.063  MB/sec    
JavaTimeBenchmarks.parseCustom:·gc.churn.nursery-allocate.norm  thrpt    5  21304653.198 ± 7164963.323    B/op    
JavaTimeBenchmarks.parseCustom:·gc.count                        thrpt    5        29.000                counts    
JavaTimeBenchmarks.parseCustom:·gc.time                         thrpt    5        31.000                    ms    
```


### Machine specifications

* MacBook Pro (16-inch, 2019)
* 2.6 GHz 6-Core Intel Core i7
* 16 GB 2667 MHz DDR4
