### PR TITLE
Type hint transformation for sealed hierarchies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,32 @@ banana.toJson
 apple.toJson
 ```
 
+Another way of changing type hint is using `@jsonHintNames` annotation on sealed class. It allows to apply transformation
+to all type hint values in hierarchy. Same transformations are provided as for `@jsonMemberNames` annotation.
+
+Here's an example:
+
+```scala mdoc
+import zio.json._
+
+@jsonHintNames(SnakeCase)
+sealed trait FruitKind
+
+case class GoodFruit(good: Boolean) extends FruitKind
+
+case class BadFruit(bad: Boolean) extends FruitKind
+
+object FruitKind {
+  implicit val encoder: JsonEncoder[FruitKind] =
+    DeriveJsonEncoder.gen[FruitKind]
+}
+
+val goodFruit: FruitKind = GoodFruit(true)
+val badFruit: FruitKind = BadFruit(true)
+
+goodFruit.toJson
+badFruit.toJson
+```
 ## jsonDiscriminator
 
 

--- a/zio-json-macros/shared/src/test/scala/zio/json/DeriveSpec.scala
+++ b/zio-json-macros/shared/src/test/scala/zio/json/DeriveSpec.scala
@@ -31,6 +31,13 @@ object DeriveSpec extends ZIOSpecDefault {
           assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
           assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
         },
+        test("sum encoding with hint names") {
+          import examplesumhintnames._
+
+          assert("""{"child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"type":"child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
+        },
         test("sum alternative encoding") {
           import examplealtsum._
 
@@ -38,6 +45,14 @@ object DeriveSpec extends ZIOSpecDefault {
           assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
           assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
           assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
+        },
+        test("sum alternative encoding with hint names") {
+          import examplealtsumhintnames._
+
+          assert("""{"hint":"child1"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"hint":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+          assert("""{"child1":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
         }
       )
     )
@@ -59,6 +74,15 @@ object DeriveSpec extends ZIOSpecDefault {
     case class Child2() extends Parent
   }
 
+  object examplesumhintnames {
+    @jsonDerive
+    @jsonHintNames(SnakeCase)
+    sealed abstract class Parent
+
+    case class Child1() extends Parent
+    case class Child2() extends Parent
+  }
+
   object exampleempty {
     @jsonDerive
     case class Empty(a: Option[String])
@@ -72,6 +96,19 @@ object DeriveSpec extends ZIOSpecDefault {
     sealed abstract class Parent
 
     @jsonHint("Cain")
+    case class Child1() extends Parent
+
+    @jsonHint("Abel")
+    case class Child2() extends Parent
+  }
+
+  object examplealtsumhintnames {
+
+    @jsonDerive
+    @jsonDiscriminator("hint")
+    @jsonHintNames(SnakeCase)
+    sealed abstract class Parent
+
     case class Child1() extends Parent
 
     @jsonHint("Abel")

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -177,6 +177,12 @@ private[json] object jsonMemberNames {
 final case class jsonHint(name: String) extends Annotation
 
 /**
+ * If used on a sealed class will determine the strategy of type hint value transformation for disambiguating
+ * classes during serialization and deserialization. Same strategies are provided as for [[jsonMemberNames]].
+ */
+final case class jsonHintNames(format: JsonMemberFormat) extends Annotation
+
+/**
  * If used on a case class, will exit early if any fields are in the JSON that
  * do not correspond to field names in the case class.
  *
@@ -201,11 +207,13 @@ final class jsonExclude extends Annotation
  * @param sumTypeHandling see [[jsonDiscriminator]]
  * @param fieldNameMapping see [[jsonMemberNames]]
  * @param allowExtraFields see [[jsonNoExtraFields]]
+ * @param sumTypeMapping see [[jsonHintNames]]
  */
 final case class JsonCodecConfiguration(
   sumTypeHandling: SumTypeHandling = WrapperWithClassNameField,
   fieldNameMapping: JsonMemberFormat = IdentityFormat,
-  allowExtraFields: Boolean = true
+  allowExtraFields: Boolean = true,
+  sumTypeMapping: JsonMemberFormat = IdentityFormat
 )
 
 object JsonCodecConfiguration {
@@ -417,10 +425,12 @@ object DeriveJsonDecoder {
   }
 
   def split[A](ctx: SealedTrait[JsonDecoder, A])(implicit config: JsonCodecConfiguration): JsonDecoder[A] = {
+    val jsonHintFormat: JsonMemberFormat =
+      ctx.annotations.collectFirst { case jsonHintNames(format) => format }.getOrElse(config.sumTypeMapping)
     val names: Array[String] = ctx.subtypes.map { p =>
       p.annotations.collectFirst { case jsonHint(name) =>
         name
-      }.getOrElse(p.typeName.short)
+      }.getOrElse(jsonHintFormat(p.typeName.short))
     }.toArray
     val matrix: StringMatrix = new StringMatrix(names)
     lazy val tcs: Array[JsonDecoder[Any]] =
@@ -595,10 +605,12 @@ object DeriveJsonEncoder {
       }
 
   def split[A](ctx: SealedTrait[JsonEncoder, A])(implicit config: JsonCodecConfiguration): JsonEncoder[A] = {
+    val jsonHintFormat: JsonMemberFormat =
+      ctx.annotations.collectFirst { case jsonHintNames(format) => format }.getOrElse(config.sumTypeMapping)
     val names: Array[String] = ctx.subtypes.map { p =>
       p.annotations.collectFirst { case jsonHint(name) =>
         name
-      }.getOrElse(p.typeName.short)
+      }.getOrElse(jsonHintFormat(p.typeName.short))
     }.toArray
     def discrim =
       ctx.annotations.collectFirst { case jsonDiscriminator(n) => n }.orElse(config.sumTypeHandling.discriminatorField)

--- a/zio-json/shared/src/test/scala-2.x/zio/json/ConfigurableDeriveCodecSpec.scala
+++ b/zio-json/shared/src/test/scala-2.x/zio/json/ConfigurableDeriveCodecSpec.scala
@@ -113,6 +113,19 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
             expectedObj.toJson == expectedStr
           )
         },
+        test("should override sum type mapping") {
+          val expectedStr     = """{"$type":"case_class","i":1}"""
+          val expectedObj: ST = ST.CaseClass(i = 1)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"), sumTypeMapping = SnakeCase)
+          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[ST].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
         test("should prevent extra fields") {
           val jsonStr = """{"someField":1,"someOtherField":"a","extra":123}"""
 

--- a/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/CodecSpec.scala
@@ -78,6 +78,13 @@ object CodecSpec extends ZIOSpecDefault {
           assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
           assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
         },
+        test("sum encoding with hint names") {
+          import examplesumhintnames._
+
+          assert("""{"child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"type":"child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
+        },
         test("sum alternative encoding") {
           import examplealtsum._
 
@@ -85,6 +92,14 @@ object CodecSpec extends ZIOSpecDefault {
           assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
           assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
           assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
+        },
+        test("sum alternative encoding with hint names") {
+          import examplealtsumhintnames._
+
+          assert("""{"hint":"child1"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"hint":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+          assert("""{"child1":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
         },
         test("key transformation") {
           import exampletransformkeys._
@@ -232,6 +247,17 @@ object CodecSpec extends ZIOSpecDefault {
     case class Child2() extends Parent
   }
 
+  object examplesumhintnames {
+    @jsonHintNames(SnakeCase)
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val codec: JsonCodec[Parent] = DeriveJsonCodec.gen[Parent]
+    }
+    case class Child1() extends Parent
+    case class Child2() extends Parent
+  }
+
   object exampleempty {
     case class Empty(a: Option[String])
 
@@ -243,6 +269,7 @@ object CodecSpec extends ZIOSpecDefault {
   object examplealtsum {
 
     @jsonDiscriminator("hint")
+    @jsonHintNames(SnakeCase)
     sealed abstract class Parent
 
     object Parent {
@@ -250,6 +277,22 @@ object CodecSpec extends ZIOSpecDefault {
     }
 
     @jsonHint("Cain")
+    case class Child1() extends Parent
+
+    @jsonHint("Abel")
+    case class Child2() extends Parent
+  }
+
+  object examplealtsumhintnames {
+
+    @jsonDiscriminator("hint")
+    @jsonHintNames(SnakeCase)
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val codec: JsonCodec[Parent] = DeriveJsonCodec.gen[Parent]
+    }
+
     case class Child1() extends Parent
 
     @jsonHint("Abel")

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -149,6 +149,14 @@ object DecoderSpec extends ZIOSpecDefault {
           assert("""{"Child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
           assert("""{"type":"Child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
         },
+        test("sum encoding with hint names") {
+          import examplesumhintnames._
+
+          assert("""{"child1":{}}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"child2":{}}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"Child1":{}}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+          assert("""{"type":"child1"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)")))
+        },
         test("sum alternative encoding") {
           import examplealtsum._
 
@@ -156,6 +164,14 @@ object DecoderSpec extends ZIOSpecDefault {
           assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
           assert("""{"hint":"Samson"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
           assert("""{"Cain":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
+        },
+        test("sum alternative encoding with hint names") {
+          import examplealtsumhintnames._
+
+          assert("""{"hint":"child1"}""".fromJson[Parent])(isRight(equalTo(Child1()))) &&
+          assert("""{"hint":"Abel"}""".fromJson[Parent])(isRight(equalTo(Child2()))) &&
+          assert("""{"hint":"Child2"}""".fromJson[Parent])(isLeft(equalTo("(invalid disambiguator)"))) &&
+          assert("""{"child1":{}}""".fromJson[Parent])(isLeft(equalTo("(missing hint 'hint')")))
         },
         test("unicode") {
           assert(""""€🐵🥰"""".fromJson[String])(isRight(equalTo("€🐵🥰")))
@@ -544,6 +560,21 @@ object DecoderSpec extends ZIOSpecDefault {
 
   }
 
+  object examplesumhintnames {
+
+    @jsonHintNames(CamelCase)
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
+    }
+
+    case class Child1() extends Parent
+
+    case class Child2() extends Parent
+
+  }
+
   object examplealtsum {
 
     @jsonDiscriminator("hint")
@@ -554,6 +585,23 @@ object DecoderSpec extends ZIOSpecDefault {
     }
 
     @jsonHint("Cain")
+    case class Child1() extends Parent
+
+    @jsonHint("Abel")
+    case class Child2() extends Parent
+
+  }
+
+  object examplealtsumhintnames {
+
+    @jsonDiscriminator("hint")
+    @jsonHintNames(CamelCase)
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val decoder: JsonDecoder[Parent] = DeriveJsonDecoder.gen[Parent]
+    }
+
     case class Child1() extends Parent
 
     @jsonHint("Abel")

--- a/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/EncoderSpec.scala
@@ -400,10 +400,25 @@ object EncoderSpec extends ZIOSpecDefault {
           assert((Child1(): Parent).toJsonAST)(isRight(equalTo(Json.Obj(Chunk("Child1" -> Json.Obj()))))) &&
           assert((Child2(): Parent).toJsonAST)(isRight(equalTo(Json.Obj(Chunk("Cain" -> Json.Obj())))))
         },
+        test("sum encoding with hint names") {
+          import examplesumhintnames._
+
+          assert((Child1(): Parent).toJsonAST)(isRight(equalTo(Json.Obj(Chunk("child1" -> Json.Obj()))))) &&
+          assert((Child2(): Parent).toJsonAST)(isRight(equalTo(Json.Obj(Chunk("Cain" -> Json.Obj())))))
+        },
         test("sum alternative encoding") {
           import examplealtsum._
 
           assert((Child1(): Parent).toJsonAST)(isRight(equalTo(Json.Obj("hint" -> Json.Str("Child1"))))) &&
+          assert((Child2(None): Parent).toJsonAST)(isRight(equalTo(Json.Obj("hint" -> Json.Str("Abel"))))) &&
+          assert((Child2(Some("hello")): Parent).toJsonAST)(
+            (isRight(equalTo(Json.Obj("s" -> Json.Str("hello"), "hint" -> Json.Str("Abel")))))
+          )
+        },
+        test("sum alternative encoding with hint names") {
+          import examplealtsumhintnames._
+
+          assert((Child1(): Parent).toJsonAST)(isRight(equalTo(Json.Obj("hint" -> Json.Str("child1"))))) &&
           assert((Child2(None): Parent).toJsonAST)(isRight(equalTo(Json.Obj("hint" -> Json.Str("Abel"))))) &&
           assert((Child2(Some("hello")): Parent).toJsonAST)(
             (isRight(equalTo(Json.Obj("s" -> Json.Str("hello"), "hint" -> Json.Str("Abel")))))
@@ -488,9 +503,42 @@ object EncoderSpec extends ZIOSpecDefault {
 
   }
 
+  object examplesumhintnames {
+
+    @jsonHintNames(CamelCase)
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val encoder: JsonEncoder[Parent] = DeriveJsonEncoder.gen[Parent]
+    }
+
+    case class Child1() extends Parent
+
+    @jsonHint("Cain")
+    case class Child2() extends Parent
+
+  }
+
   object examplealtsum {
 
     @jsonDiscriminator("hint")
+    sealed abstract class Parent
+
+    object Parent {
+      implicit val encoder: JsonEncoder[Parent] = DeriveJsonEncoder.gen[Parent]
+    }
+
+    case class Child1() extends Parent
+
+    @jsonHint("Abel")
+    case class Child2(s: Option[String]) extends Parent
+
+  }
+
+  object examplealtsumhintnames {
+
+    @jsonDiscriminator("hint")
+    @jsonHintNames(CamelCase)
     sealed abstract class Parent
 
     object Parent {


### PR DESCRIPTION
Hi, this PR adds support for transforming type hint values in sealed hierarchies using same approach as for `@jsonMemberNames` - via new annotation `@jsonHintNames` for sealed class / trait. This approach looks more maintainable than individual `@jsonHint` for each descendent, especially when supporting some naming convention in large hierarchy.
I also noticed similar feature request in discord, so I hope this PR will be useful not only for me: https://discord.com/channels/629491597070827530/733728086637412422/1221797252432007290