### PR TITLE
Add ability to decode json in different ways and combine the results

### DIFF
--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -294,6 +294,17 @@ object DecoderSpec extends ZIOSpecDefault {
               )
             )
           )
+        },
+        test("ith") {
+          final case class Foo(a: Int)
+          final case class Bar(b: String)
+
+          implicit val fooDecoder: JsonDecoder[Foo] = DeriveJsonDecoder.gen[Foo]
+          implicit val barDecoder: JsonDecoder[Bar] = DeriveJsonDecoder.gen[Bar]
+          implicit val fooAndBarDecoder: JsonDecoder[(Foo, Bar)] = JsonDecoder[Foo].newZip(JsonDecoder[Bar])
+
+          val json = """{"a": 1, "b": "2"}"""
+          assert(json.fromJson[(Foo, Bar)])(isRight(equalTo((Foo(1), Bar("2")))))
         }
       ),
       suite("fromJsonAST")(

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -295,7 +295,7 @@ object DecoderSpec extends ZIOSpecDefault {
             )
           )
         },
-        test("ith") {
+        test("newZip") {
           final case class Foo(a: Int)
           final case class Bar(b: String)
 


### PR DESCRIPTION
This is a different zip functionality. Instead of combining decoders with inside a tuple, this allows us to decode the same json twice. 

Given the setup:

```scala
final case class Foo(a: Int)
final case class Bar(b: String)

implicit val fooDecoder: JsonDecoder[Foo] = DeriveJsonDecoder.gen[Foo]
implicit val barDecoder: JsonDecoder[Bar] = DeriveJsonDecoder.gen[Bar]
```

The old `zip` does

```scala
implicit val fooAndBarDecoder: JsonDecoder[(Foo, Bar)] = JsonDecoder[Foo].zip(JsonDecoder[Bar])
val json = """[{"a": 1}, {"b": "2"}]"""
val result: (Foo, Bar) = json.fromJson[(Foo, Bar)]
```

while `newZip` does

```scala
implicit val fooAndBarDecoder: JsonDecoder[(Foo, Bar)] = JsonDecoder[Foo].newZip(JsonDecoder[Bar])

val json = """{"a": 1, "b": "2"}"""
val result: (Foo, Bar) = json.fromJson[(Foo, Bar)]
```


Fixes zio/zio-json#487