### PR TITLE
More efficient serialization

### DIFF
--- a/zio-json/jvm/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -239,8 +239,8 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           val utc = ZonedDateTime.of(ld, ZoneId.of("Etc/UTC"))
 
           zdtAssert(n.toString, n) &&
-          zdtAssert("2020-01-01T12:36-05:00[America/New_York]", est) &&
-          zdtAssert("2020-01-01T12:36Z[Etc/UTC]", utc) &&
+          zdtAssert("2020-01-01T12:36:00-05:00[America/New_York]", est) &&
+          zdtAssert("2020-01-01T12:36:00Z[Etc/UTC]", utc) &&
           zdtAssert(
             "2018-02-01T00:00Z",
             ZonedDateTime.of(LocalDateTime.of(2018, 2, 1, 0, 0, 0), ZoneOffset.UTC)

--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -3,9 +3,8 @@ package zio.json
 import zio.Chunk
 import zio.json.ast.Json
 import zio.json.internal.{ FastStringWrite, Write }
+import zio.json.javatime.serializers
 
-import java.time.format.{ DateTimeFormatterBuilder, SignStyle }
-import java.time.temporal.ChronoField.{ MONTH_OF_YEAR, YEAR }
 import java.util.UUID
 import scala.annotation._
 import scala.collection.{ immutable, mutable }
@@ -149,7 +148,11 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
   }
 
   private[json] def stringify[A](f: A => String): JsonEncoder[A] = new JsonEncoder[A] {
-    def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write(s""""${f(a)}"""")
+    def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = {
+      out.write('"')
+      out.write(f(a))
+      out.write('"')
+    }
 
     override final def toJsonAST(a: A): Either[String, Json] =
       Right(Json.Str(f(a)))
@@ -198,7 +201,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
   }
 
   def pad(indent: Option[Int], out: Write): Unit =
-    indent.foreach(i => out.write("\n" + (" " * 2 * i)))
+    indent.foreach(i => out.write("\n" + ("  " * i)))
 
   implicit def either[A, B](implicit A: JsonEncoder[A], B: JsonEncoder[B]): JsonEncoder[Either[A, B]] =
     new JsonEncoder[Either[A, B]] {
@@ -368,50 +371,23 @@ private[json] trait EncoderLowPriority3 {
   this: JsonEncoder.type =>
 
   import java.time._
-  import java.time.format.DateTimeFormatter
 
-  implicit val dayOfWeek: JsonEncoder[DayOfWeek] = stringify(_.toString)
-  implicit val duration: JsonEncoder[Duration]   = stringify(_.toString)
-  implicit val instant: JsonEncoder[Instant]     = stringify(_.toString)
-
-  implicit val localDate: JsonEncoder[LocalDate] = stringify(
-    _.format(DateTimeFormatter.ISO_LOCAL_DATE)
-  )
-
-  implicit val localDateTime: JsonEncoder[LocalDateTime] = stringify(
-    _.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-  )
-
-  implicit val localTime: JsonEncoder[LocalTime] = stringify(
-    _.format(DateTimeFormatter.ISO_LOCAL_TIME)
-  )
-  implicit val month: JsonEncoder[Month]       = stringify(_.toString)
-  implicit val monthDay: JsonEncoder[MonthDay] = stringify(_.toString)
-
-  implicit val offsetDateTime: JsonEncoder[OffsetDateTime] = stringify(
-    _.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-  )
-
-  implicit val offsetTime: JsonEncoder[OffsetTime] = stringify(
-    _.format(DateTimeFormatter.ISO_OFFSET_TIME)
-  )
-  implicit val period: JsonEncoder[Period] = stringify(_.toString)
-
-  private val yearFormatter =
-    new DateTimeFormatterBuilder().appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD).toFormatter
-  implicit val year: JsonEncoder[Year] = stringify(_.format(yearFormatter))
-  private[this] val yearMonthFormatter = new DateTimeFormatterBuilder()
-    .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
-    .appendLiteral('-')
-    .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NEVER)
-    .toFormatter
-  implicit val yearMonth: JsonEncoder[YearMonth] = stringify(_.format(yearMonthFormatter))
-
-  implicit val zonedDateTime: JsonEncoder[ZonedDateTime] = stringify(
-    _.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
-  )
-  implicit val zoneId: JsonEncoder[ZoneId]         = stringify(_.toString)
-  implicit val zoneOffset: JsonEncoder[ZoneOffset] = stringify(_.toString)
+  implicit val dayOfWeek: JsonEncoder[DayOfWeek]           = stringify(_.toString)
+  implicit val duration: JsonEncoder[Duration]             = stringify(serializers.toString)
+  implicit val instant: JsonEncoder[Instant]               = stringify(serializers.toString)
+  implicit val localDate: JsonEncoder[LocalDate]           = stringify(serializers.toString)
+  implicit val localDateTime: JsonEncoder[LocalDateTime]   = stringify(serializers.toString)
+  implicit val localTime: JsonEncoder[LocalTime]           = stringify(serializers.toString)
+  implicit val month: JsonEncoder[Month]                   = stringify(_.toString)
+  implicit val monthDay: JsonEncoder[MonthDay]             = stringify(serializers.toString)
+  implicit val offsetDateTime: JsonEncoder[OffsetDateTime] = stringify(serializers.toString)
+  implicit val offsetTime: JsonEncoder[OffsetTime]         = stringify(serializers.toString)
+  implicit val period: JsonEncoder[Period]                 = stringify(serializers.toString)
+  implicit val year: JsonEncoder[Year]                     = stringify(serializers.toString)
+  implicit val yearMonth: JsonEncoder[YearMonth]           = stringify(serializers.toString)
+  implicit val zonedDateTime: JsonEncoder[ZonedDateTime]   = stringify(serializers.toString)
+  implicit val zoneId: JsonEncoder[ZoneId]                 = stringify(serializers.toString)
+  implicit val zoneOffset: JsonEncoder[ZoneOffset]         = stringify(serializers.toString)
 
   implicit val uuid: JsonEncoder[UUID] = stringify(_.toString)
 }

