### PR TITLE
Update snakeyaml dependency to 2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -248,7 +248,7 @@ lazy val zioJsonYaml = project
   .settings(buildInfoSettings("zio.json.yaml"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.yaml" % "snakeyaml"    % "1.33",
+      "org.yaml" % "snakeyaml"    % "2.0",
       "dev.zio" %% "zio"          % zioVersion,
       "dev.zio" %% "zio-test"     % zioVersion % "test",
       "dev.zio" %% "zio-test-sbt" % zioVersion % "test"

--- a/zio-json-yaml/src/main/scala/zio/json/yaml/internal/YamlValueConstruction.scala
+++ b/zio-json-yaml/src/main/scala/zio/json/yaml/internal/YamlValueConstruction.scala
@@ -2,7 +2,6 @@ package zio.json.yaml.internal
 
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.nodes.{ MappingNode, Node }
-import scala.annotation.nowarn
 import org.yaml.snakeyaml.LoaderOptions
 
 private[yaml] final class YamlValueConstruction extends SafeConstructor(new LoaderOptions()) {

--- a/zio-json-yaml/src/main/scala/zio/json/yaml/internal/YamlValueConstruction.scala
+++ b/zio-json-yaml/src/main/scala/zio/json/yaml/internal/YamlValueConstruction.scala
@@ -3,9 +3,9 @@ package zio.json.yaml.internal
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.nodes.{ MappingNode, Node }
 import scala.annotation.nowarn
+import org.yaml.snakeyaml.LoaderOptions
 
-@nowarn
-private[yaml] final class YamlValueConstruction extends SafeConstructor {
+private[yaml] final class YamlValueConstruction extends SafeConstructor(new LoaderOptions()) {
   def toJavaValue(node: Node): AnyRef =
     getConstructor(node).construct(node)
 


### PR DESCRIPTION
Related to https://github.com/zio/zio-json/issues/973 

snakeyaml 1.33 is vulnerable to cve CVE-2022-1471, which has a severity high or critical depending on different analysis https://nvd.nist.gov/vuln/detail/CVE-2022-1471

zio-json-yaml uses the vulnerable constructor, but 2.0 fixes the issue: https://www.veracode.com/blog/research/resolving-cve-2022-1471-snakeyaml-20-release-0

2.0 removes deprecated constructor for SafeConstructor class, so we should use another one, using a default LoaderOptions, like the previous constructor (diff of old constructor: https://bitbucket.org/snakeyaml/snakeyaml/diff/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java?at=master&diff2=3e755d254aeaa902675053047fd53368a175565a )

I removed the nowarn annotation, because it triggers a warning, since there is no warning anymore (because of uage of deprecated constructor)