### PR TITLE
More efficient serialization of collections, `scala.Either`, and `java.time._` types

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -8,6 +8,7 @@ import zio.{ Chunk, NonEmptyChunk }
 import java.util.UUID
 import scala.annotation._
 import scala.collection.{ immutable, mutable }
+import scala.reflect.ClassTag
 
 trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
   self =>
@@ -101,7 +102,7 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
   final def narrow[B <: A]: JsonEncoder[B] = self.asInstanceOf[JsonEncoder[B]]
 }
 
-object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
+object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 {
   def apply[A](implicit a: JsonEncoder[A]): JsonEncoder[A] = a
 
   implicit val string: JsonEncoder[String] = new JsonEncoder[String] {
@@ -136,12 +137,12 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
 
     override def unsafeEncode(a: Char, indent: Option[Int], out: Write): Unit = {
       out.write('"')
-      a match {
+      (a: @switch) match {
         case '"'  => out.write("\\\"")
         case '\\' => out.write("\\\\")
         case c =>
           if (c < ' ') out.write("\\u%04x".format(c.toInt))
-          else out.write(c.toString)
+          else out.write(c)
       }
       out.write('"')
     }
@@ -150,11 +151,11 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
       Right(Json.Str(a.toString))
   }
 
-  private[json] def explicit[A](f: A => String, toAst: A => Json): JsonEncoder[A] = new JsonEncoder[A] {
+  private[json] def explicit[A](f: A => String, g: A => Json): JsonEncoder[A] = new JsonEncoder[A] {
     def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write(f(a))
 
     override final def toJsonAST(a: A): Either[String, Json] =
-      Right(toAst(a))
+      Right(g(a))
   }
 
   private[json] def stringify[A](f: A => String): JsonEncoder[A] = new JsonEncoder[A] {
@@ -192,16 +193,16 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
       case Some(a) => A.unsafeEncode(a, indent, out)
     }
 
-    override def isNothing(a: Option[A]): Boolean =
-      a match {
-        case Some(value) => A.isNothing(value)
-        case None        => true
+    override def isNothing(oa: Option[A]): Boolean =
+      oa match {
+        case None    => true
+        case Some(a) => A.isNothing(a)
       }
 
-    override final def toJsonAST(a: Option[A]): Either[String, Json] =
-      a match {
-        case Some(value) => A.toJsonAST(value)
-        case None        => Right(Json.Null)
+    override final def toJsonAST(oa: Option[A]): Either[String, Json] =
+      oa match {
+        case None    => Right(Json.Null)
+        case Some(a) => A.toJsonAST(a)
       }
   }
 
@@ -210,75 +211,120 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority0 {
     case Some(i) => Some(i + 1)
   }
 
-  def pad(indent: Option[Int], out: Write): Unit =
-    indent.foreach(i => out.write("\n" + ("  " * i)))
+  def pad(indent: Option[Int], out: Write): Unit = indent match {
+    case None => ()
+    case Some(n) =>
+      out.write('\n')
+      var i = n
+      while (i > 0) {
+        out.write("  ")
+        i -= 1
+      }
+  }
 
   implicit def either[A, B](implicit A: JsonEncoder[A], B: JsonEncoder[B]): JsonEncoder[Either[A, B]] =
     new JsonEncoder[Either[A, B]] {
-
       def unsafeEncode(eab: Either[A, B], indent: Option[Int], out: Write): Unit = {
         out.write('{')
+        if (indent.isDefined) unsafeEncodePadded(eab, indent, out)
+        else unsafeEncodeCompact(eab, indent, out)
+        out.write('}')
+      }
+
+      private[this] def unsafeEncodeCompact(eab: Either[A, B], indent: Option[Int], out: Write): Unit =
+        eab match {
+          case Left(a) =>
+            out.write("\"Left\":")
+            A.unsafeEncode(a, indent, out)
+          case Right(b) =>
+            out.write("\"Right\":")
+            B.unsafeEncode(b, indent, out)
+        }
+
+      private[this] def unsafeEncodePadded(eab: Either[A, B], indent: Option[Int], out: Write): Unit = {
         val indent_ = bump(indent)
         pad(indent_, out)
         eab match {
           case Left(a) =>
-            out.write("\"Left\"")
-            if (indent.isEmpty) out.write(':')
-            else out.write(" : ")
+            out.write("\"Left\" : ")
             A.unsafeEncode(a, indent_, out)
           case Right(b) =>
-            out.write("\"Right\"")
-            if (indent.isEmpty) out.write(':')
-            else out.write(" : ")
+            out.write("\"Right\" : ")
             B.unsafeEncode(b, indent_, out)
         }
         pad(indent, out)
-        out.write('}')
       }
 
-      override final def toJsonAST(a: Either[A, B]): Either[String, Json] =
-        a match {
-          case Left(value)  => A.toJsonAST(value).map(v => Json.Obj(Chunk("Left" -> v)))
-          case Right(value) => B.toJsonAST(value).map(v => Json.Obj(Chunk("Right" -> v)))
+      override final def toJsonAST(eab: Either[A, B]): Either[String, Json] =
+        eab match {
+          case Left(a)  => A.toJsonAST(a).map(v => Json.Obj(Chunk.single("Left" -> v)))
+          case Right(b) => B.toJsonAST(b).map(v => Json.Obj(Chunk.single("Right" -> v)))
         }
     }
 
   def eraseEither[A, B](implicit A: JsonEncoder[A], B: JsonEncoder[B]): JsonEncoder[Either[A, B]] =
     new JsonEncoder[Either[A, B]] {
-      def unsafeEncode(
-        a: Either[A, B],
-        indent: Option[Int],
-        out: Write
-      ): Unit =
-        a match {
-          case Left(s)  => A.unsafeEncode(s, indent, out)
-          case Right(l) => B.unsafeEncode(l, indent, out)
+      def unsafeEncode(eab: Either[A, B], indent: Option[Int], out: Write): Unit =
+        eab match {
+          case Left(a)  => A.unsafeEncode(a, indent, out)
+          case Right(b) => B.unsafeEncode(b, indent, out)
         }
     }
-}
-
-private[json] trait EncoderLowPriority0 extends EncoderLowPriority1 {
-  this: JsonEncoder.type =>
-  implicit def chunk[A: JsonEncoder]: JsonEncoder[Chunk[A]] =
-    seq[A].contramap(_.toSeq)
-
-  implicit def nonEmptyChunk[A: JsonEncoder]: JsonEncoder[NonEmptyChunk[A]] =
-    seq[A].contramap(_.toSeq)
-
-  implicit def array[A: JsonEncoder: reflect.ClassTag]: JsonEncoder[Array[A]] =
-    seq[A].contramap(_.toSeq)
-
-  implicit def hashSet[A: JsonEncoder]: JsonEncoder[immutable.HashSet[A]] =
-    list[A].contramap(_.toList)
-
-  implicit def hashMap[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[immutable.HashMap[K, V]] =
-    keyValueChunk[K, V].contramap(Chunk.fromIterable(_))
 }
 
 private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
   this: JsonEncoder.type =>
 
+  implicit def array[A](implicit A: JsonEncoder[A], classTag: ClassTag[A]): JsonEncoder[Array[A]] =
+    new JsonEncoder[Array[A]] {
+      def unsafeEncode(as: Array[A], indent: Option[Int], out: Write): Unit =
+        if (as.isEmpty) out.write("[]")
+        else {
+          out.write('[')
+          if (indent.isDefined) unsafeEncodePadded(as, indent, out)
+          else unsafeEncodeCompact(as, indent, out)
+          out.write(']')
+        }
+
+      private[this] def unsafeEncodeCompact(as: Array[A], indent: Option[Int], out: Write): Unit = {
+        val len = as.length
+        var i   = 0
+        while (i < len) {
+          if (i != 0) out.write(',')
+          A.unsafeEncode(as(i), indent, out)
+          i += 1
+        }
+      }
+
+      private[this] def unsafeEncodePadded(as: Array[A], indent: Option[Int], out: Write): Unit = {
+        val indent_ = bump(indent)
+        pad(indent_, out)
+        val len = as.length
+        var i   = 0
+        while (i < len) {
+          if (i != 0) {
+            out.write(',')
+            pad(indent_, out)
+          }
+          A.unsafeEncode(as(i), indent_, out)
+          i += 1
+        }
+        pad(indent, out)
+      }
+
+      override final def toJsonAST(as: Array[A]): Either[String, Json] =
+        as.map(A.toJsonAST)
+          .foldLeft[Either[String, Chunk[Json]]](Right(Chunk.empty)) { (s, i) =>
+            s.flatMap(chunk => i.map(item => chunk :+ item))
+          }
+          .map(Json.Arr(_))
+    }
+
   implicit def seq[A: JsonEncoder]: JsonEncoder[Seq[A]] = iterable[A, Seq]
+
+  implicit def chunk[A: JsonEncoder]: JsonEncoder[Chunk[A]] = iterable[A, Chunk]
+
+  implicit def nonEmptyChunk[A: JsonEncoder]: JsonEncoder[NonEmptyChunk[A]] = chunk[A].contramap(_.toChunk)
 
   implicit def indexedSeq[A: JsonEncoder]: JsonEncoder[IndexedSeq[A]] = iterable[A, IndexedSeq]
 
@@ -294,17 +340,22 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
 
   implicit def set[A: JsonEncoder]: JsonEncoder[Set[A]] = iterable[A, Set]
 
+  implicit def hashSet[A: JsonEncoder]: JsonEncoder[immutable.HashSet[A]] = iterable[A, immutable.HashSet]
+
+  implicit def sortedSet[A: Ordering: JsonEncoder]: JsonEncoder[immutable.SortedSet[A]] =
+    iterable[A, immutable.SortedSet]
+
   implicit def map[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[Map[K, V]] =
     keyValueIterable[K, V, Map]
+
+  implicit def hashMap[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[immutable.HashMap[K, V]] =
+    keyValueIterable[K, V, immutable.HashMap]
 
   implicit def mutableMap[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[mutable.Map[K, V]] =
     keyValueIterable[K, V, mutable.Map]
 
   implicit def sortedMap[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[collection.SortedMap[K, V]] =
     keyValueIterable[K, V, collection.SortedMap]
-
-  implicit def sortedSet[A: Ordering: JsonEncoder]: JsonEncoder[immutable.SortedSet[A]] =
-    list[A].contramap(_.toList)
 }
 
 private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
@@ -312,34 +363,46 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
 
   implicit def iterable[A, T[X] <: Iterable[X]](implicit A: JsonEncoder[A]): JsonEncoder[T[A]] =
     new JsonEncoder[T[A]] {
+      def unsafeEncode(as: T[A], indent: Option[Int], out: Write): Unit =
+        if (as.isEmpty) out.write("[]")
+        else {
+          out.write('[')
+          if (indent.isDefined) unsafeEncodePadded(as, indent, out)
+          else unsafeEncodeCompact(as, indent, out)
+          out.write(']')
+        }
 
-      def unsafeEncode(as: T[A], indent: Option[Int], out: Write): Unit = {
-        if (as.isEmpty) return out.write("[]")
+      private[this] def unsafeEncodeCompact(as: T[A], indent: Option[Int], out: Write): Unit =
+        as.foreach {
+          var first = true
+          a =>
+            if (first) first = false
+            else out.write(',')
+            A.unsafeEncode(a, indent, out)
+        }
 
-        out.write('[')
+      private[this] def unsafeEncodePadded(as: T[A], indent: Option[Int], out: Write): Unit = {
         val indent_ = bump(indent)
         pad(indent_, out)
-        var first = true
-        as.foreach { a =>
-          if (first)
-            first = false
-          else {
-            out.write(',')
-            if (!indent.isEmpty)
+        as.foreach {
+          var first = true
+          a =>
+            if (first) first = false
+            else {
+              out.write(',')
               pad(indent_, out)
-          }
-          A.unsafeEncode(a, indent_, out)
+            }
+            A.unsafeEncode(a, indent_, out)
         }
         pad(indent, out)
-        out.write(']')
       }
 
-      override final def toJsonAST(a: T[A]): Either[String, Json] =
-        a.map(A.toJsonAST)
+      override final def toJsonAST(as: T[A]): Either[String, Json] =
+        as.map(A.toJsonAST)
           .foldLeft[Either[String, Chunk[Json]]](Right(Chunk.empty)) { (s, i) =>
             s.flatMap(chunk => i.map(item => chunk :+ item))
           }
-          .map(Json.Arr.apply)
+          .map(Json.Arr(_))
     }
 
   // not implicit because this overlaps with encoders for lists of tuples
@@ -347,42 +410,58 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
     K: JsonFieldEncoder[K],
     A: JsonEncoder[A]
   ): JsonEncoder[T[K, A]] = new JsonEncoder[T[K, A]] {
+    def unsafeEncode(kvs: T[K, A], indent: Option[Int], out: Write): Unit =
+      if (kvs.isEmpty) out.write("{}")
+      else {
+        out.write('{')
+        if (indent.isDefined) unsafeEncodePadded(kvs, indent, out)
+        else unsafeEncodeCompact(kvs, indent, out)
+        out.write('}')
+      }
 
-    def unsafeEncode(kvs: T[K, A], indent: Option[Int], out: Write): Unit = {
-      if (kvs.isEmpty) return out.write("{}")
+    private[this] def unsafeEncodeCompact(kvs: T[K, A], indent: Option[Int], out: Write): Unit =
+      kvs.foreach {
+        var first = true
+        kv =>
+          if (!A.isNothing(kv._2)) {
+            if (first) first = false
+            else out.write(',')
+            string.unsafeEncode(K.unsafeEncodeField(kv._1), indent, out)
+            out.write(':')
+            A.unsafeEncode(kv._2, indent, out)
+          }
+      }
 
-      out.write('{')
+    private[this] def unsafeEncodePadded(kvs: T[K, A], indent: Option[Int], out: Write): Unit = {
       val indent_ = bump(indent)
       pad(indent_, out)
-      var first = true
-      kvs.foreach { case (k, a) =>
-        if (!A.isNothing(a)) {
-          if (first)
-            first = false
-          else {
-            out.write(',')
-            if (!indent.isEmpty)
+      kvs.foreach {
+        var first = true
+        kv =>
+          if (!A.isNothing(kv._2)) {
+            if (first) first = false
+            else {
+              out.write(',')
               pad(indent_, out)
+            }
+            string.unsafeEncode(K.unsafeEncodeField(kv._1), indent_, out)
+            out.write(" : ")
+            A.unsafeEncode(kv._2, indent_, out)
           }
-
-          string.unsafeEncode(K.unsafeEncodeField(k), indent_, out)
-          if (indent.isEmpty) out.write(':')
-          else out.write(" : ")
-          A.unsafeEncode(a, indent_, out)
-        }
       }
       pad(indent, out)
-      out.write('}')
     }
 
-    override final def toJsonAST(a: T[K, A]): Either[String, Json] =
-      a.foldLeft[Either[String, Chunk[(String, Json)]]](Right(Chunk.empty)) { case (s, (k, v)) =>
-        for {
-          chunk <- s
-          key    = K.unsafeEncodeField(k)
-          value <- A.toJsonAST(v)
-        } yield if (value == Json.Null) chunk else chunk :+ (key -> value)
-      }.map(Json.Obj.apply)
+    override final def toJsonAST(kvs: T[K, A]): Either[String, Json] =
+      kvs
+        .foldLeft[Either[String, Chunk[(String, Json)]]](Right(Chunk.empty)) { case (s, (k, v)) =>
+          for {
+            chunk <- s
+            key    = K.unsafeEncodeField(k)
+            value <- A.toJsonAST(v)
+          } yield if (value == Json.Null) chunk else chunk :+ (key -> value)
+        }
+        .map(Json.Obj(_))
   }
 
   // not implicit because this overlaps with encoders for lists of tuples

--- a/zio-json/shared/src/main/scala/zio/json/javatime/serializers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/serializers.scala
@@ -68,16 +68,11 @@ private[json] object serializers {
     val minute     = secsOfHour * 17477 >> 20 // divide a small positive int by 60
     val second     = secsOfHour - minute * 60
     appendYear(year, s)
-    s.append('-')
-    append2Digits(month, s)
-    s.append('-')
-    append2Digits(day, s)
-    s.append('T')
-    append2Digits(hour, s)
-    s.append(':')
-    append2Digits(minute, s)
-    s.append(':')
-    append2Digits(second, s)
+    append2Digits(month, s.append('-'))
+    append2Digits(day, s.append('-'))
+    append2Digits(hour, s.append('T'))
+    append2Digits(minute, s.append(':'))
+    append2Digits(second, s.append(':'))
     val nano = x.getNano
     if (nano != 0) {
       s.append('.')
@@ -91,8 +86,7 @@ private[json] object serializers {
         if (r2 != 0) append3Digits(r2, s)
       }
     }
-    s.append('Z')
-    s.toString
+    s.append('Z').toString
   }
 
   def toString(x: LocalDate): String = {
@@ -104,8 +98,7 @@ private[json] object serializers {
   def toString(x: LocalDateTime): String = {
     val s = new java.lang.StringBuilder(32)
     appendLocalDate(x.toLocalDate, s)
-    s.append('T')
-    appendLocalTime(x.toLocalTime, s)
+    appendLocalTime(x.toLocalTime, s.append('T'))
     s.toString
   }
 
@@ -117,19 +110,15 @@ private[json] object serializers {
 
   def toString(x: MonthDay): String = {
     val s = new java.lang.StringBuilder(8)
-    s.append('-')
-    s.append('-')
-    append2Digits(x.getMonthValue, s)
-    s.append('-')
-    append2Digits(x.getDayOfMonth, s)
+    append2Digits(x.getMonthValue, s.append('-').append('-'))
+    append2Digits(x.getDayOfMonth, s.append('-'))
     s.toString
   }
 
   def toString(x: OffsetDateTime): String = {
     val s = new java.lang.StringBuilder(48)
     appendLocalDate(x.toLocalDate, s)
-    s.append('T')
-    appendLocalTime(x.toLocalTime, s)
+    appendLocalTime(x.toLocalTime, s.append('T'))
     appendZoneOffset(x.getOffset, s)
     s.toString
   }
@@ -165,23 +154,17 @@ private[json] object serializers {
   def toString(x: YearMonth): String = {
     val s = new java.lang.StringBuilder(16)
     appendYear(x.getYear, s)
-    s.append('-')
-    append2Digits(x.getMonthValue, s)
+    append2Digits(x.getMonthValue, s.append('-'))
     s.toString
   }
 
   def toString(x: ZonedDateTime): String = {
     val s = new java.lang.StringBuilder(48)
     appendLocalDate(x.toLocalDate, s)
-    s.append('T')
-    appendLocalTime(x.toLocalTime, s)
+    appendLocalTime(x.toLocalTime, s.append('T'))
     appendZoneOffset(x.getOffset, s)
     val zone = x.getZone
-    if (!zone.isInstanceOf[ZoneOffset]) {
-      s.append('[')
-      s.append(zone.getId)
-      s.append(']')
-    }
+    if (!zone.isInstanceOf[ZoneOffset]) s.append('[').append(zone.getId).append(']')
     s.toString
   }
 
@@ -195,18 +178,14 @@ private[json] object serializers {
 
   private[this] def appendLocalDate(x: LocalDate, s: java.lang.StringBuilder): Unit = {
     appendYear(x.getYear, s)
-    s.append('-')
-    append2Digits(x.getMonthValue, s)
-    s.append('-')
-    append2Digits(x.getDayOfMonth, s)
+    append2Digits(x.getMonthValue, s.append('-'))
+    append2Digits(x.getDayOfMonth, s.append('-'))
   }
 
   private[this] def appendLocalTime(x: LocalTime, s: java.lang.StringBuilder): Unit = {
     append2Digits(x.getHour, s)
-    s.append(':')
-    append2Digits(x.getMinute, s)
-    s.append(':')
-    append2Digits(x.getSecond, s)
+    append2Digits(x.getMinute, s.append(':'))
+    append2Digits(x.getSecond, s.append(':'))
     val nano = x.getNano
     if (nano != 0) {
       val dotPos = s.length
@@ -237,10 +216,7 @@ private[json] object serializers {
       val q2 = r1 * 17477 >> 20 // divide a small positive int by 60
       val r2 = r1 - q2 * 60
       append2Digits(q2, s)
-      if (r2 != 0) {
-        s.append(':')
-        append2Digits(r2, s)
-      }
+      if (r2 != 0) append2Digits(r2, s.append(':'))
     }
   }
 
@@ -248,25 +224,24 @@ private[json] object serializers {
     if (x >= 0) {
       if (x < 10000) append4Digits(x, s)
       else s.append('+').append(x): Unit
-    } else if (x > -10000) {
-      s.append('-')
-      append4Digits(-x, s)
-    } else s.append(x): Unit
+    } else if (x > -10000) append4Digits(-x, s.append('-'))
+    else s.append(x): Unit
 
-  private[this] def append4Digits(x: Int, s: java.lang.StringBuilder): Unit =
-    if (x > 999) s.append(x): Unit
-    else if (x > 99) s.append('0').append(x): Unit
-    else if (x > 9) s.append('0').append('0').append(x): Unit
-    else s.append('0').append('0').append('0').append(x): Unit
+  private[this] def append4Digits(x: Int, s: java.lang.StringBuilder): Unit = {
+    val q = x * 5243 >> 19 // divide a 4-digit positive int by 100
+    append2Digits(q, s)
+    append2Digits(x - q * 100, s)
+  }
 
-  private[this] def append3Digits(x: Int, s: java.lang.StringBuilder): Unit =
-    if (x > 99) s.append(x): Unit
-    else if (x > 9) s.append('0').append(x): Unit
-    else s.append('0').append('0').append(x): Unit
+  private[this] def append3Digits(x: Int, s: java.lang.StringBuilder): Unit = {
+    val q = x * 1311 >> 17 // divide a 3-digit positive int by 100
+    append2Digits(x - q * 100, s.append((q + '0').toChar))
+  }
 
-  private[this] def append2Digits(x: Int, s: java.lang.StringBuilder): Unit =
-    if (x > 9) s.append(x): Unit
-    else s.append('0').append(x): Unit
+  private[this] def append2Digits(x: Int, s: java.lang.StringBuilder): Unit = {
+    val q = x * 103 >> 10 // divide a 2-digit positive int by 10
+    s.append((q + '0').toChar).append((x + '0' - q * 10).toChar): Unit
+  }
 
   private[this] def to400YearCycle(day: Long): Int =
     (day / 146097).toInt // 146097 == number of days in a 400 year cycle

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -4,7 +4,6 @@ import zio._
 import zio.json._
 import zio.json.ast.Json
 import zio.test.Assertion._
-import zio.test.environment.Live
 import zio.test.{ TestAspect, _ }
 
 import java.time.{ Duration, OffsetDateTime, ZonedDateTime }

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -3,7 +3,6 @@ package testzio.json
 import zio.json._
 import zio.json.ast.Json
 import zio.test.Assertion._
-import zio.test.TestAspect._
 import zio.test._
 import zio.{ Chunk, NonEmptyChunk }
 


### PR DESCRIPTION
Results for OpenJDK 18 on my notebook:
## Before
```
[info] Benchmark                              (size)   Mode  Cnt         Score         Error  Units
[info] ADTWriting.zioJson                        N/A  thrpt    5    751137.135 ±   60844.184  ops/s
[info] AnyValsWriting.zioJson                    N/A  thrpt    5   1992064.842 ±  230755.542  ops/s
[info] ArrayOfBigDecimalsWriting.zioJson         128  thrpt    5     29949.979 ±     194.004  ops/s
[info] ArrayOfBooleansWriting.zioJson            128  thrpt    5    382517.605 ±    1383.240  ops/s
[info] ArrayOfBytesWriting.zioJson               128  thrpt    5    327511.459 ±   12887.265  ops/s
[info] ArrayOfCharsWriting.zioJson               128  thrpt    5    320712.508 ±   16738.339  ops/s
[info] ArrayOfDoublesWriting.zioJson             128  thrpt    5     63960.547 ±     813.024  ops/s
[info] ArrayOfDurationsWriting.zioJson           128  thrpt    5     60878.148 ±    4007.515  ops/s
[info] ArrayOfEnumADTsWriting.zioJson            128  thrpt    5    315286.974 ±   19576.020  ops/s
[info] ArrayOfEnumsWriting.zioJson               128  thrpt    5    345687.821 ±    4894.588  ops/s
[info] ArrayOfFloatsWriting.zioJson              128  thrpt    5     90803.752 ±    3823.350  ops/s
[info] ArrayOfInstantsWriting.zioJson            128  thrpt    5     55852.159 ±    4080.762  ops/s
[info] ArrayOfIntsWriting.zioJson                128  thrpt    5    232309.227 ±   13185.652  ops/s
[info] ArrayOfLocalDateTimesWriting.zioJson      128  thrpt    5     58191.175 ±    3890.360  ops/s
[info] ArrayOfLocalDatesWriting.zioJson          128  thrpt    5    116426.580 ±    7886.043  ops/s
[info] ArrayOfLocalTimesWriting.zioJson          128  thrpt    5     86121.884 ±    3637.461  ops/s
[info] ArrayOfLongsWriting.zioJson               128  thrpt    5    164070.273 ±    8967.729  ops/s
[info] ArrayOfMonthDaysWriting.zioJson           128  thrpt    5    148273.712 ±     185.215  ops/s
[info] ArrayOfOffsetDateTimesWriting.zioJson     128  thrpt    5     45906.834 ±    3632.603  ops/s
[info] ArrayOfOffsetTimesWriting.zioJson         128  thrpt    5     62093.539 ±    5495.363  ops/s
[info] ArrayOfPeriodsWriting.zioJson             128  thrpt    5     78696.749 ±    3833.590  ops/s
[info] ArrayOfShortsWriting.zioJson              128  thrpt    5    281872.036 ±   42555.978  ops/s
[info] ArrayOfUUIDsWriting.zioJson               128  thrpt    5    136503.452 ±    3772.384  ops/s
[info] ArrayOfYearMonthsWriting.zioJson          128  thrpt    5    131676.719 ±   15856.098  ops/s
[info] ArrayOfYearsWriting.zioJson               128  thrpt    5    162695.253 ±   23395.225  ops/s
[info] ArrayOfZoneIdsWriting.zioJson             128  thrpt    5    253575.942 ±   10639.567  ops/s
[info] ArrayOfZoneOffsetsWriting.zioJson         128  thrpt    5    137081.750 ±   18349.846  ops/s
[info] ArrayOfZonedDateTimesWriting.zioJson      128  thrpt    5     40339.126 ±    1209.882  ops/s
[info] Base64Writing.zioJson                     128  thrpt    5   4132074.769 ±  593890.913  ops/s
[info] GeoJSONWriting.zioJson                    N/A  thrpt    5      6187.090 ±     746.128  ops/s
[info] GitHubActionsAPIWriting.zioJson           N/A  thrpt    5    200599.336 ±     804.037  ops/s
[info] GoogleMapsAPIWriting.zioJson              N/A  thrpt    5     16176.657 ±     787.875  ops/s
[info] IntWriting.zioJson                        N/A  thrpt    5  17000257.761 ± 2535180.391  ops/s
[info] ListOfBooleansWriting.zioJson             128  thrpt    5    373433.221 ±   30617.585  ops/s
[info] MapOfIntsToBooleansWriting.zioJson        128  thrpt    5    105822.927 ±    1491.095  ops/s
[info] NestedStructsWriting.zioJson              128  thrpt    5    270221.312 ±    7824.922  ops/s
[info] PrimitivesWriting.zioJson                 N/A  thrpt    5   2352687.116 ±   86622.281  ops/s
[info] SetOfIntsWriting.zioJson                  128  thrpt    5    264131.892 ±   29876.933  ops/s
[info] StringOfAsciiCharsWriting.zioJson         128  thrpt    5   1999953.566 ±  129458.803  ops/s
[info] StringOfNonAsciiCharsWriting.zioJson      128  thrpt    5    910241.118 ±  143804.693  ops/s
[info] VectorOfBooleansWriting.zioJson           128  thrpt    5    413664.436 ±    2254.215  ops/s
```
## After
```
[info] Benchmark                              (size)   Mode  Cnt         Score         Error  Units
[info] ADTWriting.zioJson                        N/A  thrpt    5    765205.782 ±   45223.173  ops/s
[info] AnyValsWriting.zioJson                    N/A  thrpt    5   2003174.417 ±  176973.603  ops/s
[info] ArrayOfBigDecimalsWriting.zioJson         128  thrpt    5     30297.028 ±    1656.736  ops/s
[info] ArrayOfBooleansWriting.zioJson            128  thrpt    5    458533.793 ±   28382.429  ops/s
[info] ArrayOfBytesWriting.zioJson               128  thrpt    5    357977.852 ±   20938.364  ops/s
[info] ArrayOfCharsWriting.zioJson               128  thrpt    5    456212.528 ±   27073.913  ops/s
[info] ArrayOfDoublesWriting.zioJson             128  thrpt    5     65973.075 ±     630.854  ops/s
[info] ArrayOfDurationsWriting.zioJson           128  thrpt    5     65292.186 ±    2181.715  ops/s
[info] ArrayOfEnumADTsWriting.zioJson            128  thrpt    5    312215.415 ±   27536.009  ops/s
[info] ArrayOfEnumsWriting.zioJson               128  thrpt    5    361466.648 ±    5993.181  ops/s
[info] ArrayOfFloatsWriting.zioJson              128  thrpt    5     95933.208 ±    1062.174  ops/s
[info] ArrayOfInstantsWriting.zioJson            128  thrpt    5     92459.782 ±     250.623  ops/s
[info] ArrayOfIntsWriting.zioJson                128  thrpt    5    238332.597 ±   16080.859  ops/s
[info] ArrayOfLocalDateTimesWriting.zioJson      128  thrpt    5     65826.134 ±    3189.740  ops/s
[info] ArrayOfLocalDatesWriting.zioJson          128  thrpt    5    189121.924 ±   13587.510  ops/s
[info] ArrayOfLocalTimesWriting.zioJson          128  thrpt    5    144061.944 ±    2350.764  ops/s
[info] ArrayOfLongsWriting.zioJson               128  thrpt    5    175362.727 ±     211.747  ops/s
[info] ArrayOfMonthDaysWriting.zioJson           128  thrpt    5    245150.019 ±   11447.880  ops/s
[info] ArrayOfOffsetDateTimesWriting.zioJson     128  thrpt    5     52415.651 ±    4449.709  ops/s
[info] ArrayOfOffsetTimesWriting.zioJson         128  thrpt    5    111603.882 ±    7455.122  ops/s
[info] ArrayOfPeriodsWriting.zioJson             128  thrpt    5     80609.331 ±    2497.186  ops/s
[info] ArrayOfShortsWriting.zioJson              128  thrpt    5    295437.180 ±   24011.888  ops/s
[info] ArrayOfUUIDsWriting.zioJson               128  thrpt    5    140624.591 ±     808.847  ops/s
[info] ArrayOfYearMonthsWriting.zioJson          128  thrpt    5    227914.680 ±    1915.558  ops/s
[info] ArrayOfYearsWriting.zioJson               128  thrpt    5    285197.228 ±     473.101  ops/s
[info] ArrayOfZoneIdsWriting.zioJson             128  thrpt    5    267295.825 ±   10305.064  ops/s
[info] ArrayOfZoneOffsetsWriting.zioJson         128  thrpt    5    188215.851 ±    5746.485  ops/s
[info] ArrayOfZonedDateTimesWriting.zioJson      128  thrpt    5     55637.488 ±    2871.643  ops/s
[info] Base64Writing.zioJson                     128  thrpt    5   4053856.014 ±   13990.812  ops/s
[info] GeoJSONWriting.zioJson                    N/A  thrpt    5      6307.678 ±     534.233  ops/s
[info] GitHubActionsAPIWriting.zioJson           N/A  thrpt    5    201647.170 ±    1165.914  ops/s
[info] GoogleMapsAPIWriting.zioJson              N/A  thrpt    5     16444.251 ±     962.177  ops/s
[info] IntWriting.zioJson                        N/A  thrpt    5  17553304.162 ± 1666812.485  ops/s
[info] ListOfBooleansWriting.zioJson             128  thrpt    5    403899.956 ±   25586.063  ops/s
[info] MapOfIntsToBooleansWriting.zioJson        128  thrpt    5    111123.998 ±     825.866  ops/s
[info] NestedStructsWriting.zioJson              128  thrpt    5    263101.546 ±   27989.424  ops/s
[info] PrimitivesWriting.zioJson                 N/A  thrpt    5   2337839.699 ±  253900.390  ops/s
[info] SetOfIntsWriting.zioJson                  128  thrpt    5    257074.244 ±    4841.420  ops/s
[info] StringOfAsciiCharsWriting.zioJson         128  thrpt    5   1867367.087 ±  131764.617  ops/s
[info] StringOfNonAsciiCharsWriting.zioJson      128  thrpt    5    957493.457 ±   69881.943  ops/s
[info] VectorOfBooleansWriting.zioJson           128  thrpt    5    408153.991 ±   45155.071  ops/s
```