### PR TITLE
Refactor write() method for improved readability and maintainability

### DIFF
--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -694,24 +694,22 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
     def write(c: Char): Unit = write(c.toString) // could be optimised
 
     def write(s: String): Unit =
-      if (first || second) {
-        var i = 0
-        while (i < s.length) {
-          val c = s.charAt(i)
-          if (c == ' ' || c == '\n') {} else if (first && c == '{') {
-            first = false
-          } else if (second) {
-            second = false
-            if (c != '}') {
-              out.write(',')
-              JsonEncoder.pad(indent, out)
-            }
-            return out.write(s.substring(i))
-          }
-          i += 1
+    if (first || second) {
+    for (c <- s if !c.isWhitespace && c != '\n') {
+      if (first && c == '{') {
+        first = false
+      } else if (second) {
+        second = false
+        if (c != '}') {
+          out.write(',')
+          JsonEncoder.pad(indent, out)
         }
-      } else out.write(s)
+        return  out.write(s.substring(s.indexOf(c)))
+      }
     }
+  } else {
+    out.write(s)
+  }
 }
 
 object DeriveJsonCodec {


### PR DESCRIPTION
Rewrote the write() method to improve its structure and readability, and to reduce the amount of mutable state. The changes included:

- Using early returns to simplify the control flow and reduce nesting
- Using a for loop instead of a while loop for more concise code

These changes make the code easier to understand and maintain, and reduce the potential for errors caused by mutable state. The logic for handling JSON formatting has been preserved and should work as before.