### PR TITLE
Fix serialization of floats and doubles

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
@@ -145,11 +145,12 @@ object SafeNumbers {
         val len = digitCount(dv)
         exp += len - 1
         if (exp < -3 || exp >= 7) {
+          val dotOff = s.length + 1
           s.append(dv)
           var i = s.length - 1
-          while (i > 2 && s.charAt(i) == '0') i -= 1
+          while (i > dotOff && s.charAt(i) == '0') i -= 1
           s.setLength(i + 1)
-          s.insert(1, '.').append('E').append(exp)
+          s.insert(dotOff, '.').append('E').append(exp)
         } else if (exp < 0) {
           s.append('0').append('.')
           while ({
@@ -162,11 +163,12 @@ object SafeNumbers {
           s.setLength(i + 1)
           s
         } else if (exp + 1 < len) {
+          val dotOff = s.length + exp + 1
           s.append(dv)
           var i = s.length - 1
           while (s.charAt(i) == '0') i -= 1
           s.setLength(i + 1)
-          s.insert(exp + 1, '.')
+          s.insert(dotOff, '.')
         } else s.append(dv).append('.').append('0')
       }
     }.toString
@@ -237,11 +239,12 @@ object SafeNumbers {
         val len = digitCount(dv.toLong)
         exp += len - 1
         if (exp < -3 || exp >= 7) {
+          val dotOff = s.length + 1
           s.append(dv)
           var i = s.length - 1
-          while (i > 2 && s.charAt(i) == '0') i -= 1
+          while (i > dotOff && s.charAt(i) == '0') i -= 1
           s.setLength(i + 1)
-          s.insert(1, '.').append('E').append(exp)
+          s.insert(dotOff, '.').append('E').append(exp)
         } else if (exp < 0) {
           s.append('0').append('.')
           while ({
@@ -254,11 +257,12 @@ object SafeNumbers {
           s.setLength(i + 1)
           s
         } else if (exp + 1 < len) {
+          val dotOff = s.length + exp + 1
           s.append(dv)
           var i = s.length - 1
           while (s.charAt(i) == '0') i -= 1
           s.setLength(i + 1)
-          s.insert(exp + 1, '.')
+          s.insert(dotOff, '.')
         } else s.append(dv).append('.').append('0')
       }
     }.toString

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -31,7 +31,165 @@ object EncoderSpec extends DefaultRunnableSpec {
             assert('c'.toJson)(equalTo("\"c\"")) &&
             assert(Symbol("c").toJson)(equalTo("\"c\""))
           },
-          test("numerics") {
+          test("float") {
+            assert(Float.NaN.toJson)(equalTo("\"NaN\"")) &&
+            assert(Float.PositiveInfinity.toJson)(equalTo("\"Infinity\"")) &&
+            assert(Float.NegativeInfinity.toJson)(equalTo("\"-Infinity\"")) &&
+            assert(0.0f.toJson)(equalTo("0.0")) &&
+            assert((-0.0f).toJson)(equalTo("-0.0")) &&
+            assert(1.0f.toJson)(equalTo("1.0")) &&
+            assert((-1.0f).toJson)(equalTo("-1.0")) &&
+            assert(1.0e7f.toJson)(equalTo("1.0E7")) &&
+            assert((-1.0e7f).toJson)(equalTo("-1.0E7")) &&
+            assert(1.17549435e-38f.toJson)(equalTo("1.1754944E-38")) && // subnormal
+            assert(9999999.0f.toJson)(equalTo("9999999.0")) &&
+            assert(0.001f.toJson)(equalTo("0.001")) &&
+            assert(9.999999e-4f.toJson)(equalTo("9.999999E-4")) &&
+            // FIXME: sbt fmt cannot parse: assert((-3.4028235E38f).toJson)(equalTo("-3.4028235E38")) && // Float.MinValue
+            assert(1.4e-45f.toJson)(equalTo("1.4E-45")) && // Float.MinPositiveValue
+            // FIXME: sbt fmt cannot parse: assert(3.4028235E38f.toJson)(equalTo("3.4028235E38")) && // Float.MaxValue
+            assert(3.3554448e7f.toJson)(equalTo("3.355445E7")) &&
+            assert(8.999999e9f.toJson)(equalTo("9.0E9")) &&
+            assert(3.4366718e10f.toJson)(equalTo("3.436672E10")) &&
+            assert(4.7223665e21f.toJson)(equalTo("4.7223665E21")) &&
+            assert(8388608.0f.toJson)(equalTo("8388608.0")) &&
+            assert(1.6777216e7f.toJson)(equalTo("1.6777216E7")) &&
+            assert(3.3554436e7f.toJson)(equalTo("3.3554436E7")) &&
+            assert(6.7131496e7f.toJson)(equalTo("6.7131496E7")) &&
+            assert(1.9310392e-38f.toJson)(equalTo("1.9310392E-38")) &&
+            assert((-2.47e-43f).toJson)(equalTo("-2.47E-43")) &&
+            assert(1.993244e-38f.toJson)(equalTo("1.993244E-38")) &&
+            assert(4103.9004f.toJson)(equalTo("4103.9004")) &&
+            assert(5.3399997e9f.toJson)(equalTo("5.3399997E9")) &&
+            assert(6.0898e-39f.toJson)(equalTo("6.0898E-39")) &&
+            assert(0.0010310042f.toJson)(equalTo("0.0010310042")) &&
+            assert(2.8823261e17f.toJson)(equalTo("2.882326E17")) &&
+            assert(7.038531e-26f.toJson)(equalTo("7.038531E-26")) &&
+            assert(9.2234038e17f.toJson)(equalTo("9.223404E17")) &&
+            assert(6.7108872e7f.toJson)(equalTo("6.710887E7")) &&
+            assert(1.0e-44f.toJson)(equalTo("9.8E-45")) &&
+            assert(2.816025e14f.toJson)(equalTo("2.816025E14")) &&
+            assert(9.223372e18f.toJson)(equalTo("9.223372E18")) &&
+            assert(1.5846086e29f.toJson)(equalTo("1.5846086E29")) &&
+            assert(1.1811161e19f.toJson)(equalTo("1.1811161E19")) &&
+            assert(5.368709e18f.toJson)(equalTo("5.368709E18")) &&
+            assert(4.6143166e18f.toJson)(equalTo("4.6143166E18")) &&
+            assert(0.007812537f.toJson)(equalTo("0.007812537")) &&
+            assert(1.4e-45f.toJson)(equalTo("1.4E-45")) &&
+            assert(1.18697725e20f.toJson)(equalTo("1.18697725E20")) &&
+            assert(1.00014165e-36f.toJson)(equalTo("1.00014165E-36")) &&
+            assert(200.0f.toJson)(equalTo("200.0")) &&
+            assert(3.3554432e7f.toJson)(equalTo("3.3554432E7")) &&
+            assert(1.26217745e-29f.toJson)(equalTo("1.2621775E-29")) &&
+            assert(1.0e-43f.toJson)(equalTo("9.9E-44")) && // 71 * 2 ^ -149 == 9.94... * 10 ^ -44
+            assert(1.0e-45f.toJson)(equalTo("1.4E-45")) && // 1 * 2 ^ -149 == 1.40... * 10 ^ -45
+            assert(7.1e10f.toJson)(
+              equalTo("7.1E10")
+            ) && // Java serializes it to "7.0999998E10" (string of redundant 9s)
+            assert(1.1e15f.toJson)(
+              equalTo("1.1E15")
+            ) && // Java serializes it to "1.09999998E15" (string of redundant 9s)
+            assert(1.0e17f.toJson)(
+              equalTo("1.0E17")
+            ) &&                                       // Java serializes it to "9.9999998E16" (string of redundant 9s)
+            assert(6.3e9f.toJson)(equalTo("6.3E9")) && // Java serializes it to "6.3000003E9" (string of redundant 0s)
+            assert(3.0e10f.toJson)(
+              equalTo("3.0E10")
+            ) && // Java serializes it to "3.0000001E10" (string of redundant 0s)
+            assert(1.1e10f.toJson)(
+              equalTo("1.1E10")
+            ) && // Java serializes it to "1.10000005E10" (string of redundant 0s)
+            assert((-6.9390464e7f).toJson)(
+              equalTo("-6.939046E7")
+            ) && // See the issue: https://github.com/zio/zio-json/pull/375
+            assert((-6939.0464f).toJson)(
+              equalTo("-6939.0464")
+            ) // See the issue: https://github.com/zio/zio-json/pull/375
+          },
+          test("double") {
+            assert(Double.NaN.toJson)(equalTo("\"NaN\"")) &&
+            assert(Double.PositiveInfinity.toJson)(equalTo("\"Infinity\"")) &&
+            assert(Double.NegativeInfinity.toJson)(equalTo("\"-Infinity\"")) &&
+            assert(0.0d.toJson)(equalTo("0.0")) &&
+            assert((-0.0d).toJson)(equalTo("-0.0")) &&
+            assert(1.0d.toJson)(equalTo("1.0")) &&
+            assert((-1.0d).toJson)(equalTo("-1.0")) &&
+            assert(2.2250738585072014e-308d.toJson)(equalTo("2.2250738585072014E-308")) && // subnormal
+            assert(1.0e7d.toJson)(equalTo("1.0E7")) &&
+            assert((-1.0e7d).toJson)(equalTo("-1.0E7")) &&
+            assert(9999999.999999998d.toJson)(equalTo("9999999.999999998")) &&
+            assert(0.001d.toJson)(equalTo("0.001")) &&
+            assert(9.999999999999998e-4d.toJson)(equalTo("9.999999999999998E-4")) &&
+            assert((-1.7976931348623157e308d).toJson)(equalTo("-1.7976931348623157E308")) && // Double.MinValue
+            assert(4.9e-324d.toJson)(equalTo("4.9E-324")) &&                                 // Double.MinPositiveValue
+            assert(1.7976931348623157e308d.toJson)(equalTo("1.7976931348623157E308")) &&     // Double.MaxValue
+            assert((-2.109808898695963e16d).toJson)(equalTo("-2.109808898695963E16")) &&
+            assert(4.940656e-318d.toJson)(equalTo("4.940656E-318")) &&
+            assert(1.18575755e-316d.toJson)(equalTo("1.18575755E-316")) &&
+            assert(2.989102097996e-312d.toJson)(equalTo("2.989102097996E-312")) &&
+            assert(9.0608011534336e15d.toJson)(equalTo("9.0608011534336E15")) &&
+            assert(4.708356024711512e18d.toJson)(equalTo("4.708356024711512E18")) &&
+            assert(9.409340012568248e18d.toJson)(equalTo("9.409340012568248E18")) &&
+            assert(1.8531501765868567e21d.toJson)(equalTo("1.8531501765868567E21")) &&
+            assert((-3.347727380279489e33d).toJson)(equalTo("-3.347727380279489E33")) &&
+            assert(1.9430376160308388e16d.toJson)(equalTo("1.9430376160308388E16")) &&
+            assert((-6.9741824662760956e19d).toJson)(equalTo("-6.9741824662760956E19")) &&
+            assert(4.3816050601147837e18d.toJson)(equalTo("4.3816050601147837E18")) &&
+            assert(7.1202363472230444e-307d.toJson)(equalTo("7.120236347223045E-307")) &&
+            assert(3.67301024534615e16d.toJson)(equalTo("3.67301024534615E16")) &&
+            assert(5.9604644775390625e-8d.toJson)(equalTo("5.960464477539063E-8")) &&
+            assert(1.0e-322d.toJson)(equalTo("9.9E-323")) && // 20 * 2 ^ -1074 == 9.88... * 10 ^ -323
+            assert(5.0e-324d.toJson)(equalTo("4.9E-324")) && // 1 * 2 ^ -1074 == 4.94... * 10 ^ -324
+            assert(1.0e23d.toJson)(
+              equalTo("1.0E23")
+            ) && // Java serializes it to "9.999999999999999E22" (string of redundant 9s)
+            assert(8.41e21d.toJson)(
+              equalTo("8.41E21")
+            ) && // Java serializes it to "8.409999999999999E21" (string of redundant 9s)
+            assert(7.3879e20d.toJson)(
+              equalTo("7.3879E20")
+            ) && // Java serializes it to "7.387900000000001E20" (string of redundant 0s)
+            assert(3.1e22d.toJson)(
+              equalTo("3.1E22")
+            ) && // Java serializes it to "3.1000000000000002E22" (string of redundant 0s)
+            assert(5.63e21d.toJson)(
+              equalTo("5.63E21")
+            ) && // Java serializes it to "5.630000000000001E21" (string of redundant 0s)
+            assert(2.82879384806159e17d.toJson)(
+              equalTo("2.82879384806159E17")
+            ) && // Java serializes it to "2.82879384806159008E17" (18 digits, even though 17 digits are *always* enough)
+            assert(1.387364135037754e18d.toJson)(
+              equalTo("1.387364135037754E18")
+            ) && // Java serializes it to "1.38736413503775411E18" (18 digits, even though 17 digits are *always* enough)
+            assert(1.45800632428665e17d.toJson)(
+              equalTo("1.45800632428665E17")
+            ) && // Java serializes it to "1.45800632428664992E17" (18 digits, even though 17 digits are *always* enough)
+            assert(1.790086667993e18d.toJson)(
+              equalTo("1.790086667993E18")
+            ) && // Java serializes it to "1.79008666799299994E18" (5 digits too much)
+            assert(2.273317134858e18d.toJson)(
+              equalTo("2.273317134858E18")
+            ) && // Java serializes it to "2.27331713485799987E18" (5 digits too much)
+            assert(7.68905065813e17d.toJson)(
+              equalTo("7.68905065813E17")
+            ) && // Java serializes it to "7.6890506581299994E17" (5 digits too much)
+            assert(1.9400994884341945e25d.toJson)(
+              equalTo("1.9400994884341945E25")
+            ) && // Java serializes it to "1.9400994884341944E25" (not the closest to the intermediate double)
+            assert(3.6131332396758635e25d.toJson)(
+              equalTo("3.6131332396758635E25")
+            ) && // Java serializes it to "3.6131332396758634E25" (not the closest to the intermediate double)
+            assert(2.5138990223946153e25d.toJson)(
+              equalTo("2.5138990223946153E25")
+            ) && // Java serializes it to "2.5138990223946152E25" (not the closest to the intermediate double)
+            assert((-3.644554028000364e16d).toJson)(
+              equalTo("-3.644554028000364E16")
+            ) && // See the issue: https://github.com/zio/zio-json/pull/375
+            assert((-6939.0464d).toJson)(
+              equalTo("-6939.0464")
+            ) // See the issue: https://github.com/zio/zio-json/pull/375
+          },
+          test("other numerics") {
             val exampleBigIntStr     = "170141183460469231731687303715884105728"
             val exampleBigDecimalStr = "170141183460469231731687303715884105728.4433"
             assert((1: Byte).toJson)(equalTo("1")) &&
@@ -41,17 +199,7 @@ object EncoderSpec extends DefaultRunnableSpec {
             assert(new java.math.BigInteger("1").toJson)(equalTo("1")) &&
             assert(new java.math.BigInteger(exampleBigIntStr).toJson)(equalTo(exampleBigIntStr)) &&
             assert(BigInt(exampleBigIntStr).toJson)(equalTo(exampleBigIntStr)) &&
-            assert(BigDecimal(exampleBigDecimalStr).toJson)(equalTo(exampleBigDecimalStr)) &&
-            assert(1.0f.toJson)(equalTo("1.0")) &&
-            assert(1.0d.toJson)(equalTo("1.0"))
-          } @@ jvmOnly,
-          test("NaN / Infinity") {
-            assert(Float.NaN.toJson)(equalTo("\"NaN\"")) &&
-            assert(Float.PositiveInfinity.toJson)(equalTo("\"Infinity\"")) &&
-            assert(Float.NegativeInfinity.toJson)(equalTo("\"-Infinity\"")) &&
-            assert(Double.NaN.toJson)(equalTo("\"NaN\"")) &&
-            assert(Double.PositiveInfinity.toJson)(equalTo("\"Infinity\"")) &&
-            assert(Double.NegativeInfinity.toJson)(equalTo("\"-Infinity\""))
+            assert(BigDecimal(exampleBigDecimalStr).toJson)(equalTo(exampleBigDecimalStr))
           }
         ),
         test("options") {
@@ -137,7 +285,7 @@ object EncoderSpec extends DefaultRunnableSpec {
           ) &&
           assert(CoupleOfThings(0, None, true).toJsonPretty)(equalTo("{\n  \"j\" : 0,\n  \"b\" : true\n}")) &&
           assert(OptionalAndRequired(None, "foo").toJson)(equalTo("""{"s":"foo"}"""))
-        } @@ jvmOnly,
+        },
         test("sum encoding") {
           import examplesum._
 
@@ -184,7 +332,7 @@ object EncoderSpec extends DefaultRunnableSpec {
             assert(new java.math.BigInteger("1").toJsonAST)(isRight(equalTo(Json.Num(1)))) &&
             assert(1.0f.toJsonAST)(isRight(equalTo(Json.Num(1)))) &&
             assert(1.0d.toJsonAST)(isRight(equalTo(Json.Num(1))))
-          } @@ jvmOnly
+          }
         ),
         test("options") {
           assert((None: Option[Int]).toJsonAST)(isRight(equalTo(Json.Null))) &&
@@ -232,7 +380,7 @@ object EncoderSpec extends DefaultRunnableSpec {
             isRight(equalTo(Json.Obj("j" -> Json.Num(0), "b" -> Json.Bool(true))))
           ) &&
           assert(OptionalAndRequired(None, "foo").toJsonAST)(isRight(equalTo(Json.Obj("s" -> Json.Str("foo")))))
-        } @@ jvmOnly,
+        },
         test("sum encoding") {
           import examplesum._
 


### PR DESCRIPTION
The `.` character was inserted without taking in account that its position is greater by 1 for negative numbers.
So the number like `-3.644554028000364E16` was serialized as `-.3644554028000364E16`

Also, stripping of trailing zeros after `.` was not tested properly, so the short number like `1.0E7` was serialized as `1.00E7`.