### PR TITLE
Support for Scala 3 derives with ZIO 2.x (Forward-port of #599)

### DIFF
--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonCodecVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonCodecVersionSpecific

--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonDecoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonDecoderVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonDecoderVersionSpecific

--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonEncoderVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonEncoderVersionSpecific

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
@@ -1,0 +1,5 @@
+package zio.json
+
+trait JsonCodecVersionSpecific {
+  inline def derived[A: deriving.Mirror.Of]: JsonCodec[A] = DeriveJsonCodec.gen[A]
+}

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
@@ -1,0 +1,5 @@
+package zio.json
+
+trait JsonDecoderVersionSpecific {
+  inline def derived[A: deriving.Mirror.Of]: JsonDecoder[A] = DeriveJsonDecoder.gen[A]
+}

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
@@ -1,0 +1,5 @@
+package zio.json
+
+trait JsonEncoderVersionSpecific {
+  inline def derived[A: deriving.Mirror.Of]: JsonEncoder[A] = DeriveJsonEncoder.gen[A]
+}

--- a/zio-json/shared/src/main/scala/zio/json/JsonCodec.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonCodec.scala
@@ -84,7 +84,7 @@ final case class JsonCodec[A](encoder: JsonEncoder[A], decoder: JsonDecoder[A]) 
 
 }
 
-object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 {
+object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 with JsonCodecVersionSpecific {
   def apply[A](implicit jsonCodec: JsonCodec[A]): JsonCodec[A] = jsonCodec
 
   def apply[A](encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] = new JsonCodec(encoder, decoder)

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -217,7 +217,7 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
     decodeJson(Json.encoder.encodeJson(json, None))
 }
 
-object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 {
+object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with JsonDecoderVersionSpecific {
   type JsonError = zio.json.JsonError
   val JsonError = zio.json.JsonError
 

--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -113,7 +113,7 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
   final def zipWith[B, C](that: => JsonEncoder[B])(f: C => (A, B)): JsonEncoder[C] = self.zip(that).contramap(f)
 }
 
-object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 {
+object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with JsonEncoderVersionSpecific {
   def apply[A](implicit a: JsonEncoder[A]): JsonEncoder[A] = a
 
   implicit val string: JsonEncoder[String] = new JsonEncoder[String] {

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedCodecSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedCodecSpec.scala
@@ -1,0 +1,32 @@
+package testzio.json
+
+import zio._
+import zio.json._
+import zio.test.Assertion._
+import zio.test._
+
+object DerivedCodecSpec extends ZIOSpecDefault {
+  val spec = suite("DerivedCodecSpec")(
+    test("Derives for a product type") {
+      assertZIO(typeCheck {
+        """
+          case class Foo(bar: String) derives JsonCodec
+
+          Foo("bar").toJson.fromJson[Foo]
+        """
+      })(isRight(anything))
+    },
+    test("Derives for a sum type") {
+      assertZIO(typeCheck {
+        """
+          enum Foo derives JsonCodec:
+            case Bar
+            case Baz(baz: String)
+            case Qux(foo: Foo)
+
+          (Foo.Qux(Foo.Bar): Foo).toJson.fromJson[Foo]
+        """
+      })(isRight(anything))
+    }
+  )
+}

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -1,0 +1,33 @@
+package testzio.json
+
+import zio._
+import zio.json._
+import zio.test.Assertion._
+import zio.test._
+
+object DerivedDecoderSpec extends ZIOSpecDefault {
+
+  val spec = suite("DerivedDecoderSpec")(
+    test("Derives for a product type") {
+      assertZIO(typeCheck {
+        """
+          case class Foo(bar: String) derives JsonDecoder
+
+          "{\"bar\": \"hello\"}".fromJson[Foo]
+        """
+      })(isRight(anything))
+    },
+    test("Derives for a sum type") {
+      assertZIO(typeCheck {
+        """
+          enum Foo derives JsonDecoder:
+            case Bar
+            case Baz(baz: String)
+            case Qux(foo: Foo)
+
+          "{\"Qux\":{\"foo\":{\"Bar\":{}}}}".fromJson[Foo]
+        """
+      })(isRight(anything))
+    }
+  )
+}

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
@@ -1,0 +1,32 @@
+package testzio.json
+
+import zio._
+import zio.json._
+import zio.test.Assertion._
+import zio.test._
+
+object DerivedEncoderSpec extends ZIOSpecDefault {
+  val spec = suite("DerivedEncoderSpec")(
+    test("Derives for a product type") {
+      assertZIO(typeCheck {
+        """
+          case class Foo(bar: String) derives JsonEncoder
+
+          Foo("bar").toJson
+        """
+      })(isRight(anything))
+    },
+    test("Derives for a sum type") {
+      assertZIO(typeCheck {
+        """
+          enum Foo derives JsonEncoder:
+            case Bar
+            case Baz(baz: String)
+            case Qux(foo: Foo)
+
+          (Foo.Qux(Foo.Bar): Foo).toJson
+        """
+      })(isRight(anything))
+    }
+  )
+}


### PR DESCRIPTION
* Monkey-patch support for Scala 3 derives

* Add expression using json algebra for good measure

Forward-ported the original work by @regiskuckaertz