### PR TITLE
Monkey-patch support for Scala 3 derives

### DIFF
--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonCodecVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonCodecVersionSpecific

--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonDecoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonDecoderVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonDecoderVersionSpecific

--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonEncoderVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonEncoderVersionSpecific

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
@@ -1,5 +1,5 @@
 package zio.json
 
 trait JsonCodecVersionSpecific {
-  inline def derived[a: deriving.Mirror.Of]: JsonCodec[a] = DeriveJsonCodec.gen[a]
+  inline def derived[A: deriving.Mirror.Of]: JsonCodec[A] = DeriveJsonCodec.gen[A]
 }

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
@@ -1,0 +1,5 @@
+package zio.json
+
+trait JsonCodecVersionSpecific {
+  inline def derived[a: deriving.Mirror.Of]: JsonCodec[a] = DeriveJsonCodec.gen[a]
+}

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
@@ -1,0 +1,5 @@
+package zio.json
+
+trait JsonDecoderVersionSpecific {
+  inline def derived[a: deriving.Mirror.Of]: JsonDecoder[a] = DeriveJsonDecoder.gen[a]
+}

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
@@ -1,5 +1,5 @@
 package zio.json
 
 trait JsonDecoderVersionSpecific {
-  inline def derived[a: deriving.Mirror.Of]: JsonDecoder[a] = DeriveJsonDecoder.gen[a]
+  inline def derived[A: deriving.Mirror.Of]: JsonDecoder[A] = DeriveJsonDecoder.gen[A]
 }

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
@@ -1,5 +1,5 @@
 package zio.json
 
 trait JsonEncoderVersionSpecific {
-  inline def derived[a: deriving.Mirror.Of]: JsonEncoder[a] = DeriveJsonEncoder.gen[a]
+  inline def derived[A: deriving.Mirror.Of]: JsonEncoder[A] = DeriveJsonEncoder.gen[A]
 }

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
@@ -1,0 +1,5 @@
+package zio.json
+
+trait JsonEncoderVersionSpecific {
+  inline def derived[a: deriving.Mirror.Of]: JsonEncoder[a] = DeriveJsonEncoder.gen[a]
+}

--- a/zio-json/shared/src/main/scala/zio/json/codecs.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codecs.scala
@@ -38,7 +38,7 @@ trait JsonCodec[A] extends JsonDecoder[A] with JsonEncoder[A] { self =>
 
 }
 
