### PR TITLE
Generate case classes from JSON strings

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/codegen/Generator.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codegen/Generator.scala
@@ -1,0 +1,219 @@
+package zio.json.codegen
+
+import zio.Chunk
+import zio.json.ast.Json
+import zio.json._
+import zio.json.codegen.Generator.pascalFormat
+import JsonType._
+
+import scala.math.BigDecimal.javaBigDecimal2bigDecimal
+
+object Generator {
+
+  /**
+   * Renders the JSON string as a series of Scala case classes derived from the
+   * structure of the JSON.
+   *
+   * For example, the following JSON:
+   *
+   * {{{
+   *   {
+   *     "foo": "bar",
+   *     "baz": {
+   *       "qux": "quux"
+   *     }
+   *   }
+   * }}}
+   *
+   * Would print the following Scala code to the console:
+   *
+   * {{{
+   *   final case class RootObject(
+   *     foo: String,
+   *     baz: Baz
+   *   )
+   *
+   *   object RootObject {
+   *     implicit val codec: JsonCoder[RootObject] = DeriveJsonCodec.gen
+   *   }
+   *
+   *   final case class Baz(
+   *     qux: String
+   *   )
+   *
+   *   object Baz {
+   *   implicit val codec: JsonCoder[Baz] = DeriveJsonCodec.gen
+   *   }
+   * }}}
+   */
+  def printCaseClasses(input: String): Unit =
+    input.fromJson[ast.Json].toOption match {
+      case Some(json) => println(scala.Console.CYAN + generate(json) + scala.Console.RESET)
+      case None       => println(s"Invalid JSON: ${input}")
+    }
+
+  private[codegen] def pascalFormat(s: String): String = {
+    val parts = s.split("[_\\-.]")
+    parts.map(_.capitalize).mkString("")
+  }
+
+  private[codegen] def generate(json: ast.Json): String =
+    render(unifyTypes(json))
+
+}
+
+private[codegen] sealed trait JsonType extends Product with Serializable { self =>
+
+  def unify(that: JsonType): JsonType =
+    (self, that) match {
+      case (lhs, rhs) if lhs == rhs                 => lhs
+      case (JLong, JInt)                            => JLong
+      case (JInt, JLong)                            => JLong
+      case (JDouble, JInt | JLong)                  => JDouble
+      case (JInt | JLong, JDouble)                  => JDouble
+      case (JBigDecimal, JDouble | JInt | JLong)    => JBigDecimal
+      case (JDouble | JInt | JLong, JBigDecimal)    => JBigDecimal
+      case (JObject(lhsFields), JObject(rhsFields)) => JObject(mergeFields(lhsFields, rhsFields))
+
+      case (JOption(left), JNull)  => JOption(left)
+      case (JNull, JOption(right)) => JOption(right)
+
+      case (JOption(left), JOption(right)) => JOption(left unify right)
+
+      case (left, JOption(right)) => JOption(left unify right)
+      case (JOption(left), right) => JOption(left unify right)
+
+      case (JNull, right) => JOption(right)
+      case (left, JNull)  => JOption(left)
+
+      case (JArray(left), JArray(right)) => JArray(left unify right)
+      case (CaseClass(left, leftFields), CaseClass(right, rightFields)) if left == right =>
+        CaseClass(left, (leftFields unify rightFields).asInstanceOf[JObject])
+      case (left, right) =>
+        throw new Exception(s"""
+                               |Cannot combine:
+                               | LEFT: ${left.toString}
+                               |RIGHT: ${right.toString}
+                               |""".stripMargin)
+    }
+
+  def typeName: String = self match {
+    case CaseClass(name, _)   => name
+    case JObject(_)           => "RootObject"
+    case JString              => "String"
+    case JInt                 => "Int"
+    case JLong                => "Long"
+    case JDouble              => "Double"
+    case JBigDecimal          => "BigDecimal"
+    case JNull                => "null"
+    case JBoolean             => "Boolean"
+    case JOption(value)       => s"Option[${value.typeName}]"
+    case JArray(value)        => s"List[${value.typeName}]"
+    case Alternatives(values) => s"Alternatives[${values.map(_.typeName).mkString(", ")}]"
+  }
+
+  def makeOptional(jsonType: JsonType): JsonType = jsonType match {
+    case JNull          => JNull
+    case JOption(value) => JOption(value)
+    case other          => JOption(other)
+  }
+
+  def mergeFields(
+    lhs: Map[String, JsonType],
+    rhs: Map[String, JsonType]
+  ): Map[String, JsonType] = {
+    val result = lhs.foldLeft(rhs) { case (acc, (name, lhsValue)) =>
+      //        if (name == "thumbnails") {
+      //          println(s"lhs: ${lhsValue.toString} rhs: ${rhs.get(name)}")
+      //        }
+      acc.get(name) match {
+        case Some(rhsValue) => acc + (name -> lhsValue.unify(rhsValue))
+        case None           => acc + (name -> makeOptional(lhsValue))
+      }
+    }
+
+    println((rhs.keySet -- result.keySet) ++ (result.keySet -- rhs.keySet))
+
+    (rhs.keySet -- lhs.keySet).foldLeft(result) { case (acc, name) =>
+      acc + (name -> makeOptional(rhs(name)))
+    }
+  }
+
+}
+
+object JsonType {
+
+  final case class CaseClass(name: String, fields: JObject) extends JsonType {
+    def displayName = name
+  }
+
+  final case class JObject(fields: Map[String, JsonType]) extends JsonType
+  case object JString                                     extends JsonType
+  case object JInt                                        extends JsonType
+  case object JLong                                       extends JsonType
+  case object JDouble                                     extends JsonType
+  case object JBigDecimal                                 extends JsonType
+  case object JNull                                       extends JsonType
+  case object JBoolean                                    extends JsonType
+  final case class JOption(value: JsonType)               extends JsonType
+  final case class JArray(value: JsonType)                extends JsonType
+  final case class Alternatives(values: Chunk[JsonType])  extends JsonType
+
+  def render(jsonType: JsonType): String = {
+    val caseClasses = flattenCaseClasses(jsonType).distinct
+    caseClasses.map(renderCaseClass).mkString("\n\n")
+  }
+
+  def flattenCaseClasses(jsonType: JsonType): List[CaseClass] =
+    jsonType match {
+      case CaseClass(name, fields) =>
+        CaseClass(name, fields) :: fields.fields.toList.flatMap(t => flattenCaseClasses(t._2))
+      case JObject(fields) =>
+        fields.values.flatMap(flattenCaseClasses).toList
+      case JArray(values) =>
+        flattenCaseClasses(values)
+      case JOption(value) =>
+        flattenCaseClasses(value)
+      case _ =>
+        Nil
+    }
+
+  def renderCaseClass(clazz: CaseClass): String = {
+    val fields = clazz.fields.fields.map { case (name, value) =>
+      s"  $name: ${value.typeName}"
+    }.mkString(",\n")
+
+    s"""
+final case class ${clazz.name}(
+$fields
+)
+
+object ${clazz.name} {
+  implicit val codec: JsonCodec[${clazz.name}] = DeriveJsonCodec.gen
+}
+         """.trim
+  }
+
+  def unifyTypes(json: Json, key: Option[String] = None): JsonType =
+    json match {
+      case Json.Null => JNull
+      case Json.Arr(elements) =>
+        JArray(elements.map(unifyTypes(_, key)).reduce(_ unify _))
+      case Json.Bool(_) => JBoolean
+      case Json.Str(_)  => JString
+      case Json.Num(bigDecimal) =>
+        if (bigDecimal.isValidInt) JInt
+        else if (bigDecimal.isValidLong) JLong
+        else if (bigDecimal <= Double.MaxValue) JDouble
+        else JBigDecimal
+      case Json.Obj(fields) =>
+        val result = JObject(fields.toMap.map { case (name, value) =>
+          name -> unifyTypes(value, Some(name))
+        })
+        key match {
+          case Some(key) => CaseClass(pascalFormat(key), result)
+          case None      => CaseClass("RootObject", result)
+        }
+    }
+
+}