--- a/zio-json/shared/src/main/scala/zio/json/javatime/serializers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/serializers.scala
@@ -1,0 +1,278 @@
+package zio.json.javatime
+
+import java.time._
+
+private[json] object serializers {
+  def toString(x: Duration): String = {
+    val s = new java.lang.StringBuilder(16)
+    s.append('P').append('T')
+    val totalSecs = x.getSeconds
+    var nano      = x.getNano
+    if ((totalSecs | nano) == 0) s.append('0').append('S')
+    else {
+      var effectiveTotalSecs = totalSecs
+      if (totalSecs < 0 && nano > 0) effectiveTotalSecs += 1
+      val hours      = effectiveTotalSecs / 3600 // 3600 == seconds in a hour
+      val secsOfHour = (effectiveTotalSecs - hours * 3600).toInt
+      val minutes    = secsOfHour / 60
+      val seconds    = secsOfHour - minutes * 60
+      if (hours != 0) s.append(hours).append('H')
+      if (minutes != 0) s.append(minutes).append('M')
+      if ((seconds | nano) != 0) {
+        if (totalSecs < 0 && seconds == 0) s.append('-').append('0')
+        else s.append(seconds)
+        if (nano != 0) {
+          if (totalSecs < 0) nano = 1000000000 - nano
+          val dotPos = s.length
+          s.append(nano + 1000000000)
+          var i = s.length - 1
+          while (s.charAt(i) == '0') i -= 1
+          s.setLength(i + 1)
+          s.setCharAt(dotPos, '.')
+        }
+        s.append('S')
+      }
+    }
+    s.toString
+  }
+
+  def toString(x: Instant): String = {
+    val s           = new java.lang.StringBuilder(32)
+    val epochSecond = x.getEpochSecond
+    val epochDay =
+      (if (epochSecond >= 0) epochSecond
+       else epochSecond - 86399) / 86400 // 86400 == seconds per day
+    val secsOfDay    = (epochSecond - epochDay * 86400).toInt
+    var marchZeroDay = epochDay + 719468 // 719468 == 719528 - 60 == days 0000 to 1970 - days 1st Jan to 1st Mar
+    var adjustYear   = 0
+    if (marchZeroDay < 0) { // adjust negative years to positive for calculation
+      val adjust400YearCycles = to400YearCycle(marchZeroDay + 1) - 1
+      adjustYear = adjust400YearCycles * 400
+      marchZeroDay -= adjust400YearCycles * 146097L
+    }
+    var year           = to400YearCycle(marchZeroDay * 400 + 591)
+    var marchDayOfYear = toMarchDayOfYear(marchZeroDay, year)
+    if (marchDayOfYear < 0) { // fix year estimate
+      year -= 1
+      marchDayOfYear = toMarchDayOfYear(marchZeroDay, year)
+    }
+    val marchMonth = (marchDayOfYear * 17135 + 6854) >> 19 // (marchDayOfYear * 5 + 2) / 153
+    year += (marchMonth * 3277 >> 15) + adjustYear // year += marchMonth / 10 + adjustYear (reset any negative year and convert march-based values back to january-based)
+    val month = marchMonth +
+      (if (marchMonth < 10) 3
+       else -9)
+    val day =
+      marchDayOfYear - ((marchMonth * 1002762 - 16383) >> 15) // marchDayOfYear - (marchMonth * 306 + 5) / 10 + 1
+    val hour       = secsOfDay * 37283 >>> 27 // divide a small positive int by 3600
+    val secsOfHour = secsOfDay - hour * 3600
+    val minute     = secsOfHour * 17477 >> 20 // divide a small positive int by 60
+    val second     = secsOfHour - minute * 60
+    appendYear(year, s)
+    s.append('-')
+    append2Digits(month, s)
+    s.append('-')
+    append2Digits(day, s)
+    s.append('T')
+    append2Digits(hour, s)
+    s.append(':')
+    append2Digits(minute, s)
+    s.append(':')
+    append2Digits(second, s)
+    val nano = x.getNano
+    if (nano != 0) {
+      s.append('.')
+      val q1 = nano / 1000000
+      val r1 = nano - q1 * 1000000
+      append3Digits(q1, s)
+      if (r1 != 0) {
+        val q2 = r1 / 1000
+        val r2 = r1 - q2 * 1000
+        append3Digits(q2, s)
+        if (r2 != 0) append3Digits(r2, s)
+      }
+    }
+    s.append('Z')
+    s.toString
+  }
+
+  def toString(x: LocalDate): String = {
+    val s = new java.lang.StringBuilder(16)
+    appendLocalDate(x, s)
+    s.toString
+  }
+
+  def toString(x: LocalDateTime): String = {
+    val s = new java.lang.StringBuilder(32)
+    appendLocalDate(x.toLocalDate, s)
+    s.append('T')
+    appendLocalTime(x.toLocalTime, s)
+    s.toString
+  }
+
+  def toString(x: LocalTime): String = {
+    val s = new java.lang.StringBuilder(24)
+    appendLocalTime(x, s)
+    s.toString
+  }
+
+  def toString(x: MonthDay): String = {
+    val s = new java.lang.StringBuilder(8)
+    s.append('-')
+    s.append('-')
+    append2Digits(x.getMonthValue, s)
+    s.append('-')
+    append2Digits(x.getDayOfMonth, s)
+    s.toString
+  }
+
+  def toString(x: OffsetDateTime): String = {
+    val s = new java.lang.StringBuilder(48)
+    appendLocalDate(x.toLocalDate, s)
+    s.append('T')
+    appendLocalTime(x.toLocalTime, s)
+    appendZoneOffset(x.getOffset, s)
+    s.toString
+  }
+
+  def toString(x: OffsetTime): String = {
+    val s = new java.lang.StringBuilder(32)
+    appendLocalTime(x.toLocalTime, s)
+    appendZoneOffset(x.getOffset, s)
+    s.toString
+  }
+
+  def toString(x: Period): String = {
+    val s = new java.lang.StringBuilder(16)
+    s.append('P')
+    if (x.isZero) s.append('0').append('D')
+    else {
+      val years  = x.getYears
+      val months = x.getMonths
+      val days   = x.getDays
+      if (years != 0) s.append(years).append('Y')
+      if (months != 0) s.append(months).append('M')
+      if (days != 0) s.append(days).append('D')
+    }
+    s.toString
+  }
+
+  def toString(x: Year): String = {
+    val s = new java.lang.StringBuilder(16)
+    appendYear(x.getValue, s)
+    s.toString
+  }
+
+  def toString(x: YearMonth): String = {
+    val s = new java.lang.StringBuilder(16)
+    appendYear(x.getYear, s)
+    s.append('-')
+    append2Digits(x.getMonthValue, s)
+    s.toString
+  }
+
+  def toString(x: ZonedDateTime): String = {
+    val s = new java.lang.StringBuilder(48)
+    appendLocalDate(x.toLocalDate, s)
+    s.append('T')
+    appendLocalTime(x.toLocalTime, s)
+    appendZoneOffset(x.getOffset, s)
+    val zone = x.getZone
+    if (!zone.isInstanceOf[ZoneOffset]) {
+      s.append('[')
+      s.append(zone.getId)
+      s.append(']')
+    }
+    s.toString
+  }
+
+  def toString(x: ZoneId): String = x.getId
+
+  def toString(x: ZoneOffset): String = {
+    val s = new java.lang.StringBuilder(16)
+    appendZoneOffset(x, s)
+    s.toString
+  }
+
+  private[this] def appendLocalDate(x: LocalDate, s: java.lang.StringBuilder): Unit = {
+    appendYear(x.getYear, s)
+    s.append('-')
+    append2Digits(x.getMonthValue, s)
+    s.append('-')
+    append2Digits(x.getDayOfMonth, s)
+  }
+
+  private[this] def appendLocalTime(x: LocalTime, s: java.lang.StringBuilder): Unit = {
+    append2Digits(x.getHour, s)
+    s.append(':')
+    append2Digits(x.getMinute, s)
+    s.append(':')
+    append2Digits(x.getSecond, s)
+    val nano = x.getNano
+    if (nano != 0) {
+      val dotPos = s.length
+      s.append(nano + 1000000000)
+      var i = s.length - 1
+      while (s.charAt(i) == '0') i -= 1
+      s.setLength(i + 1)
+      s.setCharAt(dotPos, '.')
+    }
+  }
+
+  private[this] def appendZoneOffset(x: ZoneOffset, s: java.lang.StringBuilder): Unit = {
+    val totalSeconds = x.getTotalSeconds
+    if (totalSeconds == 0) s.append('Z'): Unit
+    else {
+      val q0 =
+        if (totalSeconds > 0) {
+          s.append('+')
+          totalSeconds
+        } else {
+          s.append('-')
+          -totalSeconds
+        }
+      val q1 = q0 * 37283 >>> 27 // divide a small positive int by 3600
+      val r1 = q0 - q1 * 3600
+      append2Digits(q1, s)
+      s.append(':')
+      val q2 = r1 * 17477 >> 20 // divide a small positive int by 60
+      val r2 = r1 - q2 * 60
+      append2Digits(q2, s)
+      if (r2 != 0) {
+        s.append(':')
+        append2Digits(r2, s)
+      }
+    }
+  }
+
+  private[this] def appendYear(x: Int, s: java.lang.StringBuilder): Unit =
+    if (x >= 0) {
+      if (x < 10000) append4Digits(x, s)
+      else s.append('+').append(x): Unit
+    } else if (x > -10000) {
+      s.append('-')
+      append4Digits(-x, s)
+    } else s.append(x): Unit
+
+  private[this] def append4Digits(x: Int, s: java.lang.StringBuilder): Unit =
+    if (x > 999) s.append(x): Unit
+    else if (x > 99) s.append('0').append(x): Unit
+    else if (x > 9) s.append('0').append('0').append(x): Unit
+    else s.append('0').append('0').append('0').append(x): Unit
+
+  private[this] def append3Digits(x: Int, s: java.lang.StringBuilder): Unit =
+    if (x > 99) s.append(x): Unit
+    else if (x > 9) s.append('0').append(x): Unit
+    else s.append('0').append('0').append(x): Unit
+
+  private[this] def append2Digits(x: Int, s: java.lang.StringBuilder): Unit =
+    if (x > 9) s.append(x): Unit
+    else s.append('0').append(x): Unit
+
+  private[this] def to400YearCycle(day: Long): Int =
+    (day / 146097).toInt // 146097 == number of days in a 400 year cycle
+
+  private[this] def toMarchDayOfYear(marchZeroDay: Long, year: Int): Int = {
+    val century = year / 100
+    (marchZeroDay - year * 365L).toInt - (year >> 2) + century - (century >> 2)
+  }
+}


