### PR TITLE
Add Default Parameter for Indent in JsonEncoder#encodeJson

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -70,7 +70,7 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
   /**
    * Encodes the specified value into a JSON string, with the specified indentation level.
    */
-  final def encodeJson(a: A, indent: Option[Int]): CharSequence = {
+  final def encodeJson(a: A, indent: Option[Int] = None): CharSequence = {
     val writer = new FastStringWrite(64)
     unsafeEncode(a, indent, writer)
     writer.buffer


### PR DESCRIPTION
Would it make sense to provide a default parameter here so that for the simple case you could just call `jsonEncoder.encodeJson(a)`?