### PR TITLE
fix json ast object equality

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
+++ b/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
@@ -26,7 +26,7 @@ import scala.annotation._
 /**
  * This AST of JSON is made available so that arbitrary JSON may be included as
  * part of a business object, it is not used as an intermediate representation,
- * unlike most other JSON libraries. It is not advised to `.map` or `.emap`
+ * unlike most other JSON libraries. It is not advised to `.map` or `.mapOrFail`
  * from these decoders, since a higher performance decoder is often available.
  *
  * Beware of the potential for DOS attacks, since an attacker can provide much
@@ -43,14 +43,12 @@ sealed abstract class Json { self =>
 
   override final def equals(that: Any): Boolean = {
     def objEqual(left: Map[String, Json], right: Chunk[(String, Json)]): Boolean =
-      if (right.isEmpty) true
-      else
-        right.find { case (key, r) =>
-          left.get(key) match {
-            case Some(l) if l != r => true
-            case _                 => false
-          }
-        }.isEmpty
+      right.forall { case (key, r) =>
+        left.get(key) match {
+          case Some(l) if l == r => true
+          case _                 => false
+        }
+      }
 
     that match {
       case that: Json =>

--- a/zio-json/shared/src/test/scala/zio/json/ast/JsonSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ast/JsonSpec.scala
@@ -23,12 +23,10 @@ object JsonSpec extends ZIOSpecDefault {
             "obj"  -> Json.Obj("more" -> str, "andMore" -> bool)
           )
 
-          assert(
-            List(nul, num, str, bool, arr, obj).combinations(2).forall {
-              case fst :: snd :: Nil => fst != snd
-              case _                 => false
-            }
-          )(equalTo(true))
+          assertTrue(List(nul, num, str, bool, arr, obj).combinations(2).forall {
+            case fst :: snd :: Nil => fst != snd
+            case _                 => false
+          })
         },
         test("object order does not matter for equality") {
           val obj1 = Json.Obj(
@@ -43,7 +41,7 @@ object JsonSpec extends ZIOSpecDefault {
             "foo" -> Json.Str("1")
           )
 
-          assert(obj1)(equalTo(obj2))
+          assertTrue(obj1 == obj2 && obj2 == obj1)
         },
         test("equality fails for different objects of the same size with different keys") {
           val obj1 = Json.Obj(
@@ -56,7 +54,7 @@ object JsonSpec extends ZIOSpecDefault {
             "bar" -> Json.Str("2")
           )
 
-          assertTrue(obj1 != obj2)
+          assertTrue(obj1 != obj2 && obj2 != obj1)
         },
         test("equality fails for different objects of different sizes") {
           val obj1 = Json.Obj(
@@ -70,7 +68,7 @@ object JsonSpec extends ZIOSpecDefault {
             "maux" -> Json.Str("3")
           )
 
-          assertTrue(obj1 != obj2)
+          assertTrue(obj1 != obj2 && obj2 != obj1)
         }
       ),
       suite("hashCode")(
@@ -87,7 +85,7 @@ object JsonSpec extends ZIOSpecDefault {
             "foo" -> Json.Str("1")
           )
 
-          assert(obj1.hashCode)(equalTo(obj2.hashCode))
+          assertTrue(obj1.hashCode == obj2.hashCode)
         }
       ),
       suite("foldUp")(
@@ -106,7 +104,7 @@ object JsonSpec extends ZIOSpecDefault {
               )
             )
           val result = obj.foldUp(Vector.empty[String])(collectObjKeysAndArrElements)
-          assert(result)(equalTo(Vector("eight", "seven", "six", "five", "four", "three", "two", "one")))
+          assertTrue(result == Vector("eight", "seven", "six", "five", "four", "three", "two", "one"))
         }
       ),
       suite("foldDown")(
@@ -125,18 +123,18 @@ object JsonSpec extends ZIOSpecDefault {
               )
             )
           val result = obj.foldDown(Vector.empty[String])(collectObjKeysAndArrElements)
-          assert(result)(equalTo(Vector("one", "two", "three", "four", "five", "six", "seven", "eight")))
+          assertTrue(result == Vector("one", "two", "three", "four", "five", "six", "seven", "eight"))
         }
       ),
       test("arrays with the same elements in a different order will not have the same hashCode") {
         val arr1 = Json.Arr(Json.Str("one"), Json.Obj("two" -> Json.Num(2)), Json.Num(3))
         val arr2 = Json.Arr(Json.Num(3), Json.Str("one"), Json.Obj("two" -> Json.Num(2)))
-        assert(arr1.hashCode)(not(equalTo(arr2.hashCode)))
+        assertTrue(arr1.hashCode != arr2.hashCode)
       },
       test("arrays with the same elements in the same order will have the same hashCode") {
         val arr1 = Json.Arr(Json.Str("one"), Json.Obj("two" -> Json.Num(2)), Json.Num(3))
         val arr2 = Json.Arr(Json.Str("one"), Json.Obj("two" -> Json.Num(2)), Json.Num(3))
-        assert(arr1.hashCode)(equalTo(arr2.hashCode))
+        assertTrue(arr1.hashCode == arr2.hashCode)
       },
       suite("get")(
         test("downField") {

--- a/zio-json/shared/src/test/scala/zio/json/ast/JsonSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ast/JsonSpec.scala
@@ -44,6 +44,33 @@ object JsonSpec extends ZIOSpecDefault {
           )
 
           assert(obj1)(equalTo(obj2))
+        },
+        test("equality fails for different objects of the same size with different keys") {
+          val obj1 = Json.Obj(
+            "quux" -> Json.Str("1"),
+            "bar"  -> Json.Str("2")
+          )
+
+          val obj2 = Json.Obj(
+            "baz" -> Json.Arr(Json.Bool(true), Json.Num(2)),
+            "bar" -> Json.Str("2")
+          )
+
+          assertTrue(obj1 != obj2)
+        },
+        test("equality fails for different objects of different sizes") {
+          val obj1 = Json.Obj(
+            "quux" -> Json.Str("1"),
+            "bar"  -> Json.Str("2")
+          )
+
+          val obj2 = Json.Obj(
+            "quux" -> Json.Str("1"),
+            "bar"  -> Json.Str("2"),
+            "maux" -> Json.Str("3")
+          )
+
+          assertTrue(obj1 != obj2)
         }
       ),
       suite("hashCode")(


### PR DESCRIPTION
Ran into a bug today. This should fix it.