### PR TITLE
Add eraseEither combinator to JsonEncoder/JsonCodec

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -23,16 +23,28 @@ import scala.collection.immutable
  * intCodec.encodeJson(intCodec.encodeJson(42)) == Right(42)
  * }}
  */
-trait JsonCodec[A] extends JsonDecoder[A] with JsonEncoder[A] {
+trait JsonCodec[A] extends JsonDecoder[A] with JsonEncoder[A] { self =>
   def encoder: JsonEncoder[A]
   def decoder: JsonDecoder[A]
 
   override def xmap[B](f: A => B, g: B => A): JsonCodec[B] =
     JsonCodec(encoder.contramap(g), decoder.map(f))
+
+  def eraseEither[B](that: JsonCodec[B]): JsonCodec[Either[A, B]] =
+    JsonCodec.eraseEither(self, that)
+
 }
 
 object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 {
   def apply[A](implicit jsonCodec: JsonCodec[A]): JsonCodec[A] = jsonCodec
+
+  def eraseEither[A, B](A: JsonCodec[A], B: JsonCodec[B]): JsonCodec[Either[A, B]] =
+    JsonCodec(
+      JsonEncoder.eraseEither[A, B](A, B),
+      A.decoder
+        .map(x => Left(x): Either[A, B])
+        .orElse(B.decoder.map(x => Right(x): Either[A, B]))
+    )
 
   implicit val string: JsonCodec[String]                   = JsonCodec(JsonEncoder.string, JsonDecoder.string)
   implicit val boolean: JsonCodec[Boolean]                 = JsonCodec(JsonEncoder.boolean, JsonDecoder.boolean)


### PR DESCRIPTION
Hello,

I had a need for this encoder and codec (during a spartan session) and we thought with @jdegoes it could be added to zio.json.

Basically, I had this kind of structure:

```scala
    sealed trait StringOrNumber extends Any
    object StringOrNumber {
      final case class Str(s: String) extends AnyVal with StringOrNumber
      final case class Num(s: BigDecimal)   extends AnyVal with StringOrNumber
}
```
for which I can derive a codec based on an either but the result JSON must be without `Right` or `Left` fields so I needed to code another encoder.

We gave the name `eraseEither` because it's kind of forgetting the either structure to give just the value.

I locally launch `compile` and `test` and prepare `prepare` from the contributor doc it seems all.