### PR TITLE
More backwards-compatible Scala 3 syntax changes

### DIFF
--- a/zio-json/jvm/src/main/scala/zio/json/JsonDecoderPlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/JsonDecoderPlatformSpecific.scala
@@ -123,7 +123,7 @@ trait JsonDecoderPlatformSpecific[A] { self: JsonDecoder[A] =>
                       }
                       .interruptible
                       .forkManaged
-        push = { is: Option[Chunk[Char]] =>
+        push = { (is: Option[Chunk[Char]]) =>
           val pollElements: IO[Throwable, Chunk[A]] =
             outQueue
               .takeUpTo(ZStream.DefaultChunkSize)

--- a/zio-json/jvm/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
@@ -43,7 +43,7 @@ trait JsonEncoderPlatformSpecific[A] { self: JsonEncoder[A] =>
                     }
                   }
         writeWriter <- ZManaged.succeed(new WriteWriter(writer))
-        push = { is: Option[Chunk[A]] =>
+        push = { (is: Option[Chunk[A]]) =>
           val pushChars = chunkBuffer.getAndUpdate(c => if (c.isEmpty) c else Chunk())
 
           is match {

--- a/zio-json/jvm/src/test/scala/zio/json/data/GeoJSON.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/data/GeoJSON.scala
@@ -195,7 +195,7 @@ package handrolled {
                   case 0 =>
                     if (subtype != -1)
                       throw UnsafeJson(JsonError.Message("duplicate") :: trace_)
-                    subtype = Lexer.enum(trace_, in, subtypes)
+                    subtype = Lexer.enumeration(trace_, in, subtypes)
                   case 1 =>
                     if (coordinates != null)
                       throw UnsafeJson(JsonError.Message("duplicate") :: trace_)
@@ -302,7 +302,7 @@ package handrolled {
                     if (subtype != -1)
                       throw UnsafeJson(JsonError.Message("duplicate") :: trace_)
 
-                    subtype = Lexer.enum(trace_, in, subtypes)
+                    subtype = Lexer.enumeration(trace_, in, subtypes)
                   case 1 =>
                     if (properties != null)
                       throw UnsafeJson(JsonError.Message("duplicate") :: trace_)

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -261,7 +261,7 @@ object DeriveJsonDecoder {
           if (Lexer.firstField(trace, in_))
             do {
               if (Lexer.field(trace, in_, hintmatrix) != -1) {
-                val field = Lexer.enum(trace, in_, matrix)
+                val field = Lexer.enumeration(trace, in_, matrix)
                 if (field == -1)
                   throw UnsafeJson(
                     JsonError.Message(s"invalid disambiguator") :: trace

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -80,7 +80,7 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
     try Right(unsafeDecode(Nil, new FastStringReader(str)))
     catch {
       case JsonDecoder.UnsafeJson(trace) => Left(JsonError.render(trace))
-      case _: internal.UnexpectedEnd     => Left("Unexpected end of input")
+      case _: UnexpectedEnd              => Left("Unexpected end of input")
       case _: StackOverflowError         => Left("Unexpected structure")
     }
 
@@ -117,7 +117,7 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
             in2.rewind()
             that.unsafeDecode(trace, in2)
 
-          case _: internal.UnexpectedEnd =>
+          case _: UnexpectedEnd =>
             in2.rewind()
             that.unsafeDecode(trace, in2)
         }
@@ -313,7 +313,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority0 {
               try Right(f(List.empty, reader))
               catch {
                 case JsonDecoder.UnsafeJson(trace) => Left(JsonError.render(trace))
-                case _: internal.UnexpectedEnd     => Left("Unexpected end of input")
+                case _: UnexpectedEnd              => Left("Unexpected end of input")
                 case _: StackOverflowError         => Left("Unexpected structure")
               } finally reader.close()
             result

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -65,12 +65,12 @@ object Lexer {
     in: OneCharReader,
     matrix: StringMatrix
   ): Int = {
-    val f = enum(trace, in, matrix)
+    val f = enumeration(trace, in, matrix)
     char(trace, in, ':')
     f
   }
 
-  def enum(
+  def enumeration(
     trace: List[JsonError],
     in: OneCharReader,
     matrix: StringMatrix


### PR DESCRIPTION
- parens around fns
- `enum` is reserved
- `internal` is being shadowed by `scala.internal`