### PR TITLE
fix(build): remove bloop from build (auto loaded with VSCode)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"                     % "1032048a")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"                 % "0.11.0")
 addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"                    % "0.4.3")
 addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"                % "1.5.10")


### PR DESCRIPTION
This plugin prevent SBT from starting (scala-xml library version conflicts).
Latest bloop plugin is auto-added by metals extension in VSCode (ignore rules are already in .gitignore).