### PR TITLE
yaml encoding didn't work for long sized integers.

### DIFF
--- a/zio-json-yaml/src/main/scala/zio/json/yaml/package.scala
+++ b/zio-json-yaml/src/main/scala/zio/json/yaml/package.scala
@@ -126,7 +126,7 @@ package object yaml {
       case Json.Num(value) =>
         val stripped = value.stripTrailingZeros()
         if (stripped.scale() <= 0) {
-          new ScalarNode(Tag.INT, stripped.intValue().toString, null, null, options.scalarStyle(json))
+          new ScalarNode(Tag.INT, stripped.longValue.toString, null, null, options.scalarStyle(json))
         } else {
           new ScalarNode(Tag.FLOAT, stripped.toString, null, null, options.scalarStyle(json))
         }

--- a/zio-json-yaml/src/test/scala/zio/json/yaml/YamlEncoderSpec.scala
+++ b/zio-json-yaml/src/test/scala/zio/json/yaml/YamlEncoderSpec.scala
@@ -25,6 +25,11 @@ object YamlEncoderSpec extends ZIOSpecDefault {
           isRight(equalTo("hello\n"))
         )
       },
+      test("large number") {
+        assert(Json.Num(2910000000L).toYaml(YamlOptions.default.copy(lineBreak = LineBreak.UNIX)))(
+          isRight(equalTo("2910000000\n"))
+        )
+      },
       test("special characters in string") {
         assert(Json.Arr(Json.Str("- [] &hello \\!")).toYaml(YamlOptions.default.copy(lineBreak = LineBreak.UNIX)))(
           isRight(equalTo("  - '- [] &hello \\!'\n"))


### PR DESCRIPTION
changed the Json.Num case in jsonToYaml to use BigDecimal.longValue instead of intValue

added a test

contributing link in the readme is a[dead link](https://zio.dev/about/contributing) so not sure if you need anything else

