### PR TITLE
Add decoder for java.time.Instant

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -630,7 +630,7 @@ private[json] trait DecoderLowPriority3 {
 
   implicit val dayOfWeek: JsonDecoder[DayOfWeek] = mapStringOrFail(s => parseJavaTime(DayOfWeek.valueOf, s.toUpperCase))
   implicit val duration: JsonDecoder[Duration]   = mapStringOrFail(parseJavaTime(parsers.unsafeParseDuration, _))
-  implicit val instant: JsonDecoder[Instant]     = mapStringOrFail(parseJavaTime(Instant.parse, _))
+  implicit val instant: JsonDecoder[Instant]     = mapStringOrFail(parseJavaTime(parsers.unsafeParseInstant, _))
   implicit val localDate: JsonDecoder[LocalDate] = mapStringOrFail(parseJavaTime(parsers.unsafeParseLocalDate, _))
 
   implicit val localDateTime: JsonDecoder[LocalDateTime] =

--- a/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
@@ -158,18 +158,20 @@ private[json] object parsers {
         while ({
           if (pos >= len) instantError(pos)
           ch = input.charAt(pos)
+          pos += 1
           ch >= '0' && ch <= '9' && yearDigits < 10
         }) {
           year =
             if (year > 100000000) 2147483647
             else year * 10 + (ch - '0')
           yearDigits += 1
-          pos += 1
         }
-        if (yearNeg && year == 0 || yearDigits == 10 && year > 1000000000) yearError(pos - 1)
-        if (ch != '-') yearError(yearNeg, yearDigits, pos)
-        pos += 1
-        if (yearNeg) year = -year
+        if (yearDigits == 10 && year > 1000000000) yearError(pos - 2)
+        if (yearNeg) {
+          if (year == 0) yearError(pos - 2)
+          year = -year
+        }
+        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
         year
       }
     }
@@ -261,8 +263,11 @@ private[json] object parsers {
     if (ch != 'Z') charError('Z', pos)
     if (pos != len) instantError(pos)
     val epochDay =
-      epochDayForYear(year) + (dayOfYearForYearMonth(year, month) + day - 719529)        // 719528 == days 0000 to 1970
-    Instant.ofEpochSecond(epochDay * 86400 + (hour * 3600 + minute * 60 + second), nano) // 86400 == seconds per day
+      epochDayForYear(year) + (dayOfYearForYearMonth(year, month) + day - 719529) // 719528 == days 0000 to 1970
+    Instant.ofEpochSecond(
+      epochDay * 86400 + (hour * 3600 + minute * 60 + second),
+      nano.toLong
+    ) // 86400 == seconds per day
   }
 
   def unsafeParseLocalDate(input: String): LocalDate = {
@@ -295,16 +300,17 @@ private[json] object parsers {
         while ({
           if (pos >= len) localDateError(pos)
           ch = input.charAt(pos)
+          pos += 1
           ch >= '0' && ch <= '9' && yearDigits < 9
         }) {
           year = year * 10 + (ch - '0')
           yearDigits += 1
-          pos += 1
         }
-        if (yearNeg && year == 0 || yearDigits == 10) yearError(pos - 1)
-        if (ch != '-') yearError(yearNeg, yearDigits, pos)
-        pos += 1
-        if (yearNeg) year = -year
+        if (yearNeg) {
+          if (year == 0) yearError(pos - 2)
+          year = -year
+        }
+        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
         year
       }
     }
@@ -366,16 +372,17 @@ private[json] object parsers {
         while ({
           if (pos >= len) localDateTimeError(pos)
           ch = input.charAt(pos)
+          pos += 1
           ch >= '0' && ch <= '9' && yearDigits < 9
         }) {
           year = year * 10 + (ch - '0')
           yearDigits += 1
-          pos += 1
         }
-        if (yearNeg && year == 0) yearError(pos - 1)
-        if (ch != '-') yearError(yearNeg, yearDigits, pos)
-        pos += 1
-        if (yearNeg) year = -year
+        if (yearNeg) {
+          if (year == 0) yearError(pos - 2)
+          year = -year
+        }
+        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
         year
       }
     }
@@ -585,16 +592,17 @@ private[json] object parsers {
         while ({
           if (pos >= len) offsetDateTimeError(pos)
           ch = input.charAt(pos)
+          pos += 1
           ch >= '0' && ch <= '9' && yearDigits < 9
         }) {
           year = year * 10 + (ch - '0')
           yearDigits += 1
-          pos += 1
         }
-        if (yearNeg && year == 0) yearError(pos - 1)
-        if (ch != '-') yearError(yearNeg, yearDigits, pos)
-        pos += 1
-        if (yearNeg) year = -year
+        if (yearNeg) {
+          if (year == 0) yearError(pos - 2)
+          year = -year
+        }
+        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
         year
       }
     }
@@ -893,9 +901,10 @@ private[json] object parsers {
           year = year * 10 + (ch - '0')
           yearDigits += 1
         }
-        if (yearNeg && year == 0) yearError(pos)
-        if (!yearNeg && yearDigits == 4) digitError(pos)
-        if (yearNeg) year = -year
+        if (yearNeg) {
+          if (year == 0) yearError(pos - 1)
+          year = -year
+        }
         year
       }
     }
@@ -933,16 +942,17 @@ private[json] object parsers {
         while ({
           if (pos >= len) yearMonthError(pos)
           ch = input.charAt(pos)
+          pos += 1
           ch >= '0' && ch <= '9' && yearDigits < 9
         }) {
           year = year * 10 + (ch - '0')
           yearDigits += 1
-          pos += 1
         }
-        if (yearNeg && year == 0) yearError(pos - 1)
-        if (ch != '-') yearError(yearNeg, yearDigits, pos)
-        pos += 1
-        if (yearNeg) year = -year
+        if (yearNeg) {
+          if (year == 0) yearError(pos - 2)
+          year = -year
+        }
+        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
         year
       }
     }
