### PR TITLE
Add JsonFieldDecoder and JsonFieldEncoder for refined fields

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/compat/refined.scala
+++ b/zio-json/shared/src/main/scala/zio/json/compat/refined.scala
@@ -12,4 +12,9 @@ object refined {
   implicit def decodeRefined[A: JsonDecoder, P](implicit V: Validate[A, P]): JsonDecoder[A Refined P] =
     JsonDecoder[A].mapOrFail(refineV[P](_))
 
+  implicit def encodeFieldRefined[A: JsonFieldEncoder, B]: JsonFieldEncoder[A Refined B] =
+    JsonFieldEncoder[A].contramap(_.value)
+
+  implicit def decodeFieldRefined[A: JsonFieldDecoder, P](implicit V: Validate[A, P]): JsonFieldDecoder[A Refined P] =
+    JsonFieldDecoder[A].mapOrFail(refineV[P](_))
 }


### PR DESCRIPTION
Wanted to have a property Map[String Refined P, MyObject] but It was missing the JsonField Codecs. This PR adds them. I haven't seen tests related to refined. Please let me know if you want me to add them.

Regards. 