### PR TITLE
Proxy isNothing in JsonCodec.apply

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -80,6 +80,8 @@ object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 {
 
           override def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit =
             encoder0.unsafeEncode(a, indent, out)
+
+          override def isNothing(a: A): Boolean = encoder0.isNothing(a)
         }
     }
 }


### PR DESCRIPTION
`JsonCodec.apply`, which is used to implicitly build a `JsonCodec` from an implicit `JsonEncoder` and `JsonDecoder`, is not currently proxying `isNothing` to the underlying `JsonEncoder`. This results in a `JsonCodec` that does not behave like the `JsonEncoder` it is built from.

PR changes the `isNothing` method to proxy to the underlying `JsonEncoder`.