### PR TITLE
Feat: scala3 enumeration support

### DIFF
--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -101,6 +101,23 @@ Decoding fail because 'Pear' is not a valid value
 
 Almost all of the standard library data types are supported as fields on the case class, and it is easy to add support if one is missing.
 
+### Sealed families and enums for Scala 3
+Sealed families where all members are only objects, or a Scala 3 enum with all cases parameterless are interpreted as enumerations and will encode 1:1 with their value-names.
+```scala
+enum Foo derives JsonDecoder:
+  case Bar
+  case Baz
+  case Qux
+```
+or
+```scala
+sealed trait Foo derives JsonDecoder
+object Foo:
+  case object Bar extends Foo
+  case object Baz extends Foo
+  case object Qux extends Foo
+```
+
 ## Manual instances
 
 Sometimes it is easier to reuse an existing `JsonDecoder` rather than generate a new one. This can be accomplished using convenience methods on the `JsonDecoder` typeclass to *derive* new decoders

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -55,6 +55,23 @@ apple.toJson
 
 Almost all of the standard library data types are supported as fields on the case class, and it is easy to add support if one is missing.
 
+### Sealed families and enums for Scala 3
+Sealed families where all members are only objects, or a Scala 3 enum with all cases parameterless are interpreted as enumerations and will encode 1:1 with their value-names.
+```scala
+enum Foo derives JsonEncoder:
+  case Bar
+  case Baz
+  case Qux
+```
+or
+```scala
+sealed trait Foo derives JsonEncoder
+object Foo:
+  case object Bar extends Foo
+  case object Baz extends Foo
+  case object Qux extends Foo
+```
+
 ## Manual instances
 
 Sometimes it is easier to reuse an existing `JsonEncoder` rather than generate a new one. This can be accomplished using convenience methods on the `JsonEncoder` typeclass to *derive* new decoders:

--- a/zio-json-golden/src/test/scala/zio/json/golden/GoldenSpec.scala
+++ b/zio-json-golden/src/test/scala/zio/json/golden/GoldenSpec.scala
@@ -11,9 +11,9 @@ object GoldenSpec extends ZIOSpecDefault {
   sealed trait SumType
 
   object SumType {
-    case object Case1 extends SumType
-    case object Case2 extends SumType
-    case object Case3 extends SumType
+    case object Case1  extends SumType
+    case object Case2  extends SumType
+    case class Case3() extends SumType
 
     implicit val jsonCodec: JsonCodec[SumType] = DeriveJsonCodec.gen
   }

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -402,7 +402,7 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
     lazy val namesMap: Map[String, Int] =
       names.zipWithIndex.toMap
 
-    def isEnumeration = ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
+    def isEnumeration = ctx.isEnum && ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
 
     def discrim = ctx.annotations.collectFirst { case jsonDiscriminator(n) => n }
 
@@ -641,7 +641,7 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
   def split[A](ctx: SealedTrait[JsonEncoder, A]): JsonEncoder[A] = {
     val jsonHintFormat: JsonMemberFormat =
       ctx.annotations.collectFirst { case jsonHintNames(format) => format }.getOrElse(IdentityFormat)
-    val isEnumeration = ctx.subtypes.forall(_.typeclass == caseObjectEncoder)
+    val isEnumeration = ctx.isEnum && ctx.subtypes.forall(_.typeclass == caseObjectEncoder)
 
     val discrim = ctx
       .annotations

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -402,7 +402,7 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
     lazy val namesMap: Map[String, Int] =
       names.zipWithIndex.toMap
 
-    def isEnumeration = ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
+    def isEnumeration = ctx.isEnum && ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
 
     def discrim = ctx.annotations.collectFirst { case jsonDiscriminator(n) => n }
 

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -402,7 +402,7 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
     lazy val namesMap: Map[String, Int] =
       names.zipWithIndex.toMap
 
-    def isEnumeration = ctx.isEnum && ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
+    def isEnumeration = ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
 
     def discrim = ctx.annotations.collectFirst { case jsonDiscriminator(n) => n }
 
@@ -639,9 +639,10 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
     }
 
   def split[A](ctx: SealedTrait[JsonEncoder, A]): JsonEncoder[A] = {
+    val isEnumeration = ctx.subtypes.forall(_.typeclass == caseObjectEncoder)
+
     val jsonHintFormat: JsonMemberFormat =
       ctx.annotations.collectFirst { case jsonHintNames(format) => format }.getOrElse(IdentityFormat)
-    val isEnumeration = ctx.isEnum && ctx.subtypes.forall(_.typeclass == caseObjectEncoder)
 
     val discrim = ctx
       .annotations

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -402,7 +402,7 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
     lazy val namesMap: Map[String, Int] =
       names.zipWithIndex.toMap
 
-    def isEnumeration = ctx.isEnum && ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
+    def isEnumeration = ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
 
     def discrim = ctx.annotations.collectFirst { case jsonDiscriminator(n) => n }
 
@@ -641,6 +641,8 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
   def split[A](ctx: SealedTrait[JsonEncoder, A]): JsonEncoder[A] = {
     val jsonHintFormat: JsonMemberFormat =
       ctx.annotations.collectFirst { case jsonHintNames(format) => format }.getOrElse(IdentityFormat)
+    val isEnumeration = ctx.subtypes.forall(_.typeclass == caseObjectEncoder)
+
     val discrim = ctx
       .annotations
       .collectFirst {

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -402,7 +402,10 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
     lazy val namesMap: Map[String, Int] =
       names.zipWithIndex.toMap
 
-    def isEnumeration = ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])
+    def isEnumeration = 
+      (ctx.isEnum && ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[?, ?]])) || (
+        !ctx.isEnum && ctx.subtypes.forall(_.isObject)
+      )
 
     def discrim = ctx.annotations.collectFirst { case jsonDiscriminator(n) => n }
 
