### PR TITLE
Use nested encoder for `isNothing`

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -192,7 +192,11 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
       case Some(a) => A.unsafeEncode(a, indent, out)
     }
 
-    override def isNothing(a: Option[A]): Boolean = a.isEmpty
+    override def isNothing(a: Option[A]): Boolean =
+      a match {
+        case Some(value) => A.isNothing(value)
+        case None        => true
+      }
 
     override final def toJsonAST(a: Option[A]): Either[String, Json] =
       a match {


### PR DESCRIPTION
Option's implementation of `isNothing` did not delegate to the nested Encoder in the `Some` case. One could argue for either approach, but I think this makes more sense.