### PR DESCRIPTION
Tested with [benchmarks from jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala/tree/master/jsoniter-scala-benchmark/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/benchmark):
## Before
```
[info] Benchmark                              (size)   Mode  Cnt         Score         Error  Units
[info] ADTWriting.zioJson                        N/A  thrpt    5    641749.429 ±   88832.341  ops/s
[info] AnyValsWriting.zioJson                    N/A  thrpt    5   1031663.091 ±  145986.261  ops/s
[info] ArrayOfBigDecimalsWriting.zioJson         128  thrpt    5     30140.787 ±    2272.644  ops/s
[info] ArrayOfBooleansWriting.zioJson            128  thrpt    5    162974.091 ±    7179.442  ops/s
[info] ArrayOfBytesWriting.zioJson               128  thrpt    5    146065.652 ±    5870.836  ops/s
[info] ArrayOfCharsWriting.zioJson               128  thrpt    5    143890.142 ±   13784.246  ops/s
[info] ArrayOfDoublesWriting.zioJson             128  thrpt    5     21607.773 ±    2188.168  ops/s
[info] ArrayOfDurationsWriting.zioJson           128  thrpt    5     41444.486 ±    2340.390  ops/s
[info] ArrayOfEnumADTsWriting.zioJson            128  thrpt    5    156212.569 ±   10641.182  ops/s
[info] ArrayOfEnumsWriting.zioJson               128  thrpt    5    164588.286 ±   22627.431  ops/s
[info] ArrayOfFloatsWriting.zioJson              128  thrpt    5     27790.314 ±    1507.760  ops/s
[info] ArrayOfInstantsWriting.zioJson            128  thrpt    5     20328.500 ±    2572.701  ops/s
[info] ArrayOfIntsWriting.zioJson                128  thrpt    5    121953.829 ±   11540.071  ops/s
[info] ArrayOfLocalDateTimesWriting.zioJson      128  thrpt    5     16427.644 ±     472.592  ops/s
[info] ArrayOfLocalDatesWriting.zioJson          128  thrpt    5     39251.896 ±    1746.547  ops/s
[info] ArrayOfLocalTimesWriting.zioJson          128  thrpt    5     22663.124 ±    2113.489  ops/s
[info] ArrayOfLongsWriting.zioJson               128  thrpt    5    101057.751 ±   11766.818  ops/s
[info] ArrayOfMonthDaysWriting.zioJson           128  thrpt    5     63572.597 ±    9639.537  ops/s
[info] ArrayOfOffsetDateTimesWriting.zioJson     128  thrpt    5     13868.431 ±    1017.160  ops/s
[info] ArrayOfOffsetTimesWriting.zioJson         128  thrpt    5     19015.918 ±    2607.406  ops/s
[info] ArrayOfPeriodsWriting.zioJson             128  thrpt    5     48070.910 ±    1858.225  ops/s
[info] ArrayOfShortsWriting.zioJson              128  thrpt    5    135105.655 ±   18431.134  ops/s
[info] ArrayOfUUIDsWriting.zioJson               128  thrpt    5     76567.762 ±    1907.395  ops/s
[info] ArrayOfYearMonthsWriting.zioJson          128  thrpt    5     61848.245 ±   10354.246  ops/s
[info] ArrayOfYearsWriting.zioJson               128  thrpt    5     65877.071 ±    6068.364  ops/s
[info] ArrayOfZoneIdsWriting.zioJson             128  thrpt    5     77841.887 ±    9743.622  ops/s
[info] ArrayOfZoneOffsetsWriting.zioJson         128  thrpt    5     81202.306 ±    4202.381  ops/s
[info] ArrayOfZonedDateTimesWriting.zioJson      128  thrpt    5     10003.821 ±     509.567  ops/s
[info] GitHubActionsAPIWriting.zioJson           N/A  thrpt    5    147843.742 ±    9461.001  ops/s
[info] GoogleMapsAPIWriting.zioJson              N/A  thrpt    5      9585.303 ±     572.394  ops/s
[info] IntWriting.zioJson                        N/A  thrpt    5  13726066.699 ± 1011886.445  ops/s
[info] ListOfBooleansWriting.zioJson             128  thrpt    5    173801.731 ±   21102.226  ops/s
[info] MapOfIntsToBooleansWriting.zioJson        128  thrpt    5     94150.682 ±   13055.820  ops/s
[info] PrimitivesWriting.zioJson                 N/A  thrpt    5   1203535.575 ±   48032.497  ops/s
[info] SetOfIntsWriting.zioJson                  128  thrpt    5    133599.520 ±   18815.939  ops/s
[info] StringOfAsciiCharsWriting.zioJson         128  thrpt    5   2003530.978 ±  143320.040  ops/s
[info] StringOfNonAsciiCharsWriting.zioJson      128  thrpt    5    940226.340 ±   51051.933  ops/s
[info] VectorOfBooleansWriting.zioJson           128  thrpt    5    178050.561 ±    7745.431  ops/s
```
## After
```
[info] Benchmark                              (size)   Mode  Cnt         Score         Error  Units
[info] ADTWriting.zioJson                        N/A  thrpt    5    794063.816 ±   71355.851  ops/s
[info] AnyValsWriting.zioJson                    N/A  thrpt    5   1822539.801 ±  355303.150  ops/s
[info] ArrayOfBigDecimalsWriting.zioJson         128  thrpt    5     33176.333 ±    4974.099  ops/s
[info] ArrayOfBooleansWriting.zioJson            128  thrpt    5    364610.489 ±   52042.210  ops/s
[info] ArrayOfBytesWriting.zioJson               128  thrpt    5    283862.207 ±   31803.045  ops/s
[info] ArrayOfCharsWriting.zioJson               128  thrpt    5    334642.594 ±   32364.070  ops/s
[info] ArrayOfDoublesWriting.zioJson             128  thrpt    5     24550.339 ±     207.527  ops/s
[info] ArrayOfDurationsWriting.zioJson           128  thrpt    5     64909.196 ±    3721.206  ops/s
[info] ArrayOfEnumADTsWriting.zioJson            128  thrpt    5    284354.820 ±    7252.089  ops/s
[info] ArrayOfEnumsWriting.zioJson               128  thrpt    5    319465.727 ±   47603.770  ops/s
[info] ArrayOfFloatsWriting.zioJson              128  thrpt    5     31281.729 ±    2498.736  ops/s
[info] ArrayOfInstantsWriting.zioJson            128  thrpt    5     52551.877 ±    8490.347  ops/s
[info] ArrayOfIntsWriting.zioJson                128  thrpt    5    231111.556 ±   38445.103  ops/s
[info] ArrayOfLocalDateTimesWriting.zioJson      128  thrpt    5     59553.638 ±    5692.185  ops/s
[info] ArrayOfLocalDatesWriting.zioJson          128  thrpt    5    115962.453 ±   11029.803  ops/s
[info] ArrayOfLocalTimesWriting.zioJson          128  thrpt    5     77035.734 ±    9184.439  ops/s
[info] ArrayOfLongsWriting.zioJson               128  thrpt    5    167704.343 ±   12354.562  ops/s
[info] ArrayOfMonthDaysWriting.zioJson           128  thrpt    5    145364.784 ±   17393.121  ops/s
[info] ArrayOfOffsetDateTimesWriting.zioJson     128  thrpt    5     47718.824 ±    3724.216  ops/s
[info] ArrayOfOffsetTimesWriting.zioJson         128  thrpt    5     60411.754 ±   12193.580  ops/s
[info] ArrayOfPeriodsWriting.zioJson             128  thrpt    5     81185.611 ±    9573.331  ops/s
[info] ArrayOfShortsWriting.zioJson              128  thrpt    5    270601.219 ±   25152.439  ops/s
[info] ArrayOfUUIDsWriting.zioJson               128  thrpt    5    135243.597 ±    5791.667  ops/s
[info] ArrayOfYearMonthsWriting.zioJson          128  thrpt    5    123175.013 ±   13964.292  ops/s
[info] ArrayOfYearsWriting.zioJson               128  thrpt    5    209178.366 ±   15524.710  ops/s
[info] ArrayOfZoneIdsWriting.zioJson             128  thrpt    5    256878.985 ±    8145.431  ops/s
[info] ArrayOfZoneOffsetsWriting.zioJson         128  thrpt    5    134306.787 ±   26935.020  ops/s
[info] ArrayOfZonedDateTimesWriting.zioJson      128  thrpt    5     41747.556 ±    4105.078  ops/s
[info] GitHubActionsAPIWriting.zioJson           N/A  thrpt    5    215886.849 ±   33569.250  ops/s
[info] GoogleMapsAPIWriting.zioJson              N/A  thrpt    5     17599.913 ±    1956.074  ops/s
[info] IntWriting.zioJson                        N/A  thrpt    5  19288438.667 ± 1768454.679  ops/s
[info] ListOfBooleansWriting.zioJson             128  thrpt    5    380134.457 ±    6992.076  ops/s
[info] MapOfIntsToBooleansWriting.zioJson        128  thrpt    5    104329.690 ±    9455.023  ops/s
[info] PrimitivesWriting.zioJson                 N/A  thrpt    5   2207577.744 ±  106832.946  ops/s
[info] SetOfIntsWriting.zioJson                  128  thrpt    5    238557.981 ±   46868.697  ops/s
[info] StringOfAsciiCharsWriting.zioJson         128  thrpt    5   1794317.936 ±  261846.541  ops/s
[info] StringOfNonAsciiCharsWriting.zioJson      128  thrpt    5    801937.772 ±   59733.380  ops/s
[info] VectorOfBooleansWriting.zioJson           128  thrpt    5    393926.863 ±   31341.238  ops/s
```