### PR TITLE
Rename defer to suspend

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -204,18 +204,6 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 {
 
   def apply[A](implicit a: JsonDecoder[A]): JsonDecoder[A] = a
 
-  def defer[A](decoder0: => JsonDecoder[A]): JsonDecoder[A] =
-    new JsonDecoder[A] {
-      lazy val decoder = decoder0
-
-      override def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
-        decoder.unsafeDecode(trace, in)
-
-      override def unsafeDecodeMissing(trace: List[JsonError]): A = decoder.unsafeDecodeMissing(trace)
-
-      override def fromJsonAST(json: Json): Either[String, A] = decoder.fromJsonAST(json)
-    }
-
   /**
    * Design note: we could require the position in the stream here to improve
    * debugging messages. But the cost would be that the RetractReader would need
@@ -238,6 +226,18 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 {
       }
     }
   }
+
+  def suspend[A](decoder0: => JsonDecoder[A]): JsonDecoder[A] =
+    new JsonDecoder[A] {
+      lazy val decoder = decoder0
+
+      override def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
+        decoder.unsafeDecode(trace, in)
+
+      override def unsafeDecodeMissing(trace: List[JsonError]): A = decoder.unsafeDecodeMissing(trace)
+
+      override def fromJsonAST(json: Json): Either[String, A] = decoder.fromJsonAST(json)
+    }
 
   implicit val string: JsonDecoder[String] = new JsonDecoder[String] {
 

--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -116,17 +116,6 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
 object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 {
   def apply[A](implicit a: JsonEncoder[A]): JsonEncoder[A] = a
 
-  def defer[A](encoder0: => JsonEncoder[A]): JsonEncoder[A] =
-    new JsonEncoder[A] {
-      lazy val encoder = encoder0
-
-      override def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = encoder.unsafeEncode(a, indent, out)
-
-      override def isNothing(a: A): Boolean = encoder.isNothing(a)
-
-      override def toJsonAST(a: A): Either[String, Json] = encoder.toJsonAST(a)
-    }
-
   implicit val string: JsonEncoder[String] = new JsonEncoder[String] {
 
     override def unsafeEncode(a: String, indent: Option[Int], out: Write): Unit = {
@@ -190,6 +179,17 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 {
     override final def toJsonAST(a: A): Either[String, Json] =
       Right(Json.Str(f(a)))
   }
+
+  def suspend[A](encoder0: => JsonEncoder[A]): JsonEncoder[A] =
+    new JsonEncoder[A] {
+      lazy val encoder = encoder0
+
+      override def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = encoder.unsafeEncode(a, indent, out)
+
+      override def isNothing(a: A): Boolean = encoder.isNothing(a)
+
+      override def toJsonAST(a: A): Either[String, Json] = encoder.toJsonAST(a)
+    }
 
   implicit val boolean: JsonEncoder[Boolean] = explicit(_.toString, Json.Bool.apply)
   implicit val symbol: JsonEncoder[Symbol]   = string.contramap(_.name)


### PR DESCRIPTION
I believe this sort of method is usually named `suspend` in ZIO libs. It'd be good to converge on one or the other at least :)