### PR TITLE
refactor: scala 3 const enum: simplify and cleanup

### DIFF
--- a/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonDecoderVersionSpecific.scala
@@ -17,12 +17,4 @@ trait DecoderLowPriorityVersionSpecific {
         case _                                  => Left("expected one of: " + values.toList.mkString(", "))
       }
     )
-
-  inline given constStringToEnum[T <: String](using IsConst[T] =:= true): JsonDecoder[T] =
-    JsonDecoder.string.mapOrFail(
-      {
-        case raw if raw == constValue[T] => Right(constValue[T])
-        case _                           => Left("expected one of: " + constValue[T])
-      }
-    )
 }

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
@@ -10,7 +10,4 @@ private[json] trait EncoderLowPriorityVersionSpecific {
 
   inline given unionOfStringEnumeration[T](using IsUnionOf[String, T]): JsonEncoder[T] =
     JsonEncoder.string.asInstanceOf[JsonEncoder[T]]
-
-  inline given constStringToEnum[T <: String](using IsConst[T] =:= true): JsonEncoder[T] =
-    JsonEncoder.string.narrow[T]
 }


### PR DESCRIPTION
Less is more... 

This PR removes unused code and refactors `constValueUnionTuple` to support also single constant literals so `constStringToEnum` can be dropped. 