### PR TITLE
Yet more efficient parsing of UUIDs

### DIFF
--- a/zio-json/jvm/src/jmh/scala/zio/json/UUIDBenchmarks.scala
+++ b/zio-json/jvm/src/jmh/scala/zio/json/UUIDBenchmarks.scala
@@ -1,0 +1,43 @@
+package zio.json
+
+import org.openjdk.jmh.annotations._
+import zio.Chunk
+import zio.json.uuid.UUIDParser
+import zio.random.Random
+import zio.test.Gen
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+class UUIDBenchmarks {
+  private[this] var unparsedUUIDChunk: Chunk[String] = _
+
+  @Setup
+  def setup(): Unit = {
+    val section1   = Gen.long(0x0L, 0xffffffffL).map(_.toHexString)
+    val section234 = Gen.long(0x0L, 0xffffL).map(_.toHexString)
+    val section5   = Gen.long(0x0L, 0xffffffffffffL).map(_.toHexString)
+
+    val gen: Gen[Random, String] = for {
+      s1 <- section1
+      s2 <- section234
+      s3 <- section234
+      s4 <- section234
+      s5 <- section5
+    } yield s"$s1-$s2-$s3-$s4-$s5"
+
+    unparsedUUIDChunk = zio.Runtime.global.unsafeRun(gen.runCollectN(10000).map(Chunk.fromIterable))
+  }
+
+  @Benchmark
+  def parseInBuiltUUID: Chunk[UUID] =
+    unparsedUUIDChunk.map(UUID.fromString)
+
+  @Benchmark
+  def parseCustom: Chunk[UUID] =
+    unparsedUUIDChunk.map(UUIDParser.unsafeParse)
+}

