### PR TITLE
Fixes #1003: correct indent of seq of objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The goal of this project is to create the best all-round JSON library for Scala:
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-json" % "0.6.0"
+libraryDependencies += "dev.zio" %% "zio-json" % "0.6.1"
 ```
 
 ## Example

--- a/zio-json-yaml/src/main/scala/zio/json/yaml/YamlOptions.scala
+++ b/zio-json-yaml/src/main/scala/zio/json/yaml/YamlOptions.scala
@@ -1,9 +1,12 @@
 package zio.json.yaml
 
 import org.yaml.snakeyaml.DumperOptions.{ FlowStyle, LineBreak, NonPrintableStyle, ScalarStyle }
+import org.yaml.snakeyaml.DumperOptions
+
 import zio.json.ast.Json
 
 case class YamlOptions(
+  newDumperOptions: () => DumperOptions, // this to allow user to give a a pre-set dumper for unsupported options
   dropNulls: Boolean,
   indentation: Int,
   sequenceIndentation: Int,
@@ -12,7 +15,8 @@ case class YamlOptions(
   flowStyle: Json => FlowStyle,
   scalarStyle: Json => ScalarStyle,
   keyStyle: String => ScalarStyle,
-  nonPrintableStyle: NonPrintableStyle
+  nonPrintableStyle: NonPrintableStyle,
+  indentWithIndicator: Boolean
 )
 
 object YamlOptions {
@@ -23,6 +27,7 @@ object YamlOptions {
   }
 
   val default: YamlOptions = YamlOptions(
+    () => new DumperOptions(),
     dropNulls = true,
     indentation = 2,
     sequenceIndentation = 2,
@@ -31,6 +36,7 @@ object YamlOptions {
     flowStyle = _ => FlowStyle.AUTO,
     scalarStyle = _ => ScalarStyle.PLAIN,
     keyStyle = _ => ScalarStyle.PLAIN,
-    nonPrintableStyle = NonPrintableStyle.ESCAPE
+    nonPrintableStyle = NonPrintableStyle.ESCAPE,
+    indentWithIndicator = true
   )
 }

--- a/zio-json-yaml/src/main/scala/zio/json/yaml/package.scala
+++ b/zio-json-yaml/src/main/scala/zio/json/yaml/package.scala
@@ -26,7 +26,7 @@ package object yaml {
       val yamlNode = toYamlAST(options)
 
       try {
-        val dumperOptions = new DumperOptions()
+        val dumperOptions = options.newDumperOptions()
         dumperOptions.setIndent(options.indentation)
         dumperOptions.setIndicatorIndent(options.sequenceIndentation)
         options.maxScalarWidth match {
@@ -37,6 +37,7 @@ package object yaml {
             dumperOptions.setSplitLines(false)
         }
         dumperOptions.setLineBreak(options.lineBreak)
+        dumperOptions.setIndentWithIndicator(options.indentWithIndicator)
 
         val resolver   = new Resolver
         val output     = new StringWriter()

--- a/zio-json-yaml/src/main/scala/zio/json/yaml/package.scala
+++ b/zio-json-yaml/src/main/scala/zio/json/yaml/package.scala
@@ -7,7 +7,7 @@ import org.yaml.snakeyaml.nodes.{ ScalarNode, _ }
 import org.yaml.snakeyaml.reader.StreamReader
 import org.yaml.snakeyaml.resolver.Resolver
 import org.yaml.snakeyaml.serializer._
-import org.yaml.snakeyaml.{ DumperOptions, Yaml }
+import org.yaml.snakeyaml.Yaml
 import zio.Chunk
 import zio.json.ast.Json
 import zio.json.yaml.internal.YamlValueConstruction

--- a/zio-json-yaml/src/test/scala/zio/json/yaml/YamlEncoderSpec.scala
+++ b/zio-json-yaml/src/test/scala/zio/json/yaml/YamlEncoderSpec.scala
@@ -20,6 +20,11 @@ object YamlEncoderSpec extends ZIOSpecDefault {
           isRight(equalTo(ex1Yaml))
         )
       },
+      test("object root with object in a sequence") {
+        assert(ex2.toYaml(YamlOptions.default.copy(lineBreak = LineBreak.UNIX)))(
+          isRight(equalTo(ex2Yaml))
+        )
+      },
       test("scalar root") {
         assert(Json.Str("hello").toYaml(YamlOptions.default.copy(lineBreak = LineBreak.UNIX)))(
           isRight(equalTo("hello\n"))
@@ -130,8 +135,32 @@ object YamlEncoderSpec extends ZIOSpecDefault {
       |    s: []
       |""".stripMargin
 
+  val ex2: Example2 =
+    Example2(
+      id = "ex2",
+      seq = List(SubObject(id = "a"), SubObject(id = "b"))
+    )
+
+  val ex2Yaml: String =
+    """id: ex2
+      |seq:
+      |  - id: a
+      |  - id: b
+      |""".stripMargin
+
   case class Example(i: Int, d: Double, s: List[String], o: Option[Example])
   object Example {
     implicit lazy val codec: JsonCodec[Example] = DeriveJsonCodec.gen[Example]
   }
+
+  case class SubObject(id: String)
+  object SubObject {
+    implicit lazy val codec: JsonCodec[SubObject] = DeriveJsonCodec.gen[SubObject]
+  }
+
+  case class Example2(id: String, seq: List[SubObject])
+  object Example2 {
+    implicit lazy val codec: JsonCodec[Example2] = DeriveJsonCodec.gen[Example2]
+  }
+
 }


### PR DESCRIPTION
This PR addresses #1003 as shown in the added test. The problem was just linked to the default value of `IndentWithIndicator`. 

To avoid having an other case where an user can't change a non-exposed config parameter of SnakeYaml, I also added in `YamlOption` the way to get a new base `DumpsterOptions` so that one can always pre-set it with what is needed. 