### PR TITLE
fix(JsonCodec): codec derivation on nested types

### DIFF
--- a/zio-json/shared/src/main/scala-2.12/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.12/zio/json/JsonCodecVersionSpecific.scala
@@ -1,3 +1,0 @@
-package zio.json
-
-private[json] trait JsonCodecVersionSpecific

--- a/zio-json/shared/src/main/scala-2.13/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.13/zio/json/JsonCodecVersionSpecific.scala
@@ -1,7 +1,0 @@
-package zio.json
-
-private[json] trait JsonCodecVersionSpecific {
-
-  implicit def fromEncoderDecoder[A](implicit encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] =
-    JsonCodec(encoder, decoder)
-}

--- a/zio-json/shared/src/main/scala-2.x/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.x/JsonCodecVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.json
+
+trait JsonCodecVersionSpecific

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonCodecVersionSpecific.scala
@@ -3,6 +3,4 @@ package zio.json
 private[json] trait JsonCodecVersionSpecific {
   inline def derived[A: deriving.Mirror.Of]: JsonCodec[A] = DeriveJsonCodec.gen[A]
 
-  given fromEncoderDecoder[A](using encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] =
-    JsonCodec(encoder, decoder)
 }

--- a/zio-json/shared/src/main/scala/zio/json/JsonCodec.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonCodec.scala
@@ -87,6 +87,9 @@ final case class JsonCodec[A](encoder: JsonEncoder[A], decoder: JsonDecoder[A]) 
 object JsonCodec extends GeneratedTupleCodecs with CodecLowPriority0 with JsonCodecVersionSpecific {
   def apply[A](implicit jsonCodec: JsonCodec[A]): JsonCodec[A] = jsonCodec
 
+  implicit def fromEncoderDecoder[A](encoder: JsonEncoder[A], decoder: JsonDecoder[A]): JsonCodec[A] =
+    JsonCodec(encoder, decoder)
+
   private def orElseEither[A, B](A: JsonCodec[A], B: JsonCodec[B]): JsonCodec[Either[A, B]] =
     JsonCodec(
       JsonEncoder.orElseEither[A, B](A.encoder, B.encoder),


### PR DESCRIPTION
This is a fix for issue #1128 , see details in issue comments
(Review needed, I am not familiar with this codebase)

- 'encoder' parameter is now explicit for 'fromEncoderDecoder'
- removed version-specific variants that were used to work around a test

/claim #1128