--- a/zio-json/shared/src/main/scala/zio/json/uuid/UUIDParser.scala
+++ b/zio-json/shared/src/main/scala/zio/json/uuid/UUIDParser.scala
@@ -5,8 +5,8 @@ import scala.annotation.nowarn
 // A port of https://github.com/openjdk/jdk/commit/ebadfaeb2e1cc7b5ce5f101cd8a539bc5478cf5b with optimizations applied
 private[json] object UUIDParser {
   // Converts characters to their numeric representation (for example 'E' or 'e' becomes 0XE)
-  private val CharToNumeric: Array[Byte] = {
-    // by filling in -1's we prevent parseLong from trying to parse invalid characters
+  private[this] val CharToNumeric: Array[Byte] = {
+    // by filling in -1's we prevent from trying to parse invalid characters
     val ns = Array.fill[Byte](256)(-1)
 
     ns('0') = 0
@@ -37,122 +37,85 @@ private[json] object UUIDParser {
     ns
   }
 
-  // Used to detect the presence of extra bits
-  private val mask8Z  = 0xfffffff00000000L
-  private val mask4Z  = 0xfffffffffff0000L
-  private val mask12Z = 0xfff000000000000L
-
   def unsafeParse(input: String): java.util.UUID =
-    if (input.length == 36) {
-      val ch1 = input.charAt(8)
-      val ch2 = input.charAt(13)
-      val ch3 = input.charAt(18)
-      val ch4 = input.charAt(23)
-
-      if (ch1 == '-' && ch2 == '-' && ch3 == '-' && ch4 == '-') {
-        val msb1 = parseNibbles(input, 0)
-        val msb2 = parseNibbles(input, 4)
-        val msb3 = parseNibbles(input, 9)
-        val msb4 = parseNibbles(input, 14)
-        val lsb1 = parseNibbles(input, 19)
-        val lsb2 = parseNibbles(input, 24)
-        val lsb3 = parseNibbles(input, 28)
-        val lsb4 = parseNibbles(input, 32)
-        if ((msb1 | msb2 | msb3 | msb4 | lsb1 | lsb2 | lsb3 | lsb4) >= 0) {
-          new java.util.UUID(
-            msb1 << 48 | msb2 << 32 | msb3 << 16 | msb4,
-            lsb1 << 48 | lsb2 << 32 | lsb3 << 16 | lsb4
-          )
-        } else unsafeParseExtended(input)
-      } else unsafeParseExtended(input)
-    } else unsafeParseExtended(input)
+    if (
+      input.length != 36 || {
+        val ch1 = input.charAt(8)
+        val ch2 = input.charAt(13)
+        val ch3 = input.charAt(18)
+        val ch4 = input.charAt(23)
+        ch1 != '-' || ch2 != '-' || ch3 != '-' || ch4 != '-'
+      }
+    ) unsafeParseExtended(input)
+    else {
+      val ch2n = CharToNumeric
+      val msb1 = parseNibbles(ch2n, input, 0)
+      val msb2 = parseNibbles(ch2n, input, 4)
+      val msb3 = parseNibbles(ch2n, input, 9)
+      val msb4 = parseNibbles(ch2n, input, 14)
+      val lsb1 = parseNibbles(ch2n, input, 19)
+      val lsb2 = parseNibbles(ch2n, input, 24)
+      val lsb3 = parseNibbles(ch2n, input, 28)
+      val lsb4 = parseNibbles(ch2n, input, 32)
+      if ((msb1 | msb2 | msb3 | msb4 | lsb1 | lsb2 | lsb3 | lsb4) < 0) invalidUUIDError(input)
+      new java.util.UUID(msb1 << 48 | msb2 << 32 | msb3 << 16 | msb4, lsb1 << 48 | lsb2 << 32 | lsb3 << 16 | lsb4)
+    }
 
   // A nibble is 4 bits
   @nowarn("msg=implicit numeric widening")
-  private def parseNibbles(input: String, position: Int): Long = {
+  private[this] def parseNibbles(ch2n: Array[Byte], input: String, position: Int): Long = {
     val ch1 = input.charAt(position)
     val ch2 = input.charAt(position + 1)
     val ch3 = input.charAt(position + 2)
     val ch4 = input.charAt(position + 3)
-
     if ((ch1 | ch2 | ch3 | ch4) > 0xff) -1L
-    else CharToNumeric(ch1) << 12 | CharToNumeric(ch2) << 8 | CharToNumeric(ch3) << 4 | CharToNumeric(ch4)
+    else ch2n(ch1) << 12 | ch2n(ch2) << 8 | ch2n(ch3) << 4 | ch2n(ch4)
   }
 
-  private def unsafeParseExtended(name: String): java.util.UUID = {
-    val len = name.length
+  private[this] def unsafeParseExtended(input: String): java.util.UUID = {
+    val len = input.length
     if (len > 36) throw new IllegalArgumentException("UUID string too large")
-    val dash1 = name.indexOf('-', 0)
-    val dash2 = name.indexOf('-', dash1 + 1)
-    val dash3 = name.indexOf('-', dash2 + 1)
-    val dash4 = name.indexOf('-', dash3 + 1)
-    val dash5 = name.indexOf('-', dash4 + 1)
+    val dash1 = input.indexOf('-', 0)
+    val dash2 = input.indexOf('-', dash1 + 1)
+    val dash3 = input.indexOf('-', dash2 + 1)
+    val dash4 = input.indexOf('-', dash3 + 1)
+    val dash5 = input.indexOf('-', dash4 + 1)
 
     // For any valid input, dash1 through dash4 will be positive and dash5 will be negative,
     // but it's enough to check dash4 and dash5:
     // - if dash1 is -1, dash4 will be -1
     // - if dash1 is positive but dash2 is -1, dash4 will be -1
     // - if dash1 and dash2 is positive, dash3 will be -1, dash4 will be positive, but so will dash5
-    if (dash4 < 0 || dash5 >= 0) throw new IllegalArgumentException("Invalid UUID string: " + name)
+    if (dash4 < 0 || dash5 >= 0) invalidUUIDError(input)
 
-    val section1 = checkExtraBits(section = parseSection(name, 0, dash1), zeroMask = mask8Z)
-    val section2 = checkExtraBits(section = parseSection(name, dash1 + 1, dash2), zeroMask = mask4Z)
-    val section3 = checkExtraBits(section = parseSection(name, dash2 + 1, dash3), zeroMask = mask4Z)
-    val section4 = checkExtraBits(section = parseSection(name, dash3 + 1, dash4), zeroMask = mask4Z)
-    val section5 = checkExtraBits(section = parseSection(name, dash4 + 1, len), zeroMask = mask12Z)
-
-    var mostSigBits = section1
-    mostSigBits <<= 16
-    mostSigBits |= section2
-    mostSigBits <<= 16
-    mostSigBits |= section3
-
-    var leastSigBits = section4
-    leastSigBits <<= 48
-    leastSigBits |= section5
-
-    new java.util.UUID(mostSigBits, leastSigBits)
+    val ch2n     = CharToNumeric
+    val section1 = parseSection(ch2n, input, 0, dash1, 0xfffffff00000000L)
+    val section2 = parseSection(ch2n, input, dash1 + 1, dash2, 0xfffffffffff0000L)
+    val section3 = parseSection(ch2n, input, dash2 + 1, dash3, 0xfffffffffff0000L)
+    val section4 = parseSection(ch2n, input, dash3 + 1, dash4, 0xfffffffffff0000L)
+    val section5 = parseSection(ch2n, input, dash4 + 1, len, 0xfff000000000000L)
+    new java.util.UUID((section1 << 32) | (section2 << 16) | section3, (section4 << 48) | section5)
   }
 
-  // Adapted from java.lang.Long.parseLong with multiple optimizations from @plokhotnyuk
   @nowarn("msg=implicit numeric widening")
-  private def parseSection(s: CharSequence, beginIndex: Int, endIndex: Int): Long = {
-    if ((endIndex - beginIndex) > 15) throw new NumberFormatException("UUID group exceeds acceptable length")
-
-    var i     = beginIndex
-    val limit = -Long.MaxValue
-
-    if (i < endIndex) {
-      val multmin = limit >> 4 // equivalent to dividing by 16 (Radix)
-      var result  = 0L
-      while (i < endIndex) {
-        val digit = CharToNumeric(s.charAt(i))
-        if (digit < 0 || result < multmin) throw charSequenceError(s, beginIndex, endIndex, i)
-        result <<= 4 // equivalent to multiplying by 16 (Radix)
-        i += 1
-        result -= digit
-      }
-      -result
-    } else throw new NumberFormatException("Invalid start and end indices when parsing UUID group")
-  }
-
-  // Checks whether the user has tried to supply more Hex digits than what the UUID section expects
-  // Use with maskXZ variants
-  private def checkExtraBits(section: Long, zeroMask: Long): Long =
-    if ((section & zeroMask) > 0)
-      throw new NumberFormatException(s"Extra bits detected in section: 0x${section.toHexString}")
-    else section
-
-  private def charSequenceError(
-    s: CharSequence,
+  private[this] def parseSection(
+    ch2n: Array[Byte],
+    input: String,
     beginIndex: Int,
     endIndex: Int,
-    errorIndex: Int
-  ): NumberFormatException =
-    new NumberFormatException(
-      s"""Invalid UUID format: Error at index ${errorIndex - beginIndex} in: "${s.subSequence(
-        beginIndex,
-        endIndex
-      )}""""
-    )
+    zeroMask: Long
+  ): Long = {
+    if (beginIndex >= endIndex || beginIndex + 16 < endIndex) invalidUUIDError(input)
+    var result = 0L
+    var i      = beginIndex
+    while (i < endIndex) {
+      result = (result << 4) | ch2n(input.charAt(i))
+      i += 1
+    }
+    if ((result & zeroMask) != 0) invalidUUIDError(input)
+    result
+  }
+
+  private[this] def invalidUUIDError(input: String): IllegalArgumentException =
+    throw new IllegalArgumentException(input)
 }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -156,11 +156,27 @@ object DecoderSpec extends DefaultRunnableSpec {
           assert(jsonStr.fromJson[Chunk[String]])(isRight(equalTo(expected)))
         },
         test("java.util.UUID") {
-          val ok  = """"64d7c38d-2afd-4004-9832-4e700fe400f8""""
-          val bad = """"""""
+          val ok1  = """"64d7c38d-2afd-4514-9832-4e70afe4b0f8""""
+          val ok2  = """"0000000064D7C38D-FD-14-32-70AFE4B0f8""""
+          val ok3  = """"0-0-0-0-0""""
+          val bad1 = """"""""
+          val bad2 = """"64d7c38d-2afd-4514-9832-4e70afe4b0f80""""
+          val bad3 = """"64d7c38d-2afd-4514-983-4e70afe4b0f80""""
+          val bad4 = """"64d7c38d-2afd--9832-4e70afe4b0f8""""
+          val bad5 = """"64d7c38d-2afd-XXXX-9832-4e70afe4b0f8""""
+          val bad6 = """"64d7c38d-2afd-X-9832-4e70afe4b0f8""""
+          val bad7 = """"0-0-0-0-00000000000000000""""
 
-          assert(ok.fromJson[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4004-9832-4e700fe400f8")))) &&
-          assert(bad.fromJson[UUID])(isLeft(containsString("Invalid UUID")))
+          assert(ok1.fromJson[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4514-9832-4e70afe4b0f8")))) &&
+          assert(ok2.fromJson[UUID])(isRight(equalTo(UUID.fromString("64D7C38D-00FD-0014-0032-0070AfE4B0f8")))) &&
+          assert(ok3.fromJson[UUID])(isRight(equalTo(UUID.fromString("00000000-0000-0000-0000-000000000000")))) &&
+          assert(bad1.fromJson[UUID])(isLeft(containsString("Invalid UUID: "))) &&
+          assert(bad2.fromJson[UUID])(isLeft(containsString("Invalid UUID: UUID string too large"))) &&
+          assert(bad3.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-983-4e70afe4b0f80"))) &&
+          assert(bad4.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd--9832-4e70afe4b0f8"))) &&
+          assert(bad5.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-XXXX-9832-4e70afe4b0f8"))) &&
+          assert(bad6.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-X-9832-4e70afe4b0f8"))) &&
+          assert(bad7.fromJson[UUID])(isLeft(containsString("Invalid UUID: 0-0-0-0-00000000000000000")))
         }
       ),
       suite("fromJsonAST")(
@@ -293,11 +309,27 @@ object DecoderSpec extends DefaultRunnableSpec {
           assert(json.as[Chunk[String]])(isRight(equalTo(expected)))
         },
         test("java.util.UUID") {
-          val ok  = Json.Str("64d7c38d-2afd-4004-9832-4e700fe400f8")
-          val bad = Json.Str("")
+          val ok1  = Json.Str("64d7c38d-2afd-4514-9832-4e70afe4b0f8")
+          val ok2  = Json.Str("0000000064D7C38D-FD-14-32-70AFE4B0f8")
+          val ok3  = Json.Str("0-0-0-0-0")
+          val bad1 = Json.Str("")
+          val bad2 = Json.Str("64d7c38d-2afd-4514-9832-4e70afe4b0f80")
+          val bad3 = Json.Str("64d7c38d-2afd-4514-983-4e70afe4b0f80")
+          val bad4 = Json.Str("64d7c38d-2afd--9832-4e70afe4b0f8")
+          val bad5 = Json.Str("64d7c38d-2afd-XXXX-9832-4e70afe4b0f8")
+          val bad6 = Json.Str("64d7c38d-2afd-X-9832-4e70afe4b0f8")
+          val bad7 = Json.Str("0-0-0-0-00000000000000000")
 
-          assert(ok.as[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4004-9832-4e700fe400f8")))) &&
-          assert(bad.as[UUID])(isLeft(containsString("Invalid UUID")))
+          assert(ok1.as[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4514-9832-4e70afe4b0f8")))) &&
+          assert(ok2.as[UUID])(isRight(equalTo(UUID.fromString("64D7C38D-00FD-0014-0032-0070AFE4B0f8")))) &&
+          assert(ok3.as[UUID])(isRight(equalTo(UUID.fromString("00000000-0000-0000-0000-000000000000")))) &&
+          assert(bad1.as[UUID])(isLeft(containsString("Invalid UUID: "))) &&
+          assert(bad2.as[UUID])(isLeft(containsString("Invalid UUID: UUID string too large"))) &&
+          assert(bad3.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-983-4e70afe4b0f80"))) &&
+          assert(bad4.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd--9832-4e70afe4b0f8"))) &&
+          assert(bad5.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-XXXX-9832-4e70afe4b0f8"))) &&
+          assert(bad6.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-X-9832-4e70afe4b0f8"))) &&
+          assert(bad7.as[UUID])(isLeft(containsString("Invalid UUID: 0-0-0-0-00000000000000000")))
         }
       )
     )


### PR DESCRIPTION
Below are results from my notebook:

## Before
#### Corretto 8
```
[info] Benchmark                         Mode  Cnt     Score     Error  Units
[info] UUIDBenchmarks.parseCustom       thrpt    5  1321.498 ± 142.803  ops/s
[info] UUIDBenchmarks.parseInBuiltUUID  thrpt    5   168.488 ±  26.467  ops/s
```
#### Corretto 11
```
[info] Benchmark                         Mode  Cnt     Score     Error  Units
[info] UUIDBenchmarks.parseCustom       thrpt    5  1390.546 ± 417.842  ops/s
[info] UUIDBenchmarks.parseInBuiltUUID  thrpt    5   885.639 ± 259.510  ops/s
```
#### OpenJDK 17
```
[info] Benchmark                         Mode  Cnt     Score     Error  Units
[info] UUIDBenchmarks.parseCustom       thrpt    5  1175.354 ± 234.159  ops/s
[info] UUIDBenchmarks.parseInBuiltUUID  thrpt    5  1167.585 ± 140.550  ops/s
```

## After
#### Corretto 8
```
[info] Benchmark                         Mode  Cnt     Score     Error  Units
[info] UUIDBenchmarks.parseCustom       thrpt    5  1446.843 ± 194.977  ops/s
[info] UUIDBenchmarks.parseInBuiltUUID  thrpt    5   170.562 ±  22.708  ops/s
```
#### Corretto 11
```
[info] Benchmark                         Mode  Cnt     Score     Error  Units
[info] UUIDBenchmarks.parseCustom       thrpt    5  1579.872 ± 379.859  ops/s
[info] UUIDBenchmarks.parseInBuiltUUID  thrpt    5   928.248 ± 156.684  ops/s
```
#### OpenJDK 17
```
[info] Benchmark                         Mode  Cnt     Score     Error  Units
[info] UUIDBenchmarks.parseCustom       thrpt    5  1318.247 ± 164.934  ops/s
[info] UUIDBenchmarks.parseInBuiltUUID  thrpt    5  1073.430 ± 155.882  ops/s
```