### PR TITLE
Implement inheritDiscriminator annotation

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -29,8 +29,6 @@ jobs:
         check-latest: true
     - name: Check if the README file is up to date
       run: sbt  docs/checkReadme
-    - name: Check if the site workflow is up to date
-      run: sbt  docs/checkGithubWorkflow
     - name: Check artifacts build process
       run: sbt  +publishLocal
     - name: Check website build process

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [ZIO Json](https://github.com/zio/zio-json) is a fast and secure JSON library with tight ZIO integration.
 
-[![Production Ready](https://img.shields.io/badge/Project%20Stage-Production%20Ready-brightgreen.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-json/workflows/CI/badge.svg) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-json_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-json_2.13/) [![ZIO JSON](https://img.shields.io/github/stars/zio/zio-json?style=social)](https://github.com/zio/zio-json)
+[![Production Ready](https://img.shields.io/badge/Project%20Stage-Production%20Ready-brightgreen.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-json/workflows/CI/badge.svg) [![Sonatype Releases](https://img.shields.io/nexus/r/https/oss.sonatype.org/dev.zio/zio-json_2.13.svg?label=Sonatype%20Release)](https://oss.sonatype.org/content/repositories/releases/dev/zio/zio-json_2.13/) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-json_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-json_2.13/) [![javadoc](https://javadoc.io/badge2/dev.zio/zio-json-docs_2.13/javadoc.svg)](https://javadoc.io/doc/dev.zio/zio-json-docs_2.13) [![ZIO JSON](https://img.shields.io/github/stars/zio/zio-json?style=social)](https://github.com/zio/zio-json)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The goal of this project is to create the best all-round JSON library for Scala:
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-json" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-json" % "0.6.2"
 ```
 
 ## Example

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -47,6 +47,11 @@ final case class jsonDiscriminator(name: String) extends Annotation
 // does not provide a mechanism for obtaining the CaseClass associated to the
 // Subtype.
 
+/**
+ * If used on a class extending a sealed class using `@jsonDiscriminator`, it will include the parent discriminator while encoding and decoding.
+ */
+final case class inheritDiscriminator() extends Annotation
+
 sealed trait JsonMemberFormat extends (String => String)
 case class CustomCase(f: String => String) extends JsonMemberFormat {
   override def apply(memberName: String): String = f(memberName)
@@ -215,7 +220,30 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
       .collectFirst { case _: jsonNoExtraFields => () }
       .isDefined
 
-    if (ctx.params.isEmpty) {
+    val inheritedHint = ctx
+      .annotations
+      .collectFirst { case _: inheritDiscriminator => 
+        ctx
+          .inheritedAnnotations
+          .collectFirst {
+            case jsonDiscriminator(n) => n
+          }.getOrElse(throw new Throwable("Not possible to use `inheritDiscriminator` annotation as there is no discriminator in parent class to inherit"))
+        }
+
+
+    val correctHint = inheritedHint
+      .map { _ =>
+        val jsonHintFormat: JsonMemberFormat =
+          ctx.inheritedAnnotations.collectFirst { case jsonHintNames(format) => format }.getOrElse(IdentityFormat)
+        ctx
+          .annotations.collectFirst { case jsonHint(name) =>
+            name
+          }.getOrElse(jsonHintFormat(ctx.typeInfo.short))
+      }
+    
+    val numberOfParams = ctx.params.size + inheritedHint.map(_ => 1).getOrElse(0)
+
+    if (numberOfParams == 0) {
       new JsonDecoder[A] {
         def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
           if (no_extra) {
@@ -237,7 +265,7 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
     } else {
       new JsonDecoder[A] {
         val (names, aliases): (Array[String], Array[(String, Int)]) = {
-          val names = Array.ofDim[String](ctx.params.size)
+          val names = Array.ofDim[String](numberOfParams)
           val aliasesBuilder = Array.newBuilder[(String, Int)]
           ctx.params.zipWithIndex.foreach { (p, i) =>
             names(i) = p
@@ -264,6 +292,7 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
             throw new AssertionError(msg)
           }
 
+          inheritedHint.map(hint => {names(names.length - 1) = hint; ()})
           (names, aliases)
         }
 
@@ -272,10 +301,10 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
         val spans:  Array[JsonError] = names.map(JsonError.ObjectAccess(_))
 
         lazy val tcs: Array[JsonDecoder[Any]] =
-          IArray.genericWrapArray(ctx.params.map(_.typeclass)).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
+          IArray.genericWrapArray(ctx.params.map(_.typeclass)).toArray.asInstanceOf[Array[JsonDecoder[Any]]] ++ Array(JsonDecoder.string.asInstanceOf[JsonDecoder[Any]])
 
         lazy val defaults: Array[Option[Any]] =
-          IArray.genericWrapArray(ctx.params.map(_.default)).toArray
+          IArray.genericWrapArray(ctx.params.map(_.default)).toArray ++ Array(None)
 
         lazy val namesMap: Map[String, Int] =
           (names.zipWithIndex ++ aliases).toMap
@@ -321,7 +350,12 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
             i += 1
           }
 
-          ctx.rawConstruct(new ArraySeq(ps))
+          val finalPs = if (inheritedHint.isEmpty) ps else {
+            correctHint.map(hintValue => if (hintValue != ps.last) throw UnsafeJson(JsonError.Message(s"Hint should have been $hintValue") :: trace))
+            ps.init
+          }
+
+          ctx.rawConstruct(new ArraySeq(finalPs))
         }
 
         override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): A = {
@@ -349,11 +383,21 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
                       ps(field) = tcs(field).unsafeFromJsonAST(trace_, value)
                     }
                   case None =>
-                    if (no_extra) {
-                      throw UnsafeJson(
-                        JsonError.Message(s"invalid extra field") :: trace
-                      )
+                    inheritedHint match {
+                      case Some(hint) if key == hint => 
+                        value match {
+                          case Json.Str(name) => correctHint.map(hintValue => if (hintValue != ps.last) throw UnsafeJson(JsonError.Message(s"Hint should have been $hintValue") :: trace))
+                          case _ => throw UnsafeJson(JsonError.Message(s"Non-string hint '$hint'") :: trace)
+                        }
+                  
+                      case _ =>
+                        if (no_extra) {
+                          throw UnsafeJson(
+                            JsonError.Message(s"invalid extra field") :: trace
+                          )
+                        }
                     }
+                    
                 }
               }
 
@@ -502,8 +546,31 @@ object DeriveJsonDecoder extends Derivation[JsonDecoder] { self =>
 }
 
 object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
-  def join[A](ctx: CaseClass[Typeclass, A]): JsonEncoder[A] =
-    if (ctx.params.isEmpty) {
+
+  def join[A](ctx: CaseClass[Typeclass, A]): JsonEncoder[A] = {
+
+    val inheritedHint = ctx
+      .annotations
+      .collectFirst { case _: inheritDiscriminator => 
+        ctx
+          .inheritedAnnotations
+          .collectFirst {
+            case jsonDiscriminator(n) => n
+          }.getOrElse(throw new Throwable("Not possible to use `inheritDiscriminator` annotation as there is no discriminator in parent class to inherit"))
+        }
+
+    val correctHint = {
+        val jsonHintFormat: JsonMemberFormat =
+          ctx.inheritedAnnotations.collectFirst { case jsonHintNames(format) => format }.getOrElse(IdentityFormat)
+        ctx
+          .annotations.collectFirst { case jsonHint(name) =>
+            name
+          }.getOrElse(jsonHintFormat(ctx.typeInfo.short))
+      }
+    
+    val numberOfParams = ctx.params.size + inheritedHint.map(_ => 1).getOrElse(0)
+
+    if (numberOfParams == 0) {
       new JsonEncoder[A] {
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit =
           out.write("{}")
@@ -552,6 +619,16 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
           var i = 0
           var prevFields = false
 
+          inheritedHint.map { hint =>
+
+            JsonEncoder.string.unsafeEncode(hint, indent_, out)
+            if (indent.isEmpty) out.write(":")
+            else out.write(" : ")
+            JsonEncoder.string.unsafeEncode(correctHint, indent_, out)
+
+            prevFields = true  
+          }
+
           while (i < len) {
             val tc = tcs(i)
             val p  = params(i).deref(a)
@@ -599,10 +676,17 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
                 }
               }
             }
+            .map { chunk =>
+              inheritedHint match {
+                case None => chunk
+                case Some(hint) => chunk :+ hint -> Json.Str(correctHint)
+              }
+            }
             .map(Json.Obj.apply)
         }
       }
     }
+  }
 
   def split[A](ctx: SealedTrait[JsonEncoder, A]): JsonEncoder[A] = {
     val jsonHintFormat: JsonMemberFormat =
@@ -628,11 +712,8 @@ object DeriveJsonEncoder extends Derivation[JsonEncoder] { self =>
             JsonEncoder.pad(indent_, out)
             JsonEncoder.string.unsafeEncode(name, indent_, out)
 
-            if (indent.isEmpty) {
-              out.write(":")
-            } else {
-              out.write(" : ")
-            }
+            if (indent.isEmpty) out.write(":")
+            else out.write(" : ")
 
             sub.typeclass.unsafeEncode(sub.cast(a), indent_, out)
             JsonEncoder.pad(indent, out)


### PR DESCRIPTION
This is a different approach than #1112. The PR implements a `inheritDiscriminator` annotation to be used on case classes. If the parent class doesn't have a `jsonDiscriminator` annotation it will throw a compilation error when deriving a codec. When there is a `jsonDiscriminator` it will include this in the encoding with the name of the case class or the `jsonHint`.

I don't know if this is the exact use case of @alphaho, but I guess it might be encoding and decoding with different encoders for convenience when interacting between different parts of the code base. In these cases it might be easier to use something like this annotation. And this isn't a breaking change. What do you think @987Nabil?
fixes #1056
/claim #1056

The final code for the example of @alphaho would be 
```
import zio.json._

@jsonDiscriminator("type")
sealed trait Animal
object Animal {
  @inheritDiscriminator @jsonHint("dog")
  case class Dog(name: String) extends Animal
  object Dog {
    implicit val dogCodec: JsonCodec[Dog] = DeriveJsonCodec.gen
  }
  
  @inheritDiscriminator @jsonHint("cat")
  case class Cat(name: String, weight: Double) extends Animal

  implicit val animalCodec: JsonCodec[Animal] = DeriveJsonCodec.gen
}
```

