### PR TITLE
Fixes jsonExclude annotation for Scala 3

### DIFF
--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -521,8 +521,7 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
         val len = params.length
 
         val names =
-          IArray.genericWrapArray(ctx
-            .params
+          IArray.genericWrapArray(params
             .map { p =>
               p.annotations.collectFirst {
                 case jsonField(name) => name

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -315,7 +315,7 @@ object EncoderSpec extends ZIOSpecDefault {
         },
         test("exclude fields") {
           import exampleexcludefield._
-          assert(Person("Peter", 20).toJson)(equalTo("""{"name":"Peter"}"""))
+          assert(Person(7, "Peter", 20).toJson)(equalTo("""{"name":"Peter"}"""))
         },
         test("aliases") {
           import exampleproducts._
@@ -465,7 +465,7 @@ object EncoderSpec extends ZIOSpecDefault {
 
   object exampleexcludefield {
 
-    case class Person(name: String, @jsonExclude age: Int)
+    case class Person(@jsonExclude id: Long, name: String, @jsonExclude age: Int)
 
     object Person {
       implicit val encoder: JsonEncoder[Person] = DeriveJsonEncoder.gen[Person]


### PR DESCRIPTION
It should fix the case when `@jsonExclude` field is placed before necessary fields.
The test also was modified in order to reproduce the case.
