### PR TITLE
Mergify: Does not use master

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,7 +16,6 @@ pull_request_rules:
         add: ["type: breaking"]
   - name: merge Scala Steward's PRs
     conditions:
-      - base=master
       - author=scala-steward
       - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: scalafix-rule-update)|(labels: test-library-update)"
       - "status-success=license/cla"


### PR DESCRIPTION
Btw, have you guys considered using `master`? Mistakes like this are bound to happen when things are different across the repos in our organization.
@fsvehla @mijicd