--- a/zio-json/shared/src/main/scala/zio/json/codegen/Generator.scala
+++ b/zio-json/shared/src/main/scala/zio/json/codegen/Generator.scala
@@ -1,13 +1,13 @@
 package zio.json.codegen
 
 import zio.Chunk
-import zio.json.ast.Json
 import zio.json._
+import zio.json.ast.Json
 import zio.json.codegen.Generator.pascalFormat
-import JsonType._
+import zio.json.codegen.JsonType._
 
-import java.time.format.DateTimeFormatter
 import java.time.{ LocalDate, LocalDateTime }
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.collection.immutable.ListMap
 import scala.math.BigDecimal.javaBigDecimal2bigDecimal
@@ -223,9 +223,11 @@ object ${clazz.name} {
         else if (bigDecimal <= Double.MaxValue) JDouble
         else JBigDecimal
       case Json.Obj(fields) =>
-        val result = JObject(ListMap.from(fields).map { case (name, value) =>
-          name -> unifyTypes(value, Some(name))
-        })
+        val result = JObject {
+          fields.foldLeft(ListMap.empty[String, JsonType]) { case (acc, (name, value)) =>
+            acc + (name -> unifyTypes(value, Some(name)))
+          }
+        }
         key match {
           case Some(key) => CaseClass(pascalFormat(key), result)
           case None      => CaseClass("RootObject", result)

--- a/zio-json/shared/src/test/scala/zio/json/codegen/GeneratorSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/codegen/GeneratorSpec.scala
@@ -80,6 +80,39 @@ object GeneratorSpec extends ZIOSpecDefault {
 
         assertTrue(result == expected)
       },
+      suite("parse types")(
+        test("parses LocalDate and LocalDateTime and ZonedDateTime") {
+          val json =
+            """{
+              |  "name": "John",
+              |  "age": 30,
+              |  "date": "2020-01-01",
+              |  "dateTime": "2011-04-14T16:00:49Z",
+              |  "dateTime2": "2020-01-01T00:00:00.000",
+              |  "uuid": "00000000-0000-0000-0000-000000008000"
+              |}
+                """.stripMargin
+
+          val expected =
+            """final case class RootObject(
+              |  name: String,
+              |  age: Int,
+              |  date: java.time.LocalDate,
+              |  dateTime: java.time.LocalDateTime,
+              |  dateTime2: java.time.LocalDateTime,
+              |  uuid: java.util.UUID
+              |)
+              |
+              |object RootObject {
+              |  implicit val codec: JsonCodec[RootObject] = DeriveJsonCodec.gen
+              |}
+              |""".stripMargin.trim
+
+          val result = Generator.generate(json.fromJson[ast.Json].toOption.get)
+
+          assertTrue(result == expected)
+        }
+      ),
       suite("unify types")(
         test("unify nulls and present keys to Option") {
           val json =

--- a/zio-json/shared/src/test/scala/zio/json/codegen/GeneratorSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/codegen/GeneratorSpec.scala
@@ -1,0 +1,204 @@
+package zio.json.codegen
+
+import zio.json._
+import zio.json.ast.Json
+import zio.test._
+
+object GeneratorSpec extends ZIOSpecDefault {
+  def spec = suite("GeneratorSpec")(
+    suite("generates case classes from JSON strings")(
+      test("simple object") {
+        val json =
+          """{
+            |  "name": "John",
+            |  "age": 30,
+            |  "phones": [
+            |    "+44 1234567",
+            |    "+44 2345678"
+            |  ]
+            |}
+          """.stripMargin
+
+        val expected =
+          """final case class RootObject(
+            |  name: String,
+            |  age: Int,
+            |  phones: List[String]
+            |)
+            |
+            |object RootObject {
+            |  implicit val codec: JsonCodec[RootObject] = DeriveJsonCodec.gen
+            |}
+            |""".stripMargin.trim
+
+        val result = Generator.generate(json.fromJson[ast.Json].toOption.get)
+
+        assertTrue(result == expected)
+      },
+      test("nested objects") {
+        // a person with nested pets
+
+        val json =
+          """{
+            |  "name": "John",
+            |  "age": 30,
+            |  "pets": [
+            |    {
+            |      "name": "dog",
+            |      "age": 5
+            |    },
+            |    {
+            |      "name": "cat",
+            |      "age": 2
+            |    }
+            |  ]
+            |}
+          """.stripMargin
+
+        val expected =
+          """final case class RootObject(
+            |  name: String,
+            |  age: Int,
+            |  pets: List[Pets]
+            |)
+            |
+            |object RootObject {
+            |  implicit val codec: JsonCodec[RootObject] = DeriveJsonCodec.gen
+            |}
+            |
+            |final case class Pets(
+            |  name: String,
+            |  age: Int
+            |)
+            |
+            |object Pets {
+            |  implicit val codec: JsonCodec[Pets] = DeriveJsonCodec.gen
+            |}
+            |""".stripMargin.trim
+
+        val result = Generator.generate(json.fromJson[ast.Json].toOption.get)
+
+        assertTrue(result == expected)
+      },
+      suite("unify types")(
+        test("unify nulls and present keys to Option") {
+          val json =
+            """{
+              |  "names": [
+              |    "Cool",
+              |    null,
+              |    "Jim"
+              |  ]
+              |}
+            """.stripMargin
+
+          val expected =
+            """final case class RootObject(
+              |  names: List[Option[String]]
+              |)
+              |
+              |object RootObject {
+              |  implicit val codec: JsonCodec[RootObject] = DeriveJsonCodec.gen
+              |}
+              |""".stripMargin.trim
+
+          val result = Generator.generate(json.fromJson[ast.Json].toOption.get)
+
+          assertTrue(result == expected)
+        },
+        test("unify missing keys to Option") {
+          val json =
+            """{
+              |  "people": [
+              |    {
+              |      "name": "Cool",
+              |      "age": 30
+              |    },
+              |    {
+              |      "name": "Jim"
+              |    },
+              |    {
+              |      "name": "John",
+              |      "age": 30
+              |    }
+              |  ]
+              |}
+              |""".stripMargin
+
+          val expected =
+            """final case class RootObject(
+              |  people: List[People]
+              |)
+              |
+              |object RootObject {
+              |  implicit val codec: JsonCodec[RootObject] = DeriveJsonCodec.gen
+              |}
+              |
+              |final case class People(
+              |  name: String,
+              |  age: Option[Int]
+              |)
+              |
+              |object People {
+              |  implicit val codec: JsonCodec[People] = DeriveJsonCodec.gen
+              |}
+              |""".stripMargin.trim
+
+          val result = Generator.generate(json.fromJson[Json].toOption.get)
+
+          assertTrue(result == expected)
+        },
+        test("unify Long and Int to Long") {
+          val json = """
+                       |{
+                       |  "values": [
+                       |    123,
+                       |    99999999999,
+                       |    5
+                       |  ]
+                       |}
+                       |""".stripMargin
+
+          val expected =
+            """final case class RootObject(
+              |  values: List[Long]
+              |)
+              |
+              |object RootObject {
+              |  implicit val codec: JsonCodec[RootObject] = DeriveJsonCodec.gen
+              |}
+              |""".stripMargin.trim
+
+          val result = Generator.generate(json.fromJson[Json].toOption.get)
+          assertTrue(result == expected)
+        },
+        test("unify double and int to double") {
+
+          val json = """
+                       |{
+                       |  "values": [
+                       |    123,
+                       |    99999999999,
+                       |    5.5
+                       |  ]
+                       |}
+                       |""".stripMargin
+
+          val expected =
+            """final case class RootObject(
+              |  values: List[Double]
+              |)
+              |
+              |object RootObject {
+              |  implicit val codec: JsonCodec[RootObject] = DeriveJsonCodec.gen
+              |}
+              |""".stripMargin.trim
+
+          val result = Generator.generate(json.fromJson[Json].toOption.get)
+          assertTrue(result == expected)
+
+        }
+      )
+    )
+  )
+}


### PR DESCRIPTION
Oftentimes, I find myself visually parsing the JSON output of some API call such that I can translate the results into a series of case classes and derived codecs. Wouldn't it be nice if we could, to a degree, automate this process?

Calling `Generator.printCaseClasses(jsonString)` will print a series of derived case classes to the console.

It will unify nulls and missing keys to Options, as well as unify numeric types.

```json
{
  "name": "John",
  "age": 30,
  "pets": [
    {
      "name": "dog",
      "age": 5
    },
    {
      "name": "cat",
      "age": 2.5,
      "weapon": "trebuchet"
    }
  ]
}
```

```scala
final case class RootObject(
  name: String,
  age: Int,
  pets: List[Pets]
)

object RootObject {
  implicit val codec: JsonCodec[RootObject] = DeriveJsonCodec.gen
}

final case class Pets(
  name: String,
  age: Double,
  weapon: Option[String]
)

object Pets {
  implicit val codec: JsonCodec[Pets] = DeriveJsonCodec.gen
}
```

I'm not doing anything clever around pluralization, because that seems like a fools errand 😄. The intention would be for people to copy-paste this into their IDE and then tweak the names (e.g., `RootObject` -> `Person`).