### PR TITLE
Change `zio.json.ast.Json` from sealed abstract class to sealed trait

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
+++ b/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
@@ -38,7 +38,7 @@ import scala.annotation._
  * excessive amount of heap memory).
  * JsonValue / Json / JValue
  */
-sealed abstract class Json { self =>
+sealed trait Json { self =>
   final def as[A](implicit decoder: JsonDecoder[A]): Either[String, A] = decoder.fromJsonAST(self)
 
   def asNull: Option[Unit]         = None


### PR DESCRIPTION
There is no benefit, in having here an abstract class instead of a trait, as far as I can tell.
But for derivation in the zio-ecosystem, typically abstract class is not supported (zio-schema for example).
That's why I propose to change to sealed trait. The behaviour should not change at all in my opinion.