@@ -639,7 +642,10 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
     }
 
   def split[A](ctx: SealedTrait[JsonEncoder, A]): JsonEncoder[A] = {
-    val isEnumeration = ctx.subtypes.forall(_.typeclass == caseObjectEncoder)
+    val isEnumeration = 
+      (ctx.isEnum && ctx.subtypes.forall(_.typeclass == caseObjectEncoder)) || (
+        !ctx.isEnum && ctx.subtypes.forall(_.isObject)
+      )
 
     val jsonHintFormat: JsonMemberFormat =
       ctx.annotations.collectFirst { case jsonHintNames(format) => format }.getOrElse(IdentityFormat)

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -15,11 +15,22 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
 
       assertTrue(result == Right(Foo("hello")))
     },
-    test("Derives for a sum Enumeration type") {
+    test("Derives for a sum enum Enumeration type") {
       enum Foo derives JsonDecoder:
         case Bar
         case Baz
         case Qux
+
+      val result = "\"Qux\"".fromJson[Foo]
+    
+      assertTrue(result == Right(Foo.Qux))
+    },
+    test("Derives for a sum sealed trait Enumeration type") {
+      sealed trait Foo derives JsonDecoder
+      object Foo:
+        case object Bar extends Foo
+        case object Baz extends Foo
+        case object Qux extends Foo
 
       val result = "\"Qux\"".fromJson[Foo]
     

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -9,13 +9,11 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
 
   val spec = suite("DerivedDecoderSpec")(
     test("Derives for a product type") {
-      assertZIO(typeCheck {
-        """
-          case class Foo(bar: String) derives JsonDecoder
+      case class Foo(bar: String) derives JsonDecoder
 
-          "{\"bar\": \"hello\"}".fromJson[Foo]
-        """
-      })(isRight(anything))
+      val result = "{\"bar\": \"hello\"}".fromJson[Foo]
+
+      assertTrue(result == Right(Foo("hello")))
     },
     test("Derives for a sum Enumeration type") {
       enum Foo derives JsonDecoder:
@@ -28,16 +26,14 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
       assertTrue(result == Right(Foo.Qux))
     },
     test("Derives for a sum ADT type") {
-      assertZIO(typeCheck {
-        """
-          enum Foo derives JsonDecoder:
-            case Bar
-            case Baz(baz: String)
-            case Qux(foo: Foo)
+      enum Foo derives JsonDecoder:
+        case Bar
+        case Baz(baz: String)
+        case Qux(foo: Foo)
 
-          "{\"Qux\":{\"foo\":{\"Bar\":{}}}}".fromJson[Foo]
-        """
-      })(isRight(anything))
+      val result = "{\"Qux\":{\"foo\":{\"Bar\":{}}}}".fromJson[Foo]
+
+      assertTrue(result == Right(Foo.Qux(Foo.Bar)))
     },
     test("Derives and decodes for a union of string-based literals") {
       case class Foo(aOrB: "A" | "B", optA: Option["A"]) derives JsonDecoder

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -17,7 +17,17 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
         """
       })(isRight(anything))
     },
-    test("Derives for a sum type") {
+    test("Derives for a sum Enumeration type") {
+      enum Foo derives JsonDecoder:
+        case Bar
+        case Baz
+        case Qux
+
+      val result = "\"Qux\"".fromJson[Foo]
+    
+      assertTrue(result == Right(Foo.Qux))
+    },
+    test("Derives for a sum ADT type") {
       assertZIO(typeCheck {
         """
           enum Foo derives JsonDecoder:

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
@@ -8,13 +8,11 @@ import zio.test._
 object DerivedEncoderSpec extends ZIOSpecDefault {
   val spec = suite("DerivedEncoderSpec")(
     test("Derives for a product type") {
-      assertZIO(typeCheck {
-        """
-          case class Foo(bar: String) derives JsonEncoder
+      case class Foo(bar: String) derives JsonEncoder
 
-          Foo("bar").toJson
-        """
-      })(isRight(anything))
+      val json = Foo("bar").toJson
+
+      assertTrue(json == """{"bar":"bar"}""")
     },
     test("Derives for a sum Enumeration type") {
       enum Foo derives JsonEncoder:

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
@@ -16,17 +16,25 @@ object DerivedEncoderSpec extends ZIOSpecDefault {
         """
       })(isRight(anything))
     },
-    test("Derives for a sum type") {
-      assertZIO(typeCheck {
-        """
-          enum Foo derives JsonEncoder:
-            case Bar
-            case Baz(baz: String)
-            case Qux(foo: Foo)
+    test("Derives for a sum Enumeration type") {
+      enum Foo derives JsonEncoder:
+        case Bar
+        case Baz
+        case Qux
 
-          (Foo.Qux(Foo.Bar): Foo).toJson
-        """
-      })(isRight(anything))
+      val json = (Foo.Qux: Foo).toJson
+
+      assertTrue(json == """"Qux"""")
+    },
+    test("Derives for a sum ADT type") {
+      enum Foo derives JsonEncoder:
+        case Bar
+        case Baz(baz: String)
+        case Qux(foo: Foo)
+
+      val json = (Foo.Qux(Foo.Bar): Foo).toJson
+
+      assertTrue(json == """{"Qux":{"foo":{"Bar":{}}}}""")
     },
     test("Derives and encodes for a union of string-based literals") {
       case class Foo(aOrB: "A" | "B", optA: Option["A"]) derives JsonEncoder

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
@@ -14,11 +14,22 @@ object DerivedEncoderSpec extends ZIOSpecDefault {
 
       assertTrue(json == """{"bar":"bar"}""")
     },
-    test("Derives for a sum Enumeration type") {
+    test("Derives for a sum enum Enumeration type") {
       enum Foo derives JsonEncoder:
         case Bar
         case Baz
         case Qux
+
+      val json = (Foo.Qux: Foo).toJson
+
+      assertTrue(json == """"Qux"""")
+    },
+    test("Derives for a sum sealed trait Enumeration type") {
+      sealed trait Foo derives JsonEncoder
+      object Foo:
+        case object Bar extends Foo
+        case object Baz extends Foo
+        case object Qux extends Foo
 
       val json = (Foo.Qux: Foo).toJson
 


### PR DESCRIPTION
With this PR I have tried to implement Scala 3 enumeration support. Because the current macros already do some assumptions and are build with Magnolia I did not want to disrupt to much and tried to implement it under the following condition:
If all subtypes are named values (objects without parameters) then the type is an enumeration.

This means that if an enum has mixed children, with and without parameters, then the implementations stays the same. Only for pure enumerations (all named values) the encoding/decoding will be affected. 

Breaking:
To my opinion the current implementation is wrong as enumerations are normally serialized as strings. But this PR will of course be breaking for the few using zio-json with Scala 3 enumerations already. 

I deliberately did not try to implement this for Scala 2 as these are not native enumerations. 