### PR TITLE
Support enum encoding

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala/zio/json/macros.scala
@@ -71,7 +71,17 @@ object DeriveJsonDecoder {
     if (ctx.parameters.isEmpty)
       new JsonDecoder[A] {
         def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
-          if (no_extra) {
+          // if we expect a case object we check string with his name
+          if (ctx.isObject) {
+            val value = Lexer.string(trace, in).toString
+            if (value == ctx.typeName.short) {
+              ctx.rawConstruct(Nil)
+            } else {
+              throw UnsafeJson(
+                JsonError.Message(s"expected ${ctx.typeName.short} got '$value'") :: trace)
+            }
+          }
+          else if (no_extra) {
             Lexer.char(trace, in, '{')
             Lexer.char(trace, in, '}')
           } else {
@@ -214,28 +224,48 @@ object DeriveJsonDecoder {
       ctx.subtypes.map(_.typeclass).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
     lazy val namesMap: Map[String, Int] = names.zipWithIndex.toMap
 
+    // we search over the subtypes and tries to the current string with each one
+    def findEnumMatches(trace: List[JsonError], in: RetractReader): Option[A] = {
+      import scala.util.Try
+      Try {
+        val value = Lexer.string(trace, in).toString
+        ctx.subtypes
+          .foldLeft(None.asInstanceOf[Option[A]]) {
+            case (v@Some(_), _) => v
+            case (_, s) => s.typeclass.decodeJson(s""""$value"""").toOption
+          }
+      }.getOrElse(None)
+    }
+
     def discrim = ctx.annotations.collectFirst { case jsonDiscriminator(n) => n }
     if (discrim.isEmpty)
       new JsonDecoder[A] {
         val spans: Array[JsonError] = names.map(JsonError.ObjectAccess(_))
         def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
-          Lexer.char(trace, in, '{')
-          // we're not allowing extra fields in this encoding
-          if (Lexer.firstField(trace, in)) {
-            val field = Lexer.field(trace, in, matrix)
-            if (field != -1) {
-              val trace_ = spans(field) :: trace
-              val a      = tcs(field).unsafeDecode(trace_, in).asInstanceOf[A]
-              Lexer.char(trace, in, '}')
-              a
+          try {
+            Lexer.char(trace, in, '{')
+            // we're not allowing extra fields in this encoding
+            if (Lexer.firstField(trace, in)) {
+              val field = Lexer.field(trace, in, matrix)
+              if (field != -1) {
+                val trace_ = spans(field) :: trace
+                val a = tcs(field).unsafeDecode(trace_, in).asInstanceOf[A]
+                Lexer.char(trace, in, '}')
+                a
+              } else
+                throw UnsafeJson(
+                  JsonError.Message("invalid disambiguator") :: trace
+                )
             } else
               throw UnsafeJson(
-                JsonError.Message("invalid disambiguator") :: trace
+                JsonError.Message("expected non-empty object") :: trace
               )
-          } else
-            throw UnsafeJson(
-              JsonError.Message("expected non-empty object") :: trace
-            )
+          } catch {
+            case e: UnsafeJson =>
+              // try to match a enum case object
+              in.retract()
+              findEnumMatches(trace, in).getOrElse(throw e)
+          }
         }
 
         override final def fromJsonAST(json: Json): Either[String, A] =
@@ -304,8 +334,18 @@ object DeriveJsonDecoder {
 object DeriveJsonEncoder {
   type Typeclass[A] = JsonEncoder[A]
 
-  def combine[A](ctx: CaseClass[JsonEncoder, A]): JsonEncoder[A] =
-    if (ctx.parameters.isEmpty)
+  def combine[A](ctx: CaseClass[JsonEncoder, A]): JsonEncoder[A] = {
+    // encode a case object simply with his name as a string
+    if (ctx.isObject) {
+      new JsonEncoder[A] {
+        def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit =
+          out.write(s""""${ctx.typeName.short}"""")
+
+        override final def toJsonAST(a: A): Either[String, Json] =
+          Right(Json.Obj(Chunk.empty))
+      }
+    }
+    else if (ctx.parameters.isEmpty)
       new JsonEncoder[A] {
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write("{}")
 
@@ -371,8 +411,16 @@ object DeriveJsonEncoder {
             }
             .map(Json.Obj.apply)
       }
+  }
 
   def dispatch[A](ctx: SealedTrait[JsonEncoder, A]): JsonEncoder[A] = {
+    // check if `x` is a case object (enum)
+    def isCaseObject(x: Any): Boolean = {
+      // scala js does not supports getFields
+      // x.getClass.getFields.map(_.getName) contains "MODULE$"
+      x.getClass.getName.endsWith("$")
+    }
+
     val names: Array[String] = ctx.subtypes.map { p =>
       p.annotations.collectFirst { case jsonHint(name) =>
         name
@@ -382,15 +430,19 @@ object DeriveJsonEncoder {
     if (discrim.isEmpty)
       new JsonEncoder[A] {
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = ctx.dispatch(a) { sub =>
-          out.write("{")
-          val indent_ = JsonEncoder.bump(indent)
-          JsonEncoder.pad(indent_, out)
-          JsonEncoder.string.unsafeEncode(names(sub.index), indent_, out)
-          if (indent.isEmpty) out.write(":")
-          else out.write(" : ")
-          sub.typeclass.unsafeEncode(sub.cast(a), indent_, out)
-          JsonEncoder.pad(indent, out)
-          out.write("}")
+          if (isCaseObject(a)) {
+            sub.typeclass.unsafeEncode(sub.cast(a), indent, out)
+          } else {
+            out.write("{")
+            val indent_ = JsonEncoder.bump(indent)
+            JsonEncoder.pad(indent_, out)
+            JsonEncoder.string.unsafeEncode(names(sub.index), indent_, out)
+            if (indent.isEmpty) out.write(":")
+            else out.write(" : ")
+            sub.typeclass.unsafeEncode(sub.cast(a), indent_, out)
+            JsonEncoder.pad(indent, out)
+            out.write("}")
+          }
         }
 
         override def toJsonAST(a: A): Either[String, Json] =

--- a/zio-json/shared/src/main/scala/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala/zio/json/macros.scala
@@ -77,11 +77,9 @@ object DeriveJsonDecoder {
             if (value == ctx.typeName.short) {
               ctx.rawConstruct(Nil)
             } else {
-              throw UnsafeJson(
-                JsonError.Message(s"expected ${ctx.typeName.short} got '$value'") :: trace)
+              throw UnsafeJson(JsonError.Message(s"expected ${ctx.typeName.short} got '$value'") :: trace)
             }
-          }
-          else if (no_extra) {
+          } else if (no_extra) {
             Lexer.char(trace, in, '{')
             Lexer.char(trace, in, '}')
           } else {
@@ -231,8 +229,8 @@ object DeriveJsonDecoder {
         val value = Lexer.string(trace, in).toString
         ctx.subtypes
           .foldLeft(None.asInstanceOf[Option[A]]) {
-            case (v@Some(_), _) => v
-            case (_, s) => s.typeclass.decodeJson(s""""$value"""").toOption
+            case (v @ Some(_), _) => v
+            case (_, s)           => s.typeclass.decodeJson(s""""$value"""").toOption
           }
       }.getOrElse(None)
     }
@@ -241,7 +239,7 @@ object DeriveJsonDecoder {
     if (discrim.isEmpty)
       new JsonDecoder[A] {
         val spans: Array[JsonError] = names.map(JsonError.ObjectAccess(_))
-        def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
+        def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
           try {
             Lexer.char(trace, in, '{')
             // we're not allowing extra fields in this encoding
@@ -249,7 +247,7 @@ object DeriveJsonDecoder {
               val field = Lexer.field(trace, in, matrix)
               if (field != -1) {
                 val trace_ = spans(field) :: trace
-                val a = tcs(field).unsafeDecode(trace_, in).asInstanceOf[A]
+                val a      = tcs(field).unsafeDecode(trace_, in).asInstanceOf[A]
                 Lexer.char(trace, in, '}')
                 a
               } else
@@ -266,7 +264,6 @@ object DeriveJsonDecoder {
               in.retract()
               findEnumMatches(trace, in).getOrElse(throw e)
           }
-        }
 
         override final def fromJsonAST(json: Json): Either[String, A] =
           json match {
@@ -334,7 +331,7 @@ object DeriveJsonDecoder {
 object DeriveJsonEncoder {
   type Typeclass[A] = JsonEncoder[A]
 
-  def combine[A](ctx: CaseClass[JsonEncoder, A]): JsonEncoder[A] = {
+  def combine[A](ctx: CaseClass[JsonEncoder, A]): JsonEncoder[A] =
     // encode a case object simply with his name as a string
     if (ctx.isObject) {
       new JsonEncoder[A] {
@@ -344,8 +341,7 @@ object DeriveJsonEncoder {
         override final def toJsonAST(a: A): Either[String, Json] =
           Right(Json.Obj(Chunk.empty))
       }
-    }
-    else if (ctx.parameters.isEmpty)
+    } else if (ctx.parameters.isEmpty)
       new JsonEncoder[A] {
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write("{}")
 
@@ -411,15 +407,13 @@ object DeriveJsonEncoder {
             }
             .map(Json.Obj.apply)
       }
-  }
 
   def dispatch[A](ctx: SealedTrait[JsonEncoder, A]): JsonEncoder[A] = {
     // check if `x` is a case object (enum)
-    def isCaseObject(x: Any): Boolean = {
+    def isCaseObject(x: Any): Boolean =
       // scala js does not supports getFields
       // x.getClass.getFields.map(_.getName) contains "MODULE$"
       x.getClass.getName.endsWith("$")
-    }
 
     val names: Array[String] = ctx.subtypes.map { p =>
       p.annotations.collectFirst { case jsonHint(name) =>

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -270,6 +270,25 @@ object DecoderSpec extends DefaultRunnableSpec {
           assert(ok.as[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4004-9832-4e700fe400f8")))) &&
           assert(bad.as[UUID])(isLeft(containsString("Invalid UUID")))
         }
+      ),
+      suite("decode enums")(
+        test("simple enum") {
+          import exampleenums._
+
+          val jsonStr  = """"Yellow""""
+          val expected = Yellow
+
+          assert(jsonStr.fromJson[Color])(isRight(equalTo(expected)))
+        },
+        test("case class with enum") {
+
+          import exampleenums._
+
+          val jsonStr  = """{"color": "Yellow", "name": "yellowStyle"}"""
+          val expected = Style(name = "yellowStyle", color = Yellow)
+
+          assert(jsonStr.fromJson[Style])(isRight(equalTo(expected)))
+        }
       )
     )
 
@@ -341,4 +360,20 @@ object DecoderSpec extends DefaultRunnableSpec {
     implicit val eventEncoder: JsonEncoder[Event] = DeriveJsonEncoder.gen[Event]
   }
 
+  object exampleenums {
+
+    sealed trait Color
+    case object Green extends Color
+    case object Yellow extends Color
+
+    case class Style(name: String, color: Color)
+
+    object Style {
+      implicit val decoder: JsonDecoder[Style] = DeriveJsonDecoder.gen[Style]
+    }
+    object Color {
+      implicit val decoder: JsonDecoder[Color] = DeriveJsonDecoder.gen[Color]
+    }
+
+  }
 }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -363,7 +363,7 @@ object DecoderSpec extends DefaultRunnableSpec {
   object exampleenums {
 
     sealed trait Color
-    case object Green extends Color
+    case object Green  extends Color
     case object Yellow extends Color
 
     case class Style(name: String, color: Color)

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -140,7 +140,23 @@ object EncoderSpec extends DefaultRunnableSpec {
         test("exclude fields") {
           import exampleexcludefield._
           assert(Person("Peter", 20).toJson)(equalTo("""{"name":"Peter"}"""))
-        }
+        },
+        suite("enums")(
+          test("encode enum object") {
+            import exampleenums._
+
+            val value: Color = Yellow
+
+            assert(value.toJson)(equalTo(""""Yellow""""))
+          },
+          test("encode product with enum") {
+            import exampleenums._
+
+            val value: Style = Style(name = "yellow", color = Yellow)
+
+            assert(value.toJson)(equalTo("""{"name":"yellow","color":"Yellow"}"""))
+          }
+        )
       ),
       suite("toJsonAST")(
         suite("primitives")(
@@ -306,4 +322,20 @@ object EncoderSpec extends DefaultRunnableSpec {
 
   }
 
+  object exampleenums {
+
+    sealed trait Color
+    case object Green extends Color
+    case object Yellow extends Color
+
+    case class Style(name: String, color: Color)
+
+    object Style {
+      implicit val encoder: JsonEncoder[Style] = DeriveJsonEncoder.gen[Style]
+    }
+    object Color {
+      implicit val encoder: JsonEncoder[Color] = DeriveJsonEncoder.gen[Color]
+    }
+
+  }
 }

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -325,7 +325,7 @@ object EncoderSpec extends DefaultRunnableSpec {
   object exampleenums {
 
     sealed trait Color
-    case object Green extends Color
+    case object Green  extends Color
     case object Yellow extends Color
 
     case class Style(name: String, color: Color)


### PR DESCRIPTION
From #105.

It allows to encode/decode enums (as sealed traits and case objects) like
```scala
   sealed trait Color
   case object Green extends Color
   case object Yellow extends Color
```

I think that some things needs some revision or maybe a different/better solution:

1 - When decoding a SealedTrait, lexer tries to consumes '{', if it throws an UnsafeJson exception, we try to match an enum value.
2 - Find a better approach to determine if an object is a case object (should work in scala.js too)
```scala
def isCaseObject(x: Any): Boolean = x.getClass.getName.endsWith("$")
``` 