### PR TITLE
Simplify JsonCursor >>>, field, element

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/ast/JsonCursor.scala
+++ b/zio-json/shared/src/main/scala/zio/json/ast/JsonCursor.scala
@@ -18,17 +18,18 @@ sealed trait JsonCursor[-From, +To <: Json] { self =>
   final def isObject: JsonCursor[Json, Json.Obj] = filterType(JsonType.Obj)
 
   final def isString: JsonCursor[Json, Json.Str] = filterType(JsonType.Str)
+
+  final def field(field: String)(implicit ev: To <:< Json.Obj): JsonCursor.DownField =
+    JsonCursor.DownField(self.widenTo[Json.Obj], field)
+
+  final def element(index: Int)(implicit ev: To <:< Json.Arr): JsonCursor.DownElement =
+    JsonCursor.DownElement(self.widenTo[Json.Arr], index)
+
+  final private def widenTo[To1 <: Json](implicit ev: To <:< To1): JsonCursor[From, To1] =
+    self.asInstanceOf[JsonCursor[From, To1]]
 }
 
 object JsonCursor {
-  implicit class JsonCursorObjOps[From](cursor: JsonCursor[From, Json.Obj]) {
-    def field(field: String): DownField = JsonCursor.DownField(cursor, field)
-  }
-
-  implicit class JsonCursorArrOps[From](cursor: JsonCursor[From, Json.Arr]) {
-    def element(element: Int): DownElement = JsonCursor.DownElement(cursor, element)
-  }
-
   def element(index: Int): JsonCursor[Json.Arr, Json] = DownElement(Identity.isArray, index)
 
   def field(name: String): JsonCursor[Json.Obj, Json] = DownField(Identity.isObject, name)

--- a/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
+++ b/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
@@ -115,9 +115,6 @@ sealed abstract class Json { self =>
 
       case JsonCursor.FilterType(parent, t @ jsonType) =>
         self.get(parent).flatMap(x => jsonType.get(x))
-
-      case JsonCursor.AndThen(parent, next) =>
-        self.get(parent).flatMap(x => x.get(next))
     }
 
   override final def hashCode: Int =

--- a/zio-json/shared/src/test/scala/zio/json/ast/JsonSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ast/JsonSpec.scala
@@ -139,13 +139,24 @@ object JsonSpec extends DefaultRunnableSpec {
           assert(Json.Str("test").get(filterBool))(isLeft) &&
           assert(Json.Str("test").get(filterNum))(isLeft)
         },
-        test(">>>") {
+        test(">>>, object") {
           val downUser       = JsonCursor.field("user")
           val downId         = JsonCursor.field("id")
           val downUserDownId = downUser.isObject >>> downId
 
           assert(tweet.get(downUserDownId))(
             isRight(equalTo(Json.Num(6200)))
+          )
+        },
+        test(">>>, array, filterType") {
+          val downHashtags = JsonCursor.field("entities").isObject.field("hashtags")
+          val asArray      = JsonCursor.filter(JsonType.Arr)
+          val downFirst    = JsonCursor.element(0)
+
+          val combined = downHashtags >>> asArray >>> downFirst
+
+          assert(tweet.get(combined))(
+            isRight(equalTo(Json.Str("twitter")))
           )
         }
       )


### PR DESCRIPTION
- `JsonCursor.>>>` no longer creates intermediate `AndThen` nodes
- Better compile errors for `field` / `element`

```diff
--- value field is not a member of JsonCursor.Identity
+++ Cannot prove that Json <: Json.Obj
```