@@ -991,16 +1001,17 @@ private[json] object parsers {
         while ({
           if (pos >= len) zonedDateTimeError(pos)
           ch = input.charAt(pos)
+          pos += 1
           ch >= '0' && ch <= '9' && yearDigits < 9
         }) {
           year = year * 10 + (ch - '0')
           yearDigits += 1
-          pos += 1
         }
-        if (yearNeg && year == 0) yearError(pos - 1)
-        if (ch != '-') yearError(yearNeg, yearDigits, pos)
-        pos += 1
-        if (yearNeg) year = -year
+        if (yearNeg) {
+          if (year == 0) yearError(pos - 2)
+          year = -year
+        }
+        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
         year
       }
     }
@@ -1316,7 +1327,7 @@ private[json] object parsers {
   private[this] def isLeap(year: Int): Boolean = (year & 0x3) == 0 && { // (year % 100 != 0 || year % 400 == 0)
     val cp = year * 1374389535L
     val cc = year >> 31
-    ((cp ^ cc) & 0x1FC0000000L) != 0 || (((cp >> 37).toInt - cc) & 0x3) == 0
+    ((cp ^ cc) & 0x1fc0000000L) != 0 || (((cp >> 37).toInt - cc) & 0x3) == 0
   }
 
   private[this] def nanoError(nanoDigitWeight: Int, ch: Char, pos: Int): Nothing = {

--- a/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
@@ -108,7 +108,7 @@ private[json] object parsers {
           }
         ) {
           nanos += (ch - '0') * nanoDigitWeight
-          nanoDigitWeight /= 10
+          nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
           pos += 1
         }
         if (ch != 'S') nanoError(nanoDigitWeight, 'S', pos)
@@ -253,7 +253,7 @@ private[json] object parsers {
             }
           ) {
             nano += (ch - '0') * nanoDigitWeight
-            nanoDigitWeight /= 10
+            nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
           }
         }
       }
@@ -458,7 +458,7 @@ private[json] object parsers {
             }
           ) {
             nano += (ch - '0') * nanoDigitWeight
-            nanoDigitWeight /= 10
+            nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
           }
         }
       }
@@ -523,7 +523,7 @@ private[json] object parsers {
             }
           ) {
             nano += (ch - '0') * nanoDigitWeight
-            nanoDigitWeight /= 10
+            nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
           }
         }
       }
@@ -676,7 +676,7 @@ private[json] object parsers {
           ch >= '0' && ch <= '9' && nanoDigitWeight != 0
         }) {
           nano += (ch - '0') * nanoDigitWeight
-          nanoDigitWeight /= 10
+          nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
         }
       }
     }
@@ -795,7 +795,7 @@ private[json] object parsers {
           ch >= '0' && ch <= '9' && nanoDigitWeight != 0
         }) {
           nano += (ch - '0') * nanoDigitWeight
-          nanoDigitWeight /= 10
+          nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
         }
       }
     }
@@ -1082,7 +1082,7 @@ private[json] object parsers {
           ch >= '0' && ch <= '9' && nanoDigitWeight != 0
         }) {
           nano += (ch - '0') * nanoDigitWeight
-          nanoDigitWeight /= 10
+          nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
         }
       }
     }
