### PR TITLE
Feat-string-like-field-decoder

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonFieldDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonFieldDecoder.scala
@@ -42,7 +42,7 @@ trait JsonFieldDecoder[+A] {
   def unsafeDecodeField(trace: List[JsonError], in: String): A
 }
 
-object JsonFieldDecoder {
+object JsonFieldDecoder extends LowPriorityJsonFieldDecoder {
   def apply[A](implicit a: JsonFieldDecoder[A]): JsonFieldDecoder[A] = a
 
   implicit val string: JsonFieldDecoder[String] = new JsonFieldDecoder[String] {
@@ -86,4 +86,14 @@ object JsonFieldDecoder {
   private[json] def strip(s: String, len: Int = 50): String =
     if (s.length <= len) s
     else s.substring(0, len) + "..."
+}
+
+private[json] trait LowPriorityJsonFieldDecoder {
+
+  def string: JsonFieldDecoder[String]
+
+  private def quotedString = string.map(raw => s""""$raw"""")
+
+  implicit def stringLike[T <: String: JsonDecoder]: JsonFieldDecoder[T] =
+    quotedString.mapOrFail(implicitly[JsonDecoder[T]].decodeJson)
 }

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -80,6 +80,12 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
 
       assertTrue("""{"aOrB": "A", "optA": "A"}""".fromJson[Foo] == Right(Foo("A", Some("A")))) &&
       assertTrue("""{"aOrB": "C"}""".fromJson[Foo] == Left(".aOrB(expected one of: A, B)"))
-    }
+    },
+    test("Derives and decodes for a custom map key string-based union type") {
+      case class Foo(aOrB: Map["A" | "B", Int]) derives JsonDecoder
+
+      assertTrue("""{"aOrB": {"A": 1, "B": 2}}""".fromJson[Foo] == Right(Foo(Map("A" -> 1, "B" -> 2)))) &&
+      assertTrue("""{"aOrB": {"C": 1}}""".fromJson[Foo] == Left(".aOrB.C((expected one of: A, B))"))
+    },
   )
 }

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -86,6 +86,6 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
 
       assertTrue("""{"aOrB": {"A": 1, "B": 2}}""".fromJson[Foo] == Right(Foo(Map("A" -> 1, "B" -> 2)))) &&
       assertTrue("""{"aOrB": {"C": 1}}""".fromJson[Foo] == Left(".aOrB.C((expected one of: A, B))"))
-    },
+    }
   )
 }

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedEncoderSpec.scala
@@ -59,6 +59,11 @@ object DerivedEncoderSpec extends ZIOSpecDefault {
       case class Foo(aOrB: "A" | "B", optA: Option["A"]) derives JsonEncoder
 
       assertTrue(Foo("A", Some("A")).toJson == """{"aOrB":"A","optA":"A"}""")
+    },
+    test("Derives and encodes for a custom map key string-based union type") {
+      case class Foo(aOrB: Map["A" | "B", Int]) derives JsonEncoder
+
+      assertTrue(Foo(Map("A" -> 1, "B" -> 2)).toJson == """{"aOrB":{"A":1,"B":2}}""")
     }
   )
 }


### PR DESCRIPTION
This PR should provide support for string-like types (`T <: String`) to be used as keys in json objects. 
The implementation reuses any applicable existing JsonDecoder, e.g. a decoder for a string-based const union. 

```scala
Foo(aOrB: Map["A" | "B", Int]) derives JsonDecoder
```
value encoded/decoded
```scala
Foo(Map("A" -> 1, "B" -> 2))
````
json
```json
{"aOrB":{"A":1,"B":2}}
```