### PR TITLE
Drop unneeded `with Scope`s

### DIFF
--- a/zio-json/jvm/src/main/scala/zio/json/JsonDecoderPlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/JsonDecoderPlatformSpecific.scala
@@ -30,7 +30,7 @@ trait JsonDecoderPlatformSpecific[A] { self: JsonDecoder[A] =>
   final def decodeJsonStreamInput[R](
     stream: ZStream[R, Throwable, Byte],
     charset: Charset = StandardCharsets.UTF_8
-  ): ZIO[R with Scope, Throwable, A] =
+  ): ZIO[R, Throwable, A] =
     ZIO.scoped[R] {
       stream.toInputStream
         .flatMap(is =>
@@ -48,7 +48,7 @@ trait JsonDecoderPlatformSpecific[A] { self: JsonDecoder[A] =>
    *
    * @see also [[decodeJsonStreamInput]]
    */
-  final def decodeJsonStream[R](stream: ZStream[R, Throwable, Char]): ZIO[R with Scope, Throwable, A] =
+  final def decodeJsonStream[R](stream: ZStream[R, Throwable, Char]): ZIO[R, Throwable, A] =
     ZIO.scoped[R](stream.toReader.flatMap(readAll))
 
   final def decodeJsonPipeline(

--- a/zio-json/jvm/src/test/scala-2/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala-2/zio/json/DecoderPlatformSpecificSpec.scala
@@ -18,7 +18,7 @@ import java.nio.file.Paths
 
 object DecoderPlatformSpecificSpec extends ZIOSpecDefault {
 
-  def spec: Spec[TestEnvironment with Scope, TestFailure[Any], TestSuccess] =
+  def spec: Spec[TestEnvironment, TestFailure[Any], TestSuccess] =
     suite("Decoder")(
       test("excessively nested structures") {
         // JVM specific: getResourceAsString not yet supported

--- a/zio-json/jvm/src/test/scala-2/zio/json/EncoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala-2/zio/json/EncoderPlatformSpecificSpec.scala
@@ -6,7 +6,6 @@ import testzio.json.data.geojson.generated._
 import testzio.json.data.googlemaps._
 import testzio.json.data.twitter._
 import zio.Chunk
-import zio.Scope
 import zio.json.ast.Json
 import zio.stream.ZStream
 import zio.test.Assertion._
@@ -18,7 +17,7 @@ import java.nio.file.Files
 object EncoderPlatformSpecificSpec extends ZIOSpecDefault {
   import testzio.json.DecoderSpec.logEvent._
 
-  def spec: Spec[TestEnvironment with Scope, TestFailure[Any], TestSuccess] =
+  def spec: Spec[TestEnvironment, TestFailure[Any], TestSuccess] =
     suite("Encoder")(
       suite("roundtrip")(
         testRoundTrip[DistanceMatrix]("google_maps_api_response"),


### PR DESCRIPTION
These are leftover from #594, and unnecessarily constrain the
environment types.