@@ -1314,8 +1314,9 @@ private[json] object parsers {
     else 28
 
   private[this] def isLeap(year: Int): Boolean = (year & 0x3) == 0 && { // (year % 100 != 0 || year % 400 == 0)
-    val century = year / 100
-    century * 100 != year || (century & 0x3) == 0
+    val cp = year * 1374389535L
+    val cc = year >> 31
+    ((cp ^ cc) & 0x1FC0000000L) != 0 || (((cp >> 37).toInt - cc) & 0x3) == 0
   }
 
   private[this] def nanoError(nanoDigitWeight: Int, ch: Char, pos: Int): Nothing = {

--- a/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
@@ -227,13 +227,11 @@ private[json] object parsers {
     var second, nano = 0
     var ch           = (0: Char)
     if (pos < len) {
-      var nanoDigitWeight = -1
       ch = input.charAt(pos)
       pos += 1
       if (ch == ':') {
-        nanoDigitWeight = -2
         second = {
-          if (pos + 2 >= len) instantError(pos)
+          if (pos + 1 >= len) instantError(pos)
           val ch0 = input.charAt(pos)
           val ch1 = input.charAt(pos + 1)
           if (ch0 < '0' || ch0 > '9') digitError(pos)
@@ -246,7 +244,7 @@ private[json] object parsers {
         ch = input.charAt(pos)
         pos += 1
         if (ch == '.') {
-          nanoDigitWeight = 100000000
+          var nanoDigitWeight = 100000000
           while (
             pos < len && {
               ch = input.charAt(pos)
@@ -437,40 +435,36 @@ private[json] object parsers {
     }
     var second, nano = 0
     if (pos < len) {
-      var nanoDigitWeight = -1
-      var ch              = input.charAt(pos)
+      if (input.charAt(pos) != ':') charError(':', pos)
       pos += 1
-      if (ch == ':') {
-        nanoDigitWeight = -2
-        second = {
-          if (pos + 2 >= len) localDateTimeError(pos)
-          val ch0 = input.charAt(pos)
-          val ch1 = input.charAt(pos + 1)
-          if (ch0 < '0' || ch0 > '9') digitError(pos)
-          if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-          if (ch0 > '5') secondError(pos + 1)
-          pos += 2
-          ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-        }
-        if (pos >= len) localDateTimeError(pos)
-        ch = input.charAt(pos)
+      second = {
+        if (pos + 1 >= len) localDateTimeError(pos)
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        if (ch0 < '0' || ch0 > '9') digitError(pos)
+        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
+        if (ch0 > '5') secondError(pos + 1)
+        pos += 2
+        ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+      }
+      if (pos < len) {
+        if (input.charAt(pos) != '.') charError('.', pos)
         pos += 1
-        if (ch == '.') {
-          nanoDigitWeight = 100000000
-          while (
-            pos < len && {
-              ch = input.charAt(pos)
-              pos += 1
-              ch >= '0' && ch <= '9' && nanoDigitWeight != 0
-            }
-          ) {
-            nano += (ch - '0') * nanoDigitWeight
-            nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
+        var nanoDigitWeight = 100000000
+        var ch = (0: Char)
+        while (
+          pos < len && {
+            ch = input.charAt(pos)
+            pos += 1
+            ch >= '0' && ch <= '9' && nanoDigitWeight != 0
           }
+        ) {
+          nano += (ch - '0') * nanoDigitWeight
+          nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
         }
+        if (pos != len || ch < '0' || ch > '9') localDateTimeError(pos - 1)
       }
     }
-    if (pos != len) localDateTimeError(pos)
     LocalDateTime.of(year, month, day, hour, minute, second, nano)
   }
 
@@ -502,40 +496,36 @@ private[json] object parsers {
     }
     var second, nano = 0
     if (pos < len) {
-      var nanoDigitWeight = -1
-      var ch              = input.charAt(pos)
-      if (ch == ':') {
+      if (input.charAt(pos) != ':') charError(':', pos)
+      pos += 1
+      second = {
+        if (pos + 1 >= len) localTimeError(pos)
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        if (ch0 < '0' || ch0 > '9') digitError(pos)
+        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
+        if (ch0 > '5') secondError(pos + 1)
+        pos += 2
+        ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+      }
+      if (pos < len) {
+        if (input.charAt(pos) != '.') charError('.', pos)
         pos += 1
-        nanoDigitWeight = -2
-        second = {
-          if (pos + 2 >= len) localTimeError(pos)
-          val ch0 = input.charAt(pos)
-          val ch1 = input.charAt(pos + 1)
-          if (ch0 < '0' || ch0 > '9') digitError(pos)
-          if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-          if (ch0 > '5') secondError(pos + 1)
-          pos += 2
-          ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-        }
-        if (pos >= len) localTimeError(pos)
-        ch = input.charAt(pos)
-        pos += 1
-        if (ch == '.') {
-          nanoDigitWeight = 100000000
-          while (
-            pos < len && {
-              ch = input.charAt(pos)
-              pos += 1
-              ch >= '0' && ch <= '9' && nanoDigitWeight != 0
-            }
-          ) {
-            nano += (ch - '0') * nanoDigitWeight
-            nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
+        var nanoDigitWeight = 100000000
+        var ch = (0: Char)
+        while (
+          pos < len && {
+            ch = input.charAt(pos)
+            pos += 1
+            ch >= '0' && ch <= '9' && nanoDigitWeight != 0
           }
+        ) {
+          nano += (ch - '0') * nanoDigitWeight
+          nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
         }
+        if (pos != len || ch < '0' || ch > '9') localTimeError(pos - 1)
       }
     }
-    if (pos != len) localTimeError(pos)
     LocalTime.of(hour, minute, second, nano)
   }
 
@@ -663,7 +653,7 @@ private[json] object parsers {
     if (ch == ':') {
       nanoDigitWeight = -2
       second = {
-        if (pos + 2 >= len) offsetDateTimeError(pos)
+        if (pos + 1 >= len) offsetDateTimeError(pos)
         val ch0 = input.charAt(pos)
         val ch1 = input.charAt(pos + 1)
         if (ch0 < '0' || ch0 > '9') digitError(pos)
@@ -692,7 +682,6 @@ private[json] object parsers {
       if (ch == 'Z') ZoneOffset.UTC
       else {
         val offsetNeg = ch == '-' || (ch != '+' && timezoneSignError(nanoDigitWeight, pos - 1))
-        nanoDigitWeight = -3
         val offsetHour = {
           if (pos + 1 >= len) offsetDateTimeError(pos)
           val ch0        = input.charAt(pos)
@@ -729,7 +718,6 @@ private[json] object parsers {
               ch == ':'
             }
           ) {
-            nanoDigitWeight = -4
             offsetSecond = {
               if (pos + 1 >= len) offsetDateTimeError(pos)
               val ch0 = input.charAt(pos)
@@ -782,7 +770,7 @@ private[json] object parsers {
     if (ch == ':') {
       nanoDigitWeight = -2
       second = {
-        if (pos + 2 >= len) offsetDateTimeError(pos)
+        if (pos + 1 >= len) offsetDateTimeError(pos)
         val ch0 = input.charAt(pos)
         val ch1 = input.charAt(pos + 1)
         if (ch0 < '0' || ch0 > '9') digitError(pos)
@@ -1072,7 +1060,7 @@ private[json] object parsers {
     if (ch == ':') {
       nanoDigitWeight = -2
       second = {
-        if (pos + 2 >= len) zonedDateTimeError(pos)
+        if (pos + 1 >= len) zonedDateTimeError(pos)
         val ch0 = input.charAt(pos)
         val ch1 = input.charAt(pos + 1)
         if (ch0 < '0' || ch0 > '9') digitError(pos)

--- a/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
@@ -650,7 +650,7 @@ private[json] object parsers {
     }
     var second, nano    = 0
     var nanoDigitWeight = -1
-    if (pos >= len) offsetDateTimeError(pos)
+    if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
     var ch = input.charAt(pos)
     pos += 1
     if (ch == ':') {
@@ -665,7 +665,7 @@ private[json] object parsers {
         pos += 2
         ch0 * 10 + ch1 - 528 // 528 == '0' * 11
       }
-      if (pos >= len) offsetDateTimeError(pos)
+      if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
       ch = input.charAt(pos)
       pos += 1
       if (ch == '.') {
@@ -1355,10 +1355,10 @@ private[json] object parsers {
   private[this] def durationError(pos: Int) = error("illegal duration", pos)
 
   private[this] def instantError(nanoDigitWeight: Int, pos: Int) = error(
-    if (nanoDigitWeight == -1) "expected 'Z' or ':'"
-    else if (nanoDigitWeight == -2) "expected 'Z' or '.'"
-    else if (nanoDigitWeight == 100000000) "expected digit"
-    else "expected 'Z'",
+    if (nanoDigitWeight == -1) "expected ':' or 'Z'"
+    else if (nanoDigitWeight == -2) "expected '.' or 'Z'"
+    else if (nanoDigitWeight == 0) "expected 'Z'"
+    else "expected digit or 'Z'",
     pos
   )
 
@@ -1374,7 +1374,7 @@ private[json] object parsers {
       if (nanoDigitWeight == -2) "expected '.' or '+' or '-' or 'Z'"
       else if (nanoDigitWeight == -1) "expected ':' or '+' or '-' or 'Z'"
       else if (nanoDigitWeight == 0) "expected '+' or '-' or 'Z'"
-      else "expected '+' or '-' or 'Z' or digit",
+      else "expected digit or '+' or '-' or 'Z'",
       pos
     )
 

--- a/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -497,9 +497,94 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           )
         },
         test("LocalDate") {
-          assert(stringify("01/01/2020").fromJson[LocalDate])(
+          assert(stringify("").fromJson[LocalDate])(
             isLeft(
-              equalTo("(01/01/2020 is not a valid ISO-8601 format, expected digit at index 2)")
+              equalTo("( is not a valid ISO-8601 format, illegal local date at index 0)")
+            )
+          ) &&
+          assert(stringify("2020").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020 is not a valid ISO-8601 format, illegal local date at index 0)")
+            )
+          ) &&
+          assert(stringify("X020-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(X020-01-01 is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
+            )
+          ) &&
+          assert(stringify("2X20-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2X20-01-01 is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("20X0-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(20X0-01-01 is not a valid ISO-8601 format, expected digit at index 2)")
+            )
+          ) &&
+          assert(stringify("202X-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(202X-01-01 is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("2020X01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020X01-01 is not a valid ISO-8601 format, expected '-' at index 4)")
+            )
+          ) &&
+          assert(stringify("+X0000-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+X0000-01-01 is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("+1X000-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+1X000-01-01 is not a valid ISO-8601 format, expected digit at index 2)")
+            )
+          ) &&
+          assert(stringify("+10X00-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+10X00-01-01 is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("+100X0-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+100X0-01-01 is not a valid ISO-8601 format, expected digit at index 4)")
+            )
+          ) &&
+          assert(stringify("+1000X-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+1000X-01-01 is not a valid ISO-8601 format, expected digit at index 5)")
+            )
+          ) &&
+          assert(stringify("+10000X-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+10000X-01-01 is not a valid ISO-8601 format, expected '-' or digit at index 6)")
+            )
+          ) &&
+          assert(stringify("+100000X-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+100000X-01-01 is not a valid ISO-8601 format, expected '-' or digit at index 7)")
+            )
+          ) &&
+          assert(stringify("+1000000X-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+1000000X-01-01 is not a valid ISO-8601 format, expected '-' or digit at index 8)")
+            )
+          ) &&
+          assert(stringify("+1000000000-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+1000000000-01-01 is not a valid ISO-8601 format, expected '-' at index 10)")
+            )
+          ) &&
+          assert(stringify("-1000000000-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(-1000000000-01-01 is not a valid ISO-8601 format, expected '-' at index 10)")
+            )
+          ) &&
+          assert(stringify("-0000-01-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(-0000-01-01 is not a valid ISO-8601 format, illegal year at index 4)")
             )
           )
         },

--- a/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -507,6 +507,21 @@ object JavaTimeSpec extends DefaultRunnableSpec {
               equalTo("(2020 is not a valid ISO-8601 format, illegal local date at index 0)")
             )
           ) &&
+          assert(stringify("2020-0").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-0 is not a valid ISO-8601 format, illegal local date at index 5)")
+            )
+          ) &&
+          assert(stringify("2020-01-0").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal local date at index 8)")
+            )
+          ) &&
+          assert(stringify("2020-01-012").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-01-012 is not a valid ISO-8601 format, illegal local date at index 10)")
+            )
+          ) &&
           assert(stringify("X020-01-01").fromJson[LocalDate])(
             isLeft(
               equalTo("(X020-01-01 is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
@@ -530,6 +545,31 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           assert(stringify("2020X01-01").fromJson[LocalDate])(
             isLeft(
               equalTo("(2020X01-01 is not a valid ISO-8601 format, expected '-' at index 4)")
+            )
+          ) &&
+          assert(stringify("2020-X1-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-X1-01 is not a valid ISO-8601 format, expected digit at index 5)")
+            )
+          ) &&
+          assert(stringify("2020-0X-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-0X-01 is not a valid ISO-8601 format, expected digit at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-01X01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-01X01 is not a valid ISO-8601 format, expected '-' at index 7)")
+            )
+          ) &&
+          assert(stringify("2020-01-X1").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-01-X1 is not a valid ISO-8601 format, expected digit at index 8)")
+            )
+          ) &&
+          assert(stringify("2020-01-0X").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-01-0X is not a valid ISO-8601 format, expected digit at index 9)")
             )
           ) &&
           assert(stringify("+X0000-01-01").fromJson[LocalDate])(
@@ -585,6 +625,86 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           assert(stringify("-0000-01-01").fromJson[LocalDate])(
             isLeft(
               equalTo("(-0000-01-01 is not a valid ISO-8601 format, illegal year at index 4)")
+            )
+          ) &&
+          assert(stringify("+10000").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(+10000 is not a valid ISO-8601 format, illegal local date at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-00-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-00-01 is not a valid ISO-8601 format, illegal month at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-13-01").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-13-01 is not a valid ISO-8601 format, illegal month at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-01-00").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-01-00 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-01-32").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-01-32 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-02-30").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-02-30 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-03-32").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-03-32 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-04-31").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-04-31 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-05-32").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-05-32 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-06-31").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-06-31 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-07-32").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-07-32 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-08-32").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-08-32 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-09-31").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-09-31 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-10-32").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-10-32 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-11-31").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-11-31 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-12-32").fromJson[LocalDate])(
+            isLeft(
+              equalTo("(2020-12-32 is not a valid ISO-8601 format, illegal day at index 9)")
             )
           )
         },

--- a/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -709,11 +709,294 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           )
         },
         test("LocalDateTime") {
-          assert(stringify("01-01-2020T12:36").fromJson[LocalDateTime])(
+          assert(stringify("").fromJson[LocalDateTime])(
             isLeft(
-              equalTo(
-                "(01-01-2020T12:36 is not a valid ISO-8601 format, expected digit at index 2)"
-              )
+              equalTo("( is not a valid ISO-8601 format, illegal local date time at index 0)")
+            )
+          ) &&
+          assert(stringify("2020").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020 is not a valid ISO-8601 format, illegal local date time at index 0)")
+            )
+          ) &&
+          assert(stringify("2020-0").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-0 is not a valid ISO-8601 format, illegal local date time at index 5)")
+            )
+          ) &&
+          assert(stringify("2020-01-0").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal local date time at index 8)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T0").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T0 is not a valid ISO-8601 format, illegal local date time at index 11)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:0").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:0 is not a valid ISO-8601 format, illegal local date time at index 14)")
+            )
+          ) &&
+          assert(stringify("X020-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(X020-01-01T01:01 is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
+            )
+          ) &&
+          assert(stringify("2X20-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2X20-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("20X0-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(20X0-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 2)")
+            )
+          ) &&
+          assert(stringify("202X-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(202X-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("2020X01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020X01-01T01:01 is not a valid ISO-8601 format, expected '-' at index 4)")
+            )
+          ) &&
+          assert(stringify("2020-X1-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-X1-01T01:01 is not a valid ISO-8601 format, expected digit at index 5)")
+            )
+          ) &&
+          assert(stringify("2020-0X-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-0X-01T01:01 is not a valid ISO-8601 format, expected digit at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-01X01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01X01T01:01 is not a valid ISO-8601 format, expected '-' at index 7)")
+            )
+          ) &&
+          assert(stringify("2020-01-X1T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-X1T01:01 is not a valid ISO-8601 format, expected digit at index 8)")
+            )
+          ) &&
+          assert(stringify("2020-01-0XT01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-0XT01:01 is not a valid ISO-8601 format, expected digit at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-01-01X01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01X01:01 is not a valid ISO-8601 format, expected 'T' at index 10)")
+            )
+          ) &&
+          assert(stringify("2020-01-01TX1:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01TX1:01 is not a valid ISO-8601 format, expected digit at index 11)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T0X:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T0X:01 is not a valid ISO-8601 format, expected digit at index 12)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T24:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T24:01 is not a valid ISO-8601 format, illegal hour at index 12)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01X01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01X01 is not a valid ISO-8601 format, expected ':' at index 13)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:X1").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:X1 is not a valid ISO-8601 format, expected digit at index 14)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:0X").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:0X is not a valid ISO-8601 format, expected digit at index 15)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:60").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:60 is not a valid ISO-8601 format, illegal minute at index 15)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01X").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01X is not a valid ISO-8601 format, expected ':' at index 16)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:0").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:0 is not a valid ISO-8601 format, illegal local date time at index 17)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:X1").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:X1 is not a valid ISO-8601 format, expected digit at index 17)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:0X").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:0X is not a valid ISO-8601 format, expected digit at index 18)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:60").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:60 is not a valid ISO-8601 format, illegal second at index 18)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:012").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected '.' at index 19)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:01.X").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:01.X is not a valid ISO-8601 format, illegal local date time at index 20)")
+            )
+          ) &&
+          assert(stringify("+X0000-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+X0000-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("+1X000-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+1X000-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 2)")
+            )
+          ) &&
+          assert(stringify("+10X00-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+10X00-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("+100X0-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+100X0-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 4)")
+            )
+          ) &&
+          assert(stringify("+1000X-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+1000X-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 5)")
+            )
+          ) &&
+          assert(stringify("+10000X-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+10000X-01-01T01:01 is not a valid ISO-8601 format, expected '-' or digit at index 6)")
+            )
+          ) &&
+          assert(stringify("+100000X-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+100000X-01-01T01:01 is not a valid ISO-8601 format, expected '-' or digit at index 7)")
+            )
+          ) &&
+          assert(stringify("+1000000X-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+1000000X-01-01T01:01 is not a valid ISO-8601 format, expected '-' or digit at index 8)")
+            )
+          ) &&
+          assert(stringify("+1000000000-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+1000000000-01-01T01:01 is not a valid ISO-8601 format, expected '-' at index 10)")
+            )
+          ) &&
+          assert(stringify("-1000000000-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(-1000000000-01-01T01:01 is not a valid ISO-8601 format, expected '-' at index 10)")
+            )
+          ) &&
+          assert(stringify("-0000-01-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(-0000-01-01T01:01 is not a valid ISO-8601 format, illegal year at index 4)")
+            )
+          ) &&
+          assert(stringify("+10000").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(+10000 is not a valid ISO-8601 format, illegal local date time at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-00-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-00-01T01:01 is not a valid ISO-8601 format, illegal month at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-13-01T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-13-01T01:01 is not a valid ISO-8601 format, illegal month at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-01-00T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-00T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-01-32T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-01-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-02-30T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-02-30T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-03-32T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-03-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-04-31T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-04-31T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-05-32T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-05-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-06-31T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-06-31T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-07-32T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-07-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-08-32T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-08-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-09-31T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-09-31T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-10-32T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-10-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-11-31T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-11-31T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-12-32T01:01").fromJson[LocalDateTime])(
+            isLeft(
+              equalTo("(2020-12-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
             )
           )
         },
@@ -721,7 +1004,7 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           assert(stringify("12:36.000").fromJson[LocalTime])(
             isLeft(
               equalTo(
-                "(12:36.000 is not a valid ISO-8601 format, illegal local time at index 5)"
+                "(12:36.000 is not a valid ISO-8601 format, expected ':' at index 5)"
               )
             )
           )

--- a/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -496,6 +496,308 @@ object JavaTimeSpec extends DefaultRunnableSpec {
             )
           )
         },
