### PR TITLE
fix(macros): fix fromJsonAST derivation for Scala 3

### DIFF
--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -195,7 +195,14 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
                   if (defaults(i).isDefined) {
                     ps(i) = defaults(i).get
                   } else {
-                    missing.add(names(i))
+                    val tc = tcs(i)
+                    try {
+                      // There is no default value, see if the type class decoder can handle it:
+                      ps(i) = tc.unsafeDecodeMissing(JsonError.ObjectAccess(names(i)) :: Nil)
+                    } catch {
+                      case JsonDecoder.UnsafeJson(trace) =>
+                        missing.add(names(i))
+                    }
                   }
                 }
                 i += 1

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -77,6 +77,15 @@ object DecoderSpec extends ZIOSpecDefault {
           assert("""{ "id": 1, "opt": 42 }""".fromJson[WithOpt])(isRight(equalTo(WithOpt(1, Some(42))))) &&
           assert("""{ "id": 1 }""".fromJson[WithOpt])(isRight(equalTo(WithOpt(1, None))))
         },
+        test("option - fromJsonAST") {
+          case class WithOpt(id: Int, opt: Option[Int])
+          implicit val decoder: JsonDecoder[WithOpt] = DeriveJsonDecoder.gen
+
+          assert("""{ "id": 1, "opt": 42 }""".fromJson[Json].flatMap(decoder.fromJsonAST))(
+            isRight(equalTo(WithOpt(1, Some(42))))
+          ) &&
+          assert("""{ "id": 1 }""".fromJson[Json].flatMap(decoder.fromJsonAST))(isRight(equalTo(WithOpt(1, None))))
+        },
         test("default field value") {
           import exampleproducts._
 


### PR DESCRIPTION
The fromJsonAST method derived inside the macro from Scala 3 does not perform the same check regarding Options without default value than it does for Scala 2.12 and 2.13.

This aims to fix that by simply adding the existing change inside the Scala 3 macros.

Closes #780