### PR TITLE
Migrate JsonEncoder/Decoder macro to Scala 3 native macro. No more magnolia

### DIFF
--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -194,7 +194,7 @@ final class jsonNoExtraFields extends Annotation
  */
 final class jsonExclude extends Annotation
 
-// TODO: implement same configuration for Scala 3 once this issue is resolved: https://github.com/softwaremill/magnolia/issues/296
+// TODO: implement same configuration for Scala 3
 /**
  * Implicit codec derivation configuration.
  *

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -201,11 +201,11 @@ object DeriveJsonDecoder { self =>
     def decoder(tpe: Type[?]): Expr[JsonDecoder[?]] =
       tpe match { case '[t] => Expr.summon[JsonDecoder[t]].getOrElse(deriveDecoder[t]) }
 
-    def leafTypes(of: Symbol): List[Symbol] =
+    def leafTypesSymbols(of: Symbol): List[Symbol] =
       of.children.flatMap { child =>
         if child.flags.is(Flags.Case)
         then List(child)
-        else leafTypes(child)
+        else leafTypesSymbols(child)
       }
 
 
@@ -213,7 +213,7 @@ object DeriveJsonDecoder { self =>
       val discrim = symbol.annotations.map(_.asExpr).collectFirst {
         case '{ new zio.json.jsonDiscriminator(${Expr(name)}: String) } => name
       }
-      val subTypes = leafTypes(symbol).map(_.typeRef)
+      val subTypes = leafTypesSymbols(symbol).map(_.typeRef)
 
       val names: Array[String] =
           subTypes.map { subclassType =>

--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -161,7 +161,7 @@ final class WithRetractReader(in: java.io.Reader) extends RetractReader with Aut
 private[zio] sealed trait RecordingReader extends RetractReader {
   def rewind(): Unit
 }
-private[zio] object RecordingReader {
+object RecordingReader {
   def apply(in: OneCharReader): RecordingReader =
     new WithRecordingReader(in, 64)
 }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -89,9 +89,9 @@ object DecoderSpec extends ZIOSpecDefault {
                      }.flip
           } yield assertTrue(
             // Class name in Scala 2: testzio.json.DecoderSpec.spec.Mango
-            // Class name in Scala 3: testzio.json.DecoderSpec.spec.$anonfun.Mango
+            // Class name in Scala 3: testzio.json.DecoderSpec$._$_$Mango
             error.getMessage.matches(
-              "Field names and aliases in case class testzio.json.DecoderSpec.spec(.\\$anonfun)?.Mango must be distinct, alias\\(es\\) r collide with a field or another alias"
+              "Field names and aliases in case class testzio\\.json\\.DecoderSpec((\\.spec\\.)|(\\$\\._\\$_\\$))Mango must be distinct, alias\\(es\\) r collide with a field or another alias"
             )
           )
         },
@@ -103,7 +103,7 @@ object DecoderSpec extends ZIOSpecDefault {
                      }.flip
           } yield assertTrue(
             error.getMessage.matches(
-              "Field names and aliases in case class testzio.json.DecoderSpec.spec(.\\$anonfun)?.Mango must be distinct, alias\\(es\\) r collide with a field or another alias"
+              "Field names and aliases in case class testzio\\.json\\.DecoderSpec((\\.spec\\.)|(\\$\\._\\$_\\$))Mango must be distinct, alias\\(es\\) r collide with a field or another alias"
             )
           )
         },
@@ -115,7 +115,7 @@ object DecoderSpec extends ZIOSpecDefault {
                      }.flip
           } yield assertTrue(
             error.getMessage.matches(
-              "Field names and aliases in case class testzio.json.DecoderSpec.spec(.\\$anonfun)?.Mango must be distinct, alias\\(es\\) r collide with a field or another alias"
+              "Field names and aliases in case class testzio\\.json\\.DecoderSpec((\\.spec\\.)|(\\$\\._\\$_\\$))Mango must be distinct, alias\\(es\\) r collide with a field or another alias"
             )
           )
         },


### PR DESCRIPTION
- annotation handling
- decoders for recursive data structures