### PR TITLE
Change behavior of recording readers to not capture more after rewind

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -148,7 +148,7 @@ private[zio] sealed trait RecordingReader extends RetractReader {
 }
 private[zio] object RecordingReader {
   def apply(in: OneCharReader): RecordingReader =
-    WithRecordingReader(in, 64)
+    new WithRecordingReader(in, 64)
 }
 
 // used to optimise RecordingReader

--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -55,7 +55,6 @@ private[zio] final class RewindTwice
     extends Exception(
       "RecordingReader's rewind was called twice"
     )
-    with NoStackTrace
 
 /**
  * A Reader that can retract and replay the last char that it read.
@@ -186,9 +185,10 @@ private[zio] final class WithRecordingReader(in: OneCharReader, initial: Int)
       if (reading == eob) throw new UnexpectedEnd
       val v = tape(reading)
       reading += 1
-      if (reading >= writing)
+      if (reading >= writing) {
         reading = -1 // caught up
-      writing = -1   // stop recording
+        writing = -1 // stop recording
+      }
       v
     } else {
       val v = in.readChar()
@@ -205,6 +205,7 @@ private[zio] final class WithRecordingReader(in: OneCharReader, initial: Int)
     if (writing != -1)
       reading = 0
     else throw new RewindTwice
+
   def retract(): Unit =
     if (reading == -1) {
       in match {


### PR DESCRIPTION
This is my proposed fix for https://github.com/zio/zio-json/issues/481

The implementation of `orElse` creates a `WithRecordingReader` and `rewind`s it in case the left decoder fails. The right decoder is called with the same recording reader, so it can read the same input that was read until the left side failed. The reader however continues recording the input even after reaching the end of it's "tape", so, when used on top level as in my case, it essentially records the whole input for no reason.

There are only two places in the code where `WithRecordingReader` and `rewind` is used and I believe in both cases the correct behavior is that we don't continue recording after replayed. This means `rewind` can only be called once. 
Also this made the optimization that the detected nested recording readers unusable so I removed that.