### PR TITLE
Allow to set jsonMemberNames on enum, affecting all cases

### DIFF
--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -249,7 +249,7 @@ object DeriveJsonDecoder {
 
   def join[A](ctx: CaseClass[JsonDecoder, A])(implicit config: JsonCodecConfiguration): JsonDecoder[A] = {
     val (transformNames, nameTransform): (Boolean, String => String) =
-      ctx.annotations.collectFirst { case jsonMemberNames(format) => format }
+      (ctx.annotations ++ ctx.inheritedAnnotations).collectFirst { case jsonMemberNames(format) => format }
         .orElse(Some(config.fieldNameMapping))
         .filter(_ != IdentityFormat)
         .map(true -> _)

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -197,7 +197,7 @@ final class jsonExclude extends Annotation
 object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
   def join[A](ctx: CaseClass[Typeclass, A]): JsonDecoder[A] = {
     val (transformNames, nameTransform): (Boolean, String => String) =
-      ctx.annotations.collectFirst { case jsonMemberNames(format) => format }
+      (ctx.annotations ++ ctx.inheritedAnnotations).collectFirst { case jsonMemberNames(format) => format }
         .map(true -> _)
         .getOrElse(false -> identity)
 

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -89,6 +89,9 @@ object CodecSpec extends ZIOSpecDefault {
           val cameled       = """{"small123Talk":""}"""
           val indianaJones  = """{"wHATcASEiStHIS":""}"""
           val overrides     = """{"not_modified":"","but-this-should-be":0}"""
+          val firstSnake    = """{"FirstSnake":{"known_for":"ocelli"}}"""
+          val secondSnake   = """{"SecondSnake":{"is_venomous":true}}"""
+          val kebabSnake    = """{"KebabSnake":{"number-of-legs":0}}"""
           val kebabedLegacy = """{"shish-123-kebab":""}"""
           val snakedLegacy  = """{"indiana_123_jones":""}"""
 
@@ -100,6 +103,9 @@ object CodecSpec extends ZIOSpecDefault {
           assert(cameled.fromJson[Cameled])(isRight(equalTo(Cameled("")))) &&
           assert(indianaJones.fromJson[Custom])(isRight(equalTo(Custom("")))) &&
           assert(overrides.fromJson[OverridesAlsoWork])(isRight(equalTo(OverridesAlsoWork("", 0)))) &&
+          assert(firstSnake.fromJson[SnakeEnum])(isRight(equalTo(FirstSnake("ocelli")))) &&
+          assert(secondSnake.fromJson[SnakeEnum])(isRight(equalTo(SecondSnake(true)))) &&
+          assert(kebabSnake.fromJson[SnakeEnum])(isRight(equalTo(KebabSnake(0)))) &&
           assertTrue(Kebabed("").toJson == kebabed) &&
           assertTrue(Kebabed("").toJsonAST.toOption.get == kebabed.fromJson[Json].toOption.get) &&
           assertTrue(legacy.Kebabed("").toJson == kebabedLegacy) &&
@@ -284,6 +290,17 @@ object CodecSpec extends ZIOSpecDefault {
     case class OverridesAlsoWork(@jsonField("not_modified") notModified: String, butThisShouldBe: Int)
     object OverridesAlsoWork {
       implicit val codec: JsonCodec[OverridesAlsoWork] = DeriveJsonCodec.gen[OverridesAlsoWork]
+    }
+
+    @jsonMemberNames(SnakeCase)
+    sealed trait SnakeEnum
+    final case class FirstSnake(knownFor: String) extends SnakeEnum
+    final case class SecondSnake(isVenomous: Boolean) extends SnakeEnum
+    @jsonMemberNames(KebabCase)
+    final case class KebabSnake(numberOfLegs: Int) extends SnakeEnum
+
+    object SnakeEnum {
+      implicit val decoder: JsonDecoder[SnakeEnum] = DeriveJsonDecoder.gen
     }
 
     object legacy {


### PR DESCRIPTION
This change allows to set `@jsonMemberNames` annotation on enum (sealed trait) to affect all cases, so it is no longer necessary to add the annotation to each of the cases individually. Each case can, however, override it.

Basic tests were added verifying that the annotation has effect and cases can override enum's annotation.