### PR TITLE
Allow at least 256bit for json number

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -26,7 +26,7 @@ object Lexer {
   // TODO need a variant that doesn't skip whitespace, so that attack vectors
   // consisting of an infinite stream of space can exit early.
 
-  val NumberMaxBits: Int = 128
+  val NumberMaxBits: Int = 256
 
   // True if we got a string (implies a retraction), False for }
   def firstField(trace: List[JsonError], in: RetractReader): Boolean =


### PR DESCRIPTION
The `NumberMaxBits` should be at least 256 or export as a config item.
Because in many situations, large number is important, just like ethereum ecosystem, uint256 is used everywhere.
