### PR TITLE
Deprecation of Checking the Updated Readme

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,8 +27,6 @@ jobs:
         distribution: temurin
         java-version: 17
         check-latest: true
-    - name: Check if the README file is up to date
-      run: sbt  docs/checkReadme
     - name: Check artifacts build process
       run: sbt  +publishLocal
     - name: Check website build process


### PR DESCRIPTION
Checking the readme on a pull request is deprecated a long time ago. Instead, we have to update ci to have autogenerated ci
More info [1](https://zio.dev/contributing-to-zio-ecosystem#automate-readme-generation) and [2 (recommended)](https://zio.dev/contributing-to-zio-ecosystem#utilizing-autogenerated-ci-through-the-zio-sbt-ci-plugin-recommended)