### PR TITLE
Add JsonCodec derivation from encoder and decoder

### DIFF
--- a/zio-json/shared/src/main/scala-2.12/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.12/zio/json/JsonCodecVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+private[json] trait JsonCodecVersionSpecific

--- a/zio-json/shared/src/main/scala-2.13/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.13/zio/json/JsonCodecVersionSpecific.scala
@@ -1,0 +1,7 @@
+package zio.json
+
+private[json] trait JsonCodecVersionSpecific {
+
+  implicit def fromEncoderDecoder[A](implicit encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] =
+    JsonCodec(encoder, decoder)
+}

--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonCodecVersionSpecific.scala
@@ -1,3 +1,0 @@
-package zio.json
-
-trait JsonCodecVersionSpecific

--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonDecoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonDecoderVersionSpecific.scala
@@ -1,3 +1,3 @@
 package zio.json
 
-trait JsonDecoderVersionSpecific
+private[json] trait JsonDecoderVersionSpecific

--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonEncoderVersionSpecific.scala
@@ -1,3 +1,3 @@
 package zio.json
 
-trait JsonEncoderVersionSpecific
+private[json] trait JsonEncoderVersionSpecific

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
@@ -1,5 +1,8 @@
 package zio.json
 
-trait JsonCodecVersionSpecific {
+private[json] trait JsonCodecVersionSpecific {
   inline def derived[A: deriving.Mirror.Of]: JsonCodec[A] = DeriveJsonCodec.gen[A]
+
+  given fromEncoderDecoder[A](using encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] =
+    JsonCodec(encoder, decoder)
 }

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
@@ -1,5 +1,5 @@
 package zio.json
 
-trait JsonDecoderVersionSpecific {
+private[json] trait JsonDecoderVersionSpecific {
   inline def derived[A: deriving.Mirror.Of]: JsonDecoder[A] = DeriveJsonDecoder.gen[A]
 }

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
@@ -1,5 +1,5 @@
 package zio.json
 
-trait JsonEncoderVersionSpecific {
+private[json] trait JsonEncoderVersionSpecific {
   inline def derived[A: deriving.Mirror.Of]: JsonEncoder[A] = DeriveJsonEncoder.gen[A]
 }

--- a/zio-json/shared/src/main/scala/zio/json/JsonCodec.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonCodec.scala
@@ -188,7 +188,4 @@ private[json] trait CodecLowPriority3 { this: JsonCodec.type =>
   implicit val uuid: JsonCodec[java.util.UUID] = JsonCodec(JsonEncoder.uuid, JsonDecoder.uuid)
 
   implicit val currency: JsonCodec[java.util.Currency] = JsonCodec(JsonEncoder.currency, JsonDecoder.currency)
-
-  implicit def fromEncoderDecoder[A](implicit encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] =
-    new JsonCodec(encoder, decoder)
 }

--- a/zio-json/shared/src/main/scala/zio/json/JsonCodec.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonCodec.scala
@@ -87,8 +87,6 @@ final case class JsonCodec[A](encoder: JsonEncoder[A], decoder: JsonDecoder[A]) 
 object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 with JsonCodecVersionSpecific {
   def apply[A](implicit jsonCodec: JsonCodec[A]): JsonCodec[A] = jsonCodec
 
-  def apply[A](encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] = new JsonCodec(encoder, decoder)
-
   private def orElseEither[A, B](A: JsonCodec[A], B: JsonCodec[B]): JsonCodec[Either[A, B]] =
     JsonCodec(
       JsonEncoder.orElseEither[A, B](A.encoder, B.encoder),
@@ -190,4 +188,7 @@ private[json] trait CodecLowPriority3 { this: JsonCodec.type =>
   implicit val uuid: JsonCodec[java.util.UUID] = JsonCodec(JsonEncoder.uuid, JsonDecoder.uuid)
 
   implicit val currency: JsonCodec[java.util.Currency] = JsonCodec(JsonEncoder.currency, JsonDecoder.currency)
+
+  implicit def fromEncoderDecoder[A](implicit encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] =
+    new JsonCodec(encoder, decoder)
 }


### PR DESCRIPTION
Currently `summon[JsonCodec[zio.json.ast.Json]]` fails even though there are implicit encoder and decoder.

This PR allows codec derivation for types that already have encoder and decoder, in the same way of the current collection codec derivation.