-object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 {
+object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 with JsonCodecVersionSpecific {
   def apply[A](implicit jsonCodec: JsonCodec[A]): JsonCodec[A] = jsonCodec
 
   def eraseEither[A, B](A: JsonCodec[A], B: JsonCodec[B]): JsonCodec[Either[A, B]] =

--- a/zio-json/shared/src/main/scala/zio/json/decoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/decoder.scala
@@ -215,7 +215,7 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
     decodeJson(Json.encoder.encodeJson(json, None))
 }
 
-object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 {
+object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with JsonDecoderVersionSpecific {
   type JsonError = zio.json.JsonError
   val JsonError = zio.json.JsonError
 

--- a/zio-json/shared/src/main/scala/zio/json/encoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/encoder.scala
@@ -105,7 +105,7 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
   final def narrow[B <: A]: JsonEncoder[B] = self.asInstanceOf[JsonEncoder[B]]
 }
 
-object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 {
+object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with JsonEncoderVersionSpecific {
   def apply[A](implicit a: JsonEncoder[A]): JsonEncoder[A] = a
 
   implicit val string: JsonEncoder[String] = new JsonEncoder[String] {

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedCodecSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedCodecSpec.scala
@@ -1,0 +1,29 @@
+package testzio.json
+
+import zio._
+import zio.json._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+object DerivedCodecSpec extends DefaultRunnableSpec {
+  val spec = suite("DerivedCodecSpec")(
+    testM("Derives for a product type") {
+      assertM(typeCheck {
+        """
+          case class Foo(bar: String) derives JsonCodec
+        """
+      })(isRight(anything))
+    },
+    testM("Derives for a sum type") {
+      assertM(typeCheck {
+        """
+          enum Foo derives JsonCodec:
+            case Bar
+            case Baz(baz: String)
+            case Qux(foo: Foo)
+        """
+      })(isRight(anything))
+    }
+  )
+}

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedCodecSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedCodecSpec.scala
@@ -12,6 +12,8 @@ object DerivedCodecSpec extends DefaultRunnableSpec {
       assertM(typeCheck {
         """
           case class Foo(bar: String) derives JsonCodec
+
+          Foo("bar").toJson.fromJson[Foo]
         """
       })(isRight(anything))
     },
@@ -22,6 +24,8 @@ object DerivedCodecSpec extends DefaultRunnableSpec {
             case Bar
             case Baz(baz: String)
             case Qux(foo: Foo)
+
+          (Foo.Qux(Foo.Bar): Foo).toJson.fromJson[Foo]
         """
       })(isRight(anything))
     }

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -13,6 +13,8 @@ object DerivedDecoderSpec extends DefaultRunnableSpec {
       assertM(typeCheck {
         """
           case class Foo(bar: String) derives JsonDecoder
+
+          "{\"bar\": \"hello\"}".fromJson[Foo]
         """
       })(isRight(anything))
     },
@@ -23,6 +25,8 @@ object DerivedDecoderSpec extends DefaultRunnableSpec {
             case Bar
             case Baz(baz: String)
             case Qux(foo: Foo)
+
+          "{\"Qux\":{\"foo\":{\"Bar\":{}}}}".fromJson[Foo]
         """
       })(isRight(anything))
     }

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -1,0 +1,30 @@
+package testzio.json
+
+import zio._
+import zio.json._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+object DerivedDecoderSpec extends DefaultRunnableSpec {
+
+  val spec = suite("DerivedDecoderSpec")(
+    testM("Derives for a product type") {
+      assertM(typeCheck {
+        """
+          case class Foo(bar: String) derives JsonDecoder
+        """
+      })(isRight(anything))
+    },
+    testM("Derives for a sum type") {
+      assertM(typeCheck {
+        """
+          enum Foo derives JsonDecoder:
+            case Bar
+            case Baz(baz: String)
+            case Qux(foo: Foo)
+        """
+      })(isRight(anything))
+    }
+  )
+}

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
@@ -12,6 +12,8 @@ object DerivedEncoderSpec extends DefaultRunnableSpec {
       assertM(typeCheck {
         """
           case class Foo(bar: String) derives JsonEncoder
+
+          Foo("bar").toJson
         """
       })(isRight(anything))
     },
@@ -22,6 +24,8 @@ object DerivedEncoderSpec extends DefaultRunnableSpec {
             case Bar
             case Baz(baz: String)
             case Qux(foo: Foo)
+
+          (Foo.Qux(Foo.Bar): Foo).toJson
         """
       })(isRight(anything))
     }

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
@@ -1,0 +1,29 @@
+package testzio.json
+
+import zio._
+import zio.json._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestEnvironment
+
+object DerivedEncoderSpec extends DefaultRunnableSpec {
+  val spec = suite("DerivedEncoderSpec")(
+    testM("Derives for a product type") {
+      assertM(typeCheck {
+        """
+          case class Foo(bar: String) derives JsonEncoder
+        """
+      })(isRight(anything))
+    },
+    testM("Derives for a sum type") {
+      assertM(typeCheck {
+        """
+          enum Foo derives JsonEncoder:
+            case Bar
+            case Baz(baz: String)
+            case Qux(foo: Foo)
+        """
+      })(isRight(anything))
+    }
+  )
+}


### PR DESCRIPTION
I know there is ongoing work to use scala 3 macros or shapely, but in the meantime would you see any problem with this?

Adds support for writing generic derivation a la Scala 3 i.e.
```scala
case class Foo(field: Bar) derives JsonCodec
```