+        test("Instant") {
+          assert(stringify("").fromJson[Instant])(
+            isLeft(
+              equalTo("( is not a valid ISO-8601 format, illegal instant at index 0)")
+            )
+          ) &&
+          assert(stringify("2020").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020 is not a valid ISO-8601 format, illegal instant at index 0)")
+            )
+          ) &&
+          assert(stringify("2020-0").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-0 is not a valid ISO-8601 format, illegal instant at index 5)")
+            )
+          ) &&
+          assert(stringify("2020-01-0").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal instant at index 8)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T0").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T0 is not a valid ISO-8601 format, illegal instant at index 11)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:0").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:0 is not a valid ISO-8601 format, illegal instant at index 14)")
+            )
+          ) &&
+          assert(stringify("X020-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(X020-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
+            )
+          ) &&
+          assert(stringify("2X20-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2X20-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("20X0-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(20X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
+            )
+          ) &&
+          assert(stringify("202X-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(202X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("2020X01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020X01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 4)")
+            )
+          ) &&
+          assert(stringify("2020-X1-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-X1-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
+            )
+          ) &&
+          assert(stringify("2020-0X-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-0X-01T01:01Z is not a valid ISO-8601 format, expected digit at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-01X01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01X01T01:01Z is not a valid ISO-8601 format, expected '-' at index 7)")
+            )
+          ) &&
+          assert(stringify("2020-01-X1T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-X1T01:01Z is not a valid ISO-8601 format, expected digit at index 8)")
+            )
+          ) &&
+          assert(stringify("2020-01-0XT01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-0XT01:01Z is not a valid ISO-8601 format, expected digit at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-01-01X01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01X01:01Z is not a valid ISO-8601 format, expected 'T' at index 10)")
+            )
+          ) &&
+          assert(stringify("2020-01-01TX1:01").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01TX1:01 is not a valid ISO-8601 format, expected digit at index 11)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T0X:01").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T0X:01 is not a valid ISO-8601 format, expected digit at index 12)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T24:01").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T24:01 is not a valid ISO-8601 format, illegal hour at index 12)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01X01").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01X01 is not a valid ISO-8601 format, expected ':' at index 13)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:X1").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:X1 is not a valid ISO-8601 format, expected digit at index 14)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:0X").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:0X is not a valid ISO-8601 format, expected digit at index 15)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:60").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:60 is not a valid ISO-8601 format, illegal minute at index 15)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01X").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01X is not a valid ISO-8601 format, expected 'Z' or ':' at index 16)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:0").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:0 is not a valid ISO-8601 format, illegal instant at index 17)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:X1Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:X1Z is not a valid ISO-8601 format, expected digit at index 17)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:0XZ").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:0XZ is not a valid ISO-8601 format, expected digit at index 18)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:60Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:60Z is not a valid ISO-8601 format, illegal second at index 18)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:012").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected 'Z' or '.' at index 19)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:01.X").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:01.X is not a valid ISO-8601 format, expected digit at index 20)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:01ZX").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:01ZX is not a valid ISO-8601 format, illegal instant at index 20)")
+            )
+          ) &&
+          assert(stringify("+X0000-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+X0000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("+1X000-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+1X000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
+            )
+          ) &&
+          assert(stringify("+10X00-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+10X00-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("+100X0-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+100X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 4)")
+            )
+          ) &&
+          assert(stringify("+1000X-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+1000X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
+            )
+          ) &&
+          assert(stringify("+10000X-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+10000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 6)")
+            )
+          ) &&
+          assert(stringify("+100000X-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+100000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 7)")
+            )
+          ) &&
+          assert(stringify("+1000000X-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+1000000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 8)")
+            )
+          ) &&
+          assert(stringify("+1000000001-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+1000000001-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 10)")
+            )
+          ) &&
+          assert(stringify("+3333333333-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(+3333333333-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 10)")
+            )
+          ) &&
+          assert(stringify("-1000000001-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(-1000000001-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 10)")
+            )
+          ) &&
+          assert(stringify("-0000-01-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(-0000-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 4)")
+            )
+          ) &&
+          assert(stringify("+10000").fromJson[Instant])(
+            isLeft(
+              equalTo("(+10000 is not a valid ISO-8601 format, illegal instant at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-00-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-00-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-13-01T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-13-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-01-00T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-00T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-01-32T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-02-30T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-02-30T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-03-32T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-03-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-04-31T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-04-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-05-32T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-05-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-06-31T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-06-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-07-32T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-07-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-08-32T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-08-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-09-31T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-09-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-10-32T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-10-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-11-31T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-11-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-12-32T01:01Z").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-12-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          )
+        },
         test("LocalDate") {
           assert(stringify("").fromJson[LocalDate])(
             isLeft(

--- a/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -1303,11 +1303,89 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           )
         },
         test("LocalTime") {
-          assert(stringify("12:36.000").fromJson[LocalTime])(
+          assert(stringify("").fromJson[LocalTime])(
             isLeft(
-              equalTo(
-                "(12:36.000 is not a valid ISO-8601 format, expected ':' at index 5)"
-              )
+              equalTo("( is not a valid ISO-8601 format, illegal local time at index 0)")
+            )
+          ) &&
+          assert(stringify("0").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(0 is not a valid ISO-8601 format, illegal local time at index 0)")
+            )
+          ) &&
+          assert(stringify("01:0").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:0 is not a valid ISO-8601 format, illegal local time at index 3)")
+            )
+          ) &&
+          assert(stringify("X1:01").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(X1:01 is not a valid ISO-8601 format, expected digit at index 0)")
+            )
+          ) &&
+          assert(stringify("0X:01").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(0X:01 is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("24:01").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(24:01 is not a valid ISO-8601 format, illegal hour at index 1)")
+            )
+          ) &&
+          assert(stringify("01X01").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01X01 is not a valid ISO-8601 format, expected ':' at index 2)")
+            )
+          ) &&
+          assert(stringify("01:X1").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:X1 is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("01:0X").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:0X is not a valid ISO-8601 format, expected digit at index 4)")
+            )
+          ) &&
+          assert(stringify("01:60").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:60 is not a valid ISO-8601 format, illegal minute at index 4)")
+            )
+          ) &&
+          assert(stringify("01:01X").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:01X is not a valid ISO-8601 format, expected ':' at index 5)")
+            )
+          ) &&
+          assert(stringify("01:01:0").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:01:0 is not a valid ISO-8601 format, illegal local time at index 6)")
+            )
+          ) &&
+          assert(stringify("01:01:X1").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:01:X1 is not a valid ISO-8601 format, expected digit at index 6)")
+            )
+          ) &&
+          assert(stringify("01:01:0X").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:01:0X is not a valid ISO-8601 format, expected digit at index 7)")
+            )
+          ) &&
+          assert(stringify("01:01:60").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:01:60 is not a valid ISO-8601 format, illegal second at index 7)")
+            )
+          ) &&
+          assert(stringify("01:01:012").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:01:012 is not a valid ISO-8601 format, expected '.' at index 8)")
+            )
+          ) &&
+          assert(stringify("01:01:01.X").fromJson[LocalTime])(
+            isLeft(
+              equalTo("(01:01:01.X is not a valid ISO-8601 format, illegal local time at index 9)")
             )
           )
         },

--- a/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -159,6 +159,7 @@ object JavaTimeSpec extends DefaultRunnableSpec {
         test("Instant") {
           val n = Instant.now()
           assert(stringify("1970-01-01T00:00:00Z").fromJson[Instant])(isRight(equalTo(Instant.EPOCH))) &&
+          assert(stringify("1970-01-01T00:00:00.Z").fromJson[Instant])(isRight(equalTo(Instant.EPOCH))) &&
           assert(stringify(n).fromJson[Instant])(isRight(equalTo(n)))
         },
         test("LocalDate") {
@@ -206,6 +207,7 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           val p = OffsetDateTime.of(2020, 1, 1, 12, 36, 12, 0, ZoneOffset.UTC)
           assert(stringify(n).fromJson[OffsetDateTime])(isRight(equalTo(n))) &&
           assert(stringify("2020-01-01T12:36:12Z").fromJson[OffsetDateTime])(isRight(equalTo(p)))
+          assert(stringify("2020-01-01T12:36:12.Z").fromJson[OffsetDateTime])(isRight(equalTo(p)))
         },
         test("OffsetTime") {
           val n = OffsetTime.now()
@@ -619,7 +621,7 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           ) &&
           assert(stringify("2020-01-01T01:01X").fromJson[Instant])(
             isLeft(
-              equalTo("(2020-01-01T01:01X is not a valid ISO-8601 format, expected 'Z' or ':' at index 16)")
+              equalTo("(2020-01-01T01:01X is not a valid ISO-8601 format, expected ':' or 'Z' at index 16)")
             )
           ) &&
           assert(stringify("2020-01-01T01:01:0").fromJson[Instant])(
@@ -644,12 +646,17 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           ) &&
           assert(stringify("2020-01-01T01:01:012").fromJson[Instant])(
             isLeft(
-              equalTo("(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected 'Z' or '.' at index 19)")
+              equalTo("(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected '.' or 'Z' at index 19)")
             )
           ) &&
           assert(stringify("2020-01-01T01:01:01.X").fromJson[Instant])(
             isLeft(
-              equalTo("(2020-01-01T01:01:01.X is not a valid ISO-8601 format, expected digit at index 20)")
+              equalTo("(2020-01-01T01:01:01.X is not a valid ISO-8601 format, expected digit or 'Z' at index 20)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:01.123456789X").fromJson[Instant])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:01.123456789X is not a valid ISO-8601 format, expected 'Z' at index 29)")
             )
           ) &&
           assert(stringify("2020-01-01T01:01:01ZX").fromJson[Instant])(
@@ -1403,11 +1410,326 @@ object JavaTimeSpec extends DefaultRunnableSpec {
           )
         },
         test("OffsetDateTime") {
-          assert(stringify("01-01-2020T12:36:12Z").fromJson[OffsetDateTime])(
+          assert(stringify("").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("( is not a valid ISO-8601 format, illegal offset date time at index 0)")
+            )
+          ) &&
+          assert(stringify("2020").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020 is not a valid ISO-8601 format, illegal offset date time at index 0)")
+            )
+          ) &&
+          assert(stringify("2020-0").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-0 is not a valid ISO-8601 format, illegal offset date time at index 5)")
+            )
+          ) &&
+          assert(stringify("2020-01-0").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal offset date time at index 8)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T0").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T0 is not a valid ISO-8601 format, illegal offset date time at index 11)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:0").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:0 is not a valid ISO-8601 format, illegal offset date time at index 14)")
+            )
+          ) &&
+          assert(stringify("X020-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(X020-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
+            )
+          ) &&
+          assert(stringify("2X20-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2X20-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("20X0-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(20X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
+            )
+          ) &&
+          assert(stringify("202X-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(202X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("2020X01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020X01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 4)")
+            )
+          ) &&
+          assert(stringify("2020-X1-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-X1-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
+            )
+          ) &&
+          assert(stringify("2020-0X-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-0X-01T01:01Z is not a valid ISO-8601 format, expected digit at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-01X01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01X01T01:01Z is not a valid ISO-8601 format, expected '-' at index 7)")
+            )
+          ) &&
+          assert(stringify("2020-01-X1T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-X1T01:01Z is not a valid ISO-8601 format, expected digit at index 8)")
+            )
+          ) &&
+          assert(stringify("2020-01-0XT01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-0XT01:01Z is not a valid ISO-8601 format, expected digit at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-01-01X01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01X01:01Z is not a valid ISO-8601 format, expected 'T' at index 10)")
+            )
+          ) &&
+          assert(stringify("2020-01-01TX1:01").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01TX1:01 is not a valid ISO-8601 format, expected digit at index 11)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T0X:01").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T0X:01 is not a valid ISO-8601 format, expected digit at index 12)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T24:01").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T24:01 is not a valid ISO-8601 format, illegal hour at index 12)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01X01").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01X01 is not a valid ISO-8601 format, expected ':' at index 13)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:X1").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:X1 is not a valid ISO-8601 format, expected digit at index 14)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:0X").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:0X is not a valid ISO-8601 format, expected digit at index 15)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:60").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:60 is not a valid ISO-8601 format, illegal minute at index 15)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01").fromJson[OffsetDateTime])(
             isLeft(
               equalTo(
-                "(01-01-2020T12:36:12Z is not a valid ISO-8601 format, expected digit at index 2)"
+                "(2020-01-01T01:01 is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 16)"
               )
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01X").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo(
+                "(2020-01-01T01:01X is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 16)"
+              )
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:0").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:0 is not a valid ISO-8601 format, illegal offset date time at index 17)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:X1Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:X1Z is not a valid ISO-8601 format, expected digit at index 17)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:0XZ").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:0XZ is not a valid ISO-8601 format, expected digit at index 18)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:60Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:60Z is not a valid ISO-8601 format, illegal second at index 18)")
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:01").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo(
+                "(2020-01-01T01:01:01 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 19)"
+              )
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:012").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo(
+                "(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 19)"
+              )
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:01.X").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo(
+                "(2020-01-01T01:01:01.X is not a valid ISO-8601 format, expected digit or '+' or '-' or 'Z' at index 20)"
+              )
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:01.123456789X").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo(
+                "(2020-01-01T01:01:01.123456789X is not a valid ISO-8601 format, expected '+' or '-' or 'Z' at index 29)"
+              )
+            )
+          ) &&
+          assert(stringify("2020-01-01T01:01:01ZX").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-01T01:01:01ZX is not a valid ISO-8601 format, illegal offset date time at index 20)")
+            )
+          ) &&
+          assert(stringify("+X0000-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+X0000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
+            )
+          ) &&
+          assert(stringify("+1X000-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+1X000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
+            )
+          ) &&
+          assert(stringify("+10X00-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+10X00-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
+            )
+          ) &&
+          assert(stringify("+100X0-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+100X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 4)")
+            )
+          ) &&
+          assert(stringify("+1000X-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+1000X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
+            )
+          ) &&
+          assert(stringify("+10000X-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+10000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 6)")
+            )
+          ) &&
+          assert(stringify("+100000X-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+100000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 7)")
+            )
+          ) &&
+          assert(stringify("+1000000X-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+1000000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 8)")
+            )
+          ) &&
+          assert(stringify("+1000000000-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+1000000000-01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 10)")
+            )
+          ) &&
+          assert(stringify("-1000000000-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(-1000000000-01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 10)")
+            )
+          ) &&
+          assert(stringify("-0000-01-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(-0000-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 4)")
+            )
+          ) &&
+          assert(stringify("+10000").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(+10000 is not a valid ISO-8601 format, illegal offset date time at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-00-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-00-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-13-01T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-13-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
+            )
+          ) &&
+          assert(stringify("2020-01-00T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-00T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-01-32T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-01-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-02-30T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-02-30T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-03-32T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-03-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-04-31T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-04-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-05-32T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-05-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-06-31T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-06-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-07-32T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-07-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-08-32T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-08-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-09-31T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-09-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-10-32T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-10-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-11-31T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-11-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
+            )
+          ) &&
+          assert(stringify("2020-12-32T01:01Z").fromJson[OffsetDateTime])(
+            isLeft(
+              equalTo("(2020-12-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
             )
           )
         },


### PR DESCRIPTION
+ simplify parsing of negative or more than 4 digit years
+ more precise position in parsing errors