### PR TITLE
Rename root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ addCommandAlias("testJS", "zioJsonJS/test")
 
 val zioVersion = "2.0.12"
 
-lazy val root = project
+lazy val zioJsonRoot = project
   .in(file("."))
   .settings(
     publish / skip := true,


### PR DESCRIPTION
IntelliJ uses the name of the root module as the project name. This is shown as the window title and in the project history. Just root is confusing and makes it harder to find the project in the menus.