### PR TITLE
Fix #292: decode special numbers (Infinite, NaN)

### DIFF
--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -260,7 +260,7 @@ object DecoderPlatformSpecificSpec extends DefaultRunnableSpec {
             }
             assert(decoder.decodeJson("true"))(equalTo(Right(true.asInstanceOf[AnyVal]))) &&
             assert(decoder.decodeJson("42"))(equalTo(Right(42.asInstanceOf[AnyVal]))) &&
-            assert(decoder.decodeJson("\"a string\""))(equalTo(Left("(expected a number, got a)")))
+            assert(decoder.decodeJson("\"a string\""))(equalTo(Left("(expected a number, got \")")))
           }
         )
       )

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -260,7 +260,7 @@ object DecoderPlatformSpecificSpec extends DefaultRunnableSpec {
             }
             assert(decoder.decodeJson("true"))(equalTo(Right(true.asInstanceOf[AnyVal]))) &&
             assert(decoder.decodeJson("42"))(equalTo(Right(42.asInstanceOf[AnyVal]))) &&
-            assert(decoder.decodeJson("\"a string\""))(equalTo(Left("(expected a number, got \")")))
+            assert(decoder.decodeJson("\"a string\""))(equalTo(Left("(expected an Int)")))
           }
         )
       )

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -290,6 +290,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
         (in.nextNonWhitespace(): @switch) match {
           case '"' =>
+            in.retract()
             val i = f(trace, in)
             Lexer.charOnly(trace, in, '"')
             i

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -282,7 +282,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
 
   // numbers decode from numbers or strings for maximum compatibility
   private[this] def number[A](
-    f: (List[JsonError], RetractReader) => A,
+    f: (List[JsonError], RetractReader, Boolean) => A,
     fromBigDecimal: java.math.BigDecimal => A
   ): JsonDecoder[A] =
     new JsonDecoder[A] {
@@ -290,13 +290,12 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
         (in.nextNonWhitespace(): @switch) match {
           case '"' =>
-            in.retract()
-            val i = f(trace, in)
+            val i = f(trace, in, false)
             Lexer.charOnly(trace, in, '"')
             i
           case _ =>
             in.retract()
-            f(trace, in)
+            f(trace, in, true)
         }
 
       override final def fromJsonAST(json: Json): Either[String, A] =
@@ -309,7 +308,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
           case Json.Str(value) =>
             val reader = new FastStringReader(value)
             val result =
-              try Right(f(List.empty, reader))
+              try Right(f(List.empty, reader, true))
               catch {
                 case JsonDecoder.UnsafeJson(trace) => Left(JsonError.render(trace))
                 case _: internal.UnexpectedEnd     => Left("Unexpected end of input")

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -165,8 +165,8 @@ object Lexer {
         )
     }
 
-  def byte(trace: List[JsonError], in: RetractReader): Byte = {
-    checkNumber(trace, in)
+  def byte(trace: List[JsonError], in: RetractReader, performPreparation: Boolean): Byte = {
+    if (performPreparation) prepareNumber(trace, in)
     try {
       val i = UnsafeNumbers.byte_(in, false)
       in.retract()
@@ -177,8 +177,8 @@ object Lexer {
     }
   }
 
-  def short(trace: List[JsonError], in: RetractReader): Short = {
-    checkNumber(trace, in)
+  def short(trace: List[JsonError], in: RetractReader, performPreparation: Boolean): Short = {
+    if (performPreparation) prepareNumber(trace, in)
     try {
       val i = UnsafeNumbers.short_(in, false)
       in.retract()
@@ -189,8 +189,8 @@ object Lexer {
     }
   }
 
-  def int(trace: List[JsonError], in: RetractReader): Int = {
-    checkNumber(trace, in)
+  def int(trace: List[JsonError], in: RetractReader, performPreparation: Boolean): Int = {
+    if (performPreparation) prepareNumber(trace, in)
     try {
       val i = UnsafeNumbers.int_(in, false)
       in.retract()
@@ -201,8 +201,8 @@ object Lexer {
     }
   }
 
-  def long(trace: List[JsonError], in: RetractReader): Long = {
-    checkNumber(trace, in)
+  def long(trace: List[JsonError], in: RetractReader, performPreparation: Boolean): Long = {
+    if (performPreparation) prepareNumber(trace, in)
     try {
       val i = UnsafeNumbers.long_(in, false)
       in.retract()
@@ -215,9 +215,10 @@ object Lexer {
 
   def bigInteger(
     trace: List[JsonError],
-    in: RetractReader
+    in: RetractReader,
+    performPreparation: Boolean
   ): java.math.BigInteger = {
-    checkNumber(trace, in)
+    if (performPreparation) prepareNumber(trace, in)
     try {
       val i = UnsafeNumbers.bigInteger_(in, false, NumberMaxBits)
       in.retract()
@@ -228,8 +229,8 @@ object Lexer {
     }
   }
 
-  def float(trace: List[JsonError], in: RetractReader): Float = {
-    checkFloatingPointNumber(trace, in)
+  def float(trace: List[JsonError], in: RetractReader, performPreparation: Boolean): Float = {
+    if (performPreparation) prepareNumber(trace, in)
     try {
       val i = UnsafeNumbers.float_(in, false, NumberMaxBits)
       in.retract()
@@ -240,8 +241,8 @@ object Lexer {
     }
   }
 
-  def double(trace: List[JsonError], in: RetractReader): Double = {
-    checkFloatingPointNumber(trace, in)
+  def double(trace: List[JsonError], in: RetractReader, performPreparation: Boolean): Double = {
+    if (performPreparation) prepareNumber(trace, in)
     try {
       val i = UnsafeNumbers.double_(in, false, NumberMaxBits)
       in.retract()
@@ -254,9 +255,10 @@ object Lexer {
 
   def bigDecimal(
     trace: List[JsonError],
-    in: RetractReader
+    in: RetractReader,
+    performPreparation: Boolean
   ): java.math.BigDecimal = {
-    checkNumber(trace, in)
+    if (performPreparation) prepareNumber(trace, in)
     try {
       val i = UnsafeNumbers.bigDecimal_(in, false, NumberMaxBits)
       in.retract()
@@ -268,7 +270,7 @@ object Lexer {
   }
 
   // really just a way to consume the whitespace
-  private def checkNumber(trace: List[JsonError], in: RetractReader): Unit = {
+  private def prepareNumber(trace: List[JsonError], in: RetractReader): Unit = {
     (in.nextNonWhitespace(): @switch) match {
       case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => ()
       case c =>
@@ -277,17 +279,6 @@ object Lexer {
         )
     }
     in.retract()
-  }
-
-  private def checkFloatingPointNumber(trace: List[JsonError], in: RetractReader): Unit = {
-    (in.nextNonWhitespace(): @switch) match {
-      case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => in.retract()
-      case '"' => ()
-      case c =>
-        throw UnsafeJson(
-          JsonError.Message(s"expected a number, got $c") :: trace
-        )
-    }
   }
 
   // optional whitespace and then an expected character

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -112,7 +112,7 @@ object Lexer {
         }
       case '"' =>
         skipString(trace, in)
-      case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
+      case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'N' | 'I' =>
         skipNumber(in)
       case c => throw UnsafeJson(JsonError.Message(s"unexpected '$c'") :: trace)
     }
@@ -270,7 +270,7 @@ object Lexer {
   // really just a way to consume the whitespace
   private def checkNumber(trace: List[JsonError], in: RetractReader): Unit = {
     (in.nextNonWhitespace(): @switch) match {
-      case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => ()
+      case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'N' | 'I' => ()
       case c =>
         throw UnsafeJson(
           JsonError.Message(s"expected a number, got $c") :: trace
@@ -299,7 +299,7 @@ object Lexer {
   // non-positional for performance
   @inline private[this] def isNumber(c: Char): Boolean =
     (c: @switch) match {
-      case '+' | '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '.' | 'e' | 'E' =>
+      case '+' | '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '.' | 'e' | 'E' | 'N' | 'a' | 'I' | 'n' | 'f' | 'i' | 't' | 'y' =>
         true
       case _ => false
     }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -25,6 +25,15 @@ object DecoderSpec extends DefaultRunnableSpec {
             isLeft(equalTo("(expected a 128 bit BigInteger)"))
           )
         },
+        test("Infinity") {
+          assert("Infinity".fromJson[Double])(isRight(Assertion.assertion("isPositiveInfinity")()(_.isPosInfinity)))
+        },
+        test("-Infinity") {
+          assert("-Infinity".fromJson[Double])(isRight(Assertion.assertion("isNegativeInfinity")()(_.isNegInfinity)))
+        },
+        test("NaN") {
+          assert("NaN".fromJson[Double])(isRight(Assertion.assertion("isNaN")()(_.isNaN)))
+        },
         test("collections") {
           val arr = """[1, 2, 3]"""
           val obj = """{ "a": 1 }"""

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -34,9 +34,6 @@ object DecoderSpec extends DefaultRunnableSpec {
         test("NaN") {
           assert("\"NaN\"".fromJson[Double])(isRight(Assertion.assertion("isNaN")()(_.isNaN)))
         },
-        test("-Infinity symbol") {
-          assert("-Infinity".fromJson[Double])(isLeft(equalTo("expected a number, got -")))
-        },
         test("collections") {
           val arr = """[1, 2, 3]"""
           val obj = """{ "a": 1 }"""

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -29,7 +29,9 @@ object DecoderSpec extends DefaultRunnableSpec {
           assert("\"Infinity\"".fromJson[Double])(isRight(Assertion.assertion("isPositiveInfinity")()(_.isPosInfinity)))
         },
         test("-Infinity") {
-          assert("\"-Infinity\"".fromJson[Double])(isRight(Assertion.assertion("isNegativeInfinity")()(_.isNegInfinity)))
+          assert("\"-Infinity\"".fromJson[Double])(
+            isRight(Assertion.assertion("isNegativeInfinity")()(_.isNegInfinity))
+          )
         },
         test("NaN") {
           assert("\"NaN\"".fromJson[Double])(isRight(Assertion.assertion("isNaN")()(_.isNaN)))

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -26,13 +26,16 @@ object DecoderSpec extends DefaultRunnableSpec {
           )
         },
         test("Infinity") {
-          assert("Infinity".fromJson[Double])(isRight(Assertion.assertion("isPositiveInfinity")()(_.isPosInfinity)))
+          assert("\"Infinity\"".fromJson[Double])(isRight(Assertion.assertion("isPositiveInfinity")()(_.isPosInfinity)))
         },
         test("-Infinity") {
-          assert("-Infinity".fromJson[Double])(isRight(Assertion.assertion("isNegativeInfinity")()(_.isNegInfinity)))
+          assert("\"-Infinity\"".fromJson[Double])(isRight(Assertion.assertion("isNegativeInfinity")()(_.isNegInfinity)))
         },
         test("NaN") {
-          assert("NaN".fromJson[Double])(isRight(Assertion.assertion("isNaN")()(_.isNaN)))
+          assert("\"NaN\"".fromJson[Double])(isRight(Assertion.assertion("isNaN")()(_.isNaN)))
+        },
+        test("-Infinity symbol") {
+          assert("-Infinity".fromJson[Double])(isLeft(equalTo("expected a number, got -")))
         },
         test("collections") {
           val arr = """[1, 2, 3]"""


### PR DESCRIPTION
To fix it, it seems that I've to add chars N and I in the function `checkNumber`  in `lexer,scala` . But it seems that something equivalent should be done for the function `skipValue`  and `isNumber`. For the last one, it seems that we have to add in the case the letters in NaN and Infinity.

I have also added some tests.