### PR TITLE
ZIO 2: default parameters support for Scala 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ object Banana {
 }
 ```
 
+_Note: If you’re using Scala 3 and your case class is defining default parameters, `-Yretain-trees` needs to be added to `scalacOptions`._
+
 Now we can parse JSON into our object
 
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,12 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
     // as per @fommil, optimization slows things down.
     scalacOptions -= "-opt:l:inline",
     scalacOptions -= "-opt-inline-from:zio.internal.**",
-    //scalaVersion := ScalaDotty,
+    Test / scalacOptions ++= {
+      if (scalaVersion.value == ScalaDotty)
+        Vector("-Yretain-trees")
+      else
+        Vector.empty
+    },
     libraryDependencies ++= Seq(
       "dev.zio"                %%% "zio"                     % zioVersion,
       "dev.zio"                %%% "zio-streams"             % zioVersion,
@@ -87,7 +92,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform)
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((3, _)) =>
           Vector(
-            "com.softwaremill.magnolia1_3" %%% "magnolia" % "1.0.0"
+            "com.softwaremill.magnolia1_3" %%% "magnolia" % "1.1.2"
           )
 
         case _ =>

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -82,7 +82,7 @@ object DecoderSpec extends ZIOSpecDefault {
 
           assert("""{}""".fromJson[DefaultString])(isRight(equalTo(DefaultString("")))) &&
           assert("""{"s": null}""".fromJson[DefaultString])(isRight(equalTo(DefaultString(""))))
-        } @@ TestAspect.exceptScala3,
+        },
         test("sum encoding") {
           import examplesum._
 
@@ -273,7 +273,7 @@ object DecoderSpec extends ZIOSpecDefault {
 
           assert(Json.Obj().as[DefaultString])(isRight(equalTo(DefaultString("")))) &&
           assert(Json.Obj("s" -> Json.Null).as[DefaultString])(isRight(equalTo(DefaultString(""))))
-        } @@ TestAspect.exceptScala3,
+        },
         test("sum encoding") {
           import examplesum._
 


### PR DESCRIPTION
Requires the `-Yretain-trees`  scalacOption