### PR TITLE
fix unused explicitEmptyCollection annotation in macros and AST encoding

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -14,7 +14,7 @@ name: Website
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Git Checkout

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -482,34 +482,29 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
 private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
   this: JsonDecoder.type =>
 
-  implicit def array[A: JsonDecoder: reflect.ClassTag](implicit config: JsonCodecConfiguration): JsonDecoder[Array[A]] =
+  implicit def array[A: JsonDecoder: reflect.ClassTag]: JsonDecoder[Array[A]] =
     new JsonDecoder[Array[A]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): Array[A] =
-        if (!config.explicitEmptyCollections) Array.empty
-        else super.unsafeDecodeMissing(trace)
+      override def unsafeDecodeMissing(trace: List[JsonError]): Array[A] = Array.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Array[A] =
         builder(trace, in, Array.newBuilder[A])
     }
 
-  implicit def seq[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[Seq[A]] =
+  implicit def seq[A: JsonDecoder]: JsonDecoder[Seq[A]] =
     new JsonDecoder[Seq[A]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): Seq[A] =
-        if (!config.explicitEmptyCollections) Seq.empty
-        else super.unsafeDecodeMissing(trace)
+        Seq.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Seq[A] =
         builder(trace, in, immutable.Seq.newBuilder[A])
     }
 
-  implicit def chunk[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[Chunk[A]] =
+  implicit def chunk[A: JsonDecoder]: JsonDecoder[Chunk[A]] =
     new JsonDecoder[Chunk[A]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): Chunk[A] =
-        if (!config.explicitEmptyCollections) Chunk.empty
-        else super.unsafeDecodeMissing(trace)
+      override def unsafeDecodeMissing(trace: List[JsonError]): Chunk[A] = Chunk.empty
 
       val decoder = JsonDecoder[A]
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Chunk[A] =
@@ -528,169 +523,136 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
   implicit def nonEmptyChunk[A: JsonDecoder]: JsonDecoder[NonEmptyChunk[A]] =
     chunk[A].mapOrFail(NonEmptyChunk.fromChunk(_).toRight("Chunk was empty"))
 
-  implicit def indexedSeq[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[IndexedSeq[A]] =
+  implicit def indexedSeq[A: JsonDecoder]: JsonDecoder[IndexedSeq[A]] =
     new JsonDecoder[IndexedSeq[A]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): IndexedSeq[A] =
-        if (!config.explicitEmptyCollections) IndexedSeq.empty
-        else super.unsafeDecodeMissing(trace)
+      override def unsafeDecodeMissing(trace: List[JsonError]): IndexedSeq[A] = IndexedSeq.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): IndexedSeq[A] =
         builder(trace, in, IndexedSeq.newBuilder[A])
     }
 
-  implicit def linearSeq[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[immutable.LinearSeq[A]] =
+  implicit def linearSeq[A: JsonDecoder]: JsonDecoder[immutable.LinearSeq[A]] =
     new JsonDecoder[immutable.LinearSeq[A]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): immutable.LinearSeq[A] =
-        if (!config.explicitEmptyCollections) immutable.LinearSeq.empty
-        else super.unsafeDecodeMissing(trace)
+        immutable.LinearSeq.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): LinearSeq[A] =
         builder(trace, in, immutable.LinearSeq.newBuilder[A])
     }
 
-  implicit def listSet[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[immutable.ListSet[A]] =
+  implicit def listSet[A: JsonDecoder]: JsonDecoder[immutable.ListSet[A]] =
     new JsonDecoder[immutable.ListSet[A]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): immutable.ListSet[A] =
-        if (!config.explicitEmptyCollections) immutable.ListSet.empty
-        else super.unsafeDecodeMissing(trace)
+        immutable.ListSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): ListSet[A] =
         builder(trace, in, immutable.ListSet.newBuilder[A])
     }
 
-  implicit def treeSet[A: JsonDecoder: Ordering](implicit
-    config: JsonCodecConfiguration
-  ): JsonDecoder[immutable.TreeSet[A]] =
+  implicit def treeSet[A: JsonDecoder: Ordering]: JsonDecoder[immutable.TreeSet[A]] =
     new JsonDecoder[immutable.TreeSet[A]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): immutable.TreeSet[A] =
-        if (!config.explicitEmptyCollections) immutable.TreeSet.empty
-        else super.unsafeDecodeMissing(trace)
+        immutable.TreeSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): TreeSet[A] =
         builder(trace, in, immutable.TreeSet.newBuilder[A])
     }
 
-  implicit def list[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[List[A]] =
+  implicit def list[A: JsonDecoder]: JsonDecoder[List[A]] =
     new JsonDecoder[List[A]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): List[A] =
-        if (!config.explicitEmptyCollections) List.empty
-        else super.unsafeDecodeMissing(trace)
+      override def unsafeDecodeMissing(trace: List[JsonError]): List[A] = List.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): List[A] =
         builder(trace, in, new mutable.ListBuffer[A])
     }
 
-  implicit def vector[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[Vector[A]] =
+  implicit def vector[A: JsonDecoder]: JsonDecoder[Vector[A]] =
     new JsonDecoder[Vector[A]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): Vector[A] =
-        if (!config.explicitEmptyCollections) Vector.empty
-        else super.unsafeDecodeMissing(trace)
+        Vector.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Vector[A] =
         builder(trace, in, immutable.Vector.newBuilder[A])
     }
 
-  implicit def set[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[Set[A]] =
+  implicit def set[A: JsonDecoder]: JsonDecoder[Set[A]] =
     new JsonDecoder[Set[A]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): Set[A] =
-        if (!config.explicitEmptyCollections) Set.empty
-        else super.unsafeDecodeMissing(trace)
+      override def unsafeDecodeMissing(trace: List[JsonError]): Set[A] = Set.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Set[A] =
         builder(trace, in, Set.newBuilder[A])
     }
 
-  implicit def hashSet[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[immutable.HashSet[A]] =
+  implicit def hashSet[A: JsonDecoder]: JsonDecoder[immutable.HashSet[A]] =
     new JsonDecoder[immutable.HashSet[A]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): immutable.HashSet[A] =
-        if (!config.explicitEmptyCollections) immutable.HashSet.empty
-        else super.unsafeDecodeMissing(trace)
+        immutable.HashSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.HashSet[A] =
         builder(trace, in, immutable.HashSet.newBuilder[A])
     }
 
-  implicit def map[K: JsonFieldDecoder, V: JsonDecoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonDecoder[Map[K, V]] =
+  implicit def map[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[Map[K, V]] =
     new JsonDecoder[Map[K, V]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): Map[K, V] =
-        if (!config.explicitEmptyCollections) Map.empty
-        else super.unsafeDecodeMissing(trace)
+      override def unsafeDecodeMissing(trace: List[JsonError]): Map[K, V] = Map.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Map[K, V] =
         keyValueBuilder(trace, in, Map.newBuilder[K, V])
     }
 
-  implicit def hashMap[K: JsonFieldDecoder, V: JsonDecoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonDecoder[immutable.HashMap[K, V]] =
+  implicit def hashMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[immutable.HashMap[K, V]] =
     new JsonDecoder[immutable.HashMap[K, V]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): immutable.HashMap[K, V] =
-        if (!config.explicitEmptyCollections) immutable.HashMap.empty
-        else super.unsafeDecodeMissing(trace)
+        immutable.HashMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.HashMap[K, V] =
         keyValueBuilder(trace, in, immutable.HashMap.newBuilder[K, V])
     }
 
-  implicit def mutableMap[K: JsonFieldDecoder, V: JsonDecoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonDecoder[mutable.Map[K, V]] =
+  implicit def mutableMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[mutable.Map[K, V]] =
     new JsonDecoder[mutable.Map[K, V]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): mutable.Map[K, V] =
-        if (!config.explicitEmptyCollections) mutable.Map.empty
-        else super.unsafeDecodeMissing(trace)
+      override def unsafeDecodeMissing(trace: List[JsonError]): mutable.Map[K, V] = mutable.Map.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): mutable.Map[K, V] =
         keyValueBuilder(trace, in, mutable.Map.newBuilder[K, V])
     }
 
-  implicit def sortedSet[A: Ordering: JsonDecoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonDecoder[immutable.SortedSet[A]] =
+  implicit def sortedSet[A: Ordering: JsonDecoder]: JsonDecoder[immutable.SortedSet[A]] =
     new JsonDecoder[immutable.SortedSet[A]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): immutable.SortedSet[A] =
-        if (!config.explicitEmptyCollections) immutable.SortedSet.empty
-        else super.unsafeDecodeMissing(trace)
+        immutable.SortedSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.SortedSet[A] =
         builder(trace, in, immutable.SortedSet.newBuilder[A])
     }
 
-  implicit def sortedMap[K: JsonFieldDecoder: Ordering, V: JsonDecoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonDecoder[collection.SortedMap[K, V]] =
+  implicit def sortedMap[K: JsonFieldDecoder: Ordering, V: JsonDecoder]: JsonDecoder[collection.SortedMap[K, V]] =
     new JsonDecoder[collection.SortedMap[K, V]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): collection.SortedMap[K, V] =
-        if (!config.explicitEmptyCollections) collection.SortedMap.empty
-        else super.unsafeDecodeMissing(trace)
+        collection.SortedMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): collection.SortedMap[K, V] =
         keyValueBuilder(trace, in, collection.SortedMap.newBuilder[K, V])
     }
 
-  implicit def listMap[K: JsonFieldDecoder, V: JsonDecoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonDecoder[immutable.ListMap[K, V]] =
+  implicit def listMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[immutable.ListMap[K, V]] =
     new JsonDecoder[immutable.ListMap[K, V]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): immutable.ListMap[K, V] =
-        if (!config.explicitEmptyCollections) immutable.ListMap.empty
-        else super.unsafeDecodeMissing(trace)
+        immutable.ListMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.ListMap[K, V] =
         keyValueBuilder(trace, in, immutable.ListMap.newBuilder[K, V])
@@ -711,12 +673,10 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 private[json] trait DecoderLowPriority2 extends DecoderLowPriority3 {
   this: JsonDecoder.type =>
 
-  implicit def iterable[A: JsonDecoder](implicit config: JsonCodecConfiguration): JsonDecoder[Iterable[A]] =
+  implicit def iterable[A: JsonDecoder]: JsonDecoder[Iterable[A]] =
     new JsonDecoder[Iterable[A]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): Iterable[A] =
-        if (!config.explicitEmptyCollections) Iterable.empty
-        else super.unsafeDecodeMissing(trace)
+      override def unsafeDecodeMissing(trace: List[JsonError]): Iterable[A] = Iterable.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Iterable[A] =
         builder(trace, in, immutable.Iterable.newBuilder[A])
@@ -725,14 +685,12 @@ private[json] trait DecoderLowPriority2 extends DecoderLowPriority3 {
   // not implicit because this overlaps with decoders for lists of tuples
   def keyValueChunk[K, A](implicit
     K: JsonFieldDecoder[K],
-    A: JsonDecoder[A],
-    config: JsonCodecConfiguration
+    A: JsonDecoder[A]
   ): JsonDecoder[Chunk[(K, A)]] =
     new JsonDecoder[Chunk[(K, A)]] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): Chunk[(K, A)] =
-        if (!config.explicitEmptyCollections) Chunk.empty
-        else super.unsafeDecodeMissing(trace)
+        Chunk.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Chunk[(K, A)] =
         keyValueBuilder[K, A, ({ type lambda[X, Y] = Chunk[(X, Y)] })#lambda](

--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -308,8 +308,7 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
 
   implicit def array[A](implicit
     A: JsonEncoder[A],
-    classTag: ClassTag[A],
-    config: JsonCodecConfiguration
+    classTag: ClassTag[A]
   ): JsonEncoder[Array[A]] =
     new JsonEncoder[Array[A]] {
 
@@ -358,78 +357,46 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
           .map(Json.Arr(_))
     }
 
-  implicit def seq[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[Seq[A]] = iterable[A, Seq]
+  implicit def seq[A: JsonEncoder]: JsonEncoder[Seq[A]] = iterable[A, Seq]
 
-  implicit def chunk[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[Chunk[A]] = iterable[A, Chunk]
+  implicit def chunk[A: JsonEncoder]: JsonEncoder[Chunk[A]] = iterable[A, Chunk]
 
   implicit def nonEmptyChunk[A: JsonEncoder]: JsonEncoder[NonEmptyChunk[A]] = chunk[A].contramap(_.toChunk)
 
-  implicit def indexedSeq[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[IndexedSeq[A]] = iterable[A, IndexedSeq]
+  implicit def indexedSeq[A: JsonEncoder]: JsonEncoder[IndexedSeq[A]] = iterable[A, IndexedSeq]
 
-  implicit def linearSeq[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[immutable.LinearSeq[A]] = iterable[A, immutable.LinearSeq]
+  implicit def linearSeq[A: JsonEncoder]: JsonEncoder[immutable.LinearSeq[A]] = iterable[A, immutable.LinearSeq]
 
-  implicit def listSet[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[immutable.ListSet[A]] = iterable[A, immutable.ListSet]
+  implicit def listSet[A: JsonEncoder]: JsonEncoder[immutable.ListSet[A]] = iterable[A, immutable.ListSet]
 
-  implicit def treeSet[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[immutable.TreeSet[A]] = iterable[A, immutable.TreeSet]
+  implicit def treeSet[A: JsonEncoder]: JsonEncoder[immutable.TreeSet[A]] = iterable[A, immutable.TreeSet]
 
-  implicit def list[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[List[A]] = iterable[A, List]
+  implicit def list[A: JsonEncoder]: JsonEncoder[List[A]] = iterable[A, List]
 
-  implicit def vector[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[Vector[A]] = iterable[A, Vector]
+  implicit def vector[A: JsonEncoder]: JsonEncoder[Vector[A]] = iterable[A, Vector]
 
-  implicit def set[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[Set[A]] =
+  implicit def set[A: JsonEncoder]: JsonEncoder[Set[A]] =
     iterable[A, Set]
 
-  implicit def hashSet[A: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[immutable.HashSet[A]] =
+  implicit def hashSet[A: JsonEncoder]: JsonEncoder[immutable.HashSet[A]] =
     iterable[A, immutable.HashSet]
 
-  implicit def sortedSet[A: Ordering: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[immutable.SortedSet[A]] =
+  implicit def sortedSet[A: Ordering: JsonEncoder]: JsonEncoder[immutable.SortedSet[A]] =
     iterable[A, immutable.SortedSet]
 
-  implicit def map[K: JsonFieldEncoder, V: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[Map[K, V]] =
+  implicit def map[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[Map[K, V]] =
     keyValueIterable[K, V, Map]
 
-  implicit def hashMap[K: JsonFieldEncoder, V: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[immutable.HashMap[K, V]] =
+  implicit def hashMap[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[immutable.HashMap[K, V]] =
     keyValueIterable[K, V, immutable.HashMap]
 
-  implicit def mutableMap[K: JsonFieldEncoder, V: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[mutable.Map[K, V]] =
+  implicit def mutableMap[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[mutable.Map[K, V]] =
     keyValueIterable[K, V, mutable.Map]
 
-  implicit def sortedMap[K: JsonFieldEncoder, V: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[collection.SortedMap[K, V]] =
+  implicit def sortedMap[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[collection.SortedMap[K, V]] =
     keyValueIterable[K, V, collection.SortedMap]
 
-  implicit def listMap[K: JsonFieldEncoder, V: JsonEncoder](implicit
-    config: JsonCodecConfiguration
-  ): JsonEncoder[immutable.ListMap[K, V]] =
+  implicit def listMap[K: JsonFieldEncoder, V: JsonEncoder]: JsonEncoder[immutable.ListMap[K, V]] =
     keyValueIterable[K, V, immutable.ListMap]
 }
 
@@ -437,8 +404,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
   this: JsonEncoder.type =>
 
   implicit def iterable[A, T[X] <: Iterable[X]](implicit
-    A: JsonEncoder[A],
-    config: JsonCodecConfiguration
+    A: JsonEncoder[A]
   ): JsonEncoder[T[A]] =
     new JsonEncoder[T[A]] {
 
@@ -489,8 +455,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
   // not implicit because this overlaps with encoders for lists of tuples
   def keyValueIterable[K, A, T[X, Y] <: Iterable[(X, Y)]](implicit
     K: JsonFieldEncoder[K],
-    A: JsonEncoder[A],
-    config: JsonCodecConfiguration
+    A: JsonEncoder[A]
   ): JsonEncoder[T[K, A]] = new JsonEncoder[T[K, A]] {
 
     override def isEmpty(a: T[K, A]): Boolean = a.isEmpty
@@ -508,11 +473,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
       kvs.foreach {
         var first = true
         kv =>
-          if (
-            (!A.isNothing(kv._2) && !A.isEmpty(kv._2)) || (A
-              .isNothing(kv._2) && config.explicitNulls) || (A.isEmpty(kv._2) && config.explicitEmptyCollections)
-          ) {
-            // if (!A.isNothing(kv._2)) {
+          if (!A.isNothing(kv._2)) {
             if (first) first = false
             else out.write(',')
             string.unsafeEncode(K.unsafeEncodeField(kv._1), indent, out)
@@ -527,11 +488,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
       kvs.foreach {
         var first = true
         kv =>
-          if (
-            (!A.isNothing(kv._2) && !A.isEmpty(kv._2)) || (A
-              .isNothing(kv._2) && config.explicitNulls) || (A.isEmpty(kv._2) && config.explicitEmptyCollections)
-          ) {
-            // if (!A.isNothing(kv._2)) {
+          if (!A.isNothing(kv._2)) {
             if (first) first = false
             else {
               out.write(',')
@@ -560,8 +517,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
   // not implicit because this overlaps with encoders for lists of tuples
   def keyValueChunk[K, A](implicit
     K: JsonFieldEncoder[K],
-    A: JsonEncoder[A],
-    config: JsonCodecConfiguration
+    A: JsonEncoder[A]
   ): JsonEncoder[({ type lambda[X, Y] = Chunk[(X, Y)] })#lambda[K, A]] =
     keyValueIterable[K, A, ({ type lambda[X, Y] = Chunk[(X, Y)] })#lambda]
 }

--- a/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
@@ -8,139 +8,18 @@ import zio.Chunk
 import scala.collection.immutable
 import scala.collection.mutable
 
-object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
-  case class ClassWithFields(someField: Int, someOtherField: String)
-
-  sealed trait ST
-
-  object ST {
-    case object CaseObj          extends ST
-    case class CaseClass(i: Int) extends ST
-  }
-
-  case class OptionalField(a: Option[Int])
+object AnnotationsCodecSpec extends ZIOSpecDefault {
 
   def spec = suite("ConfigurableDeriveCodecSpec")(
-    suite("defaults")(
-      suite("string")(
-        test("should not map field names by default") {
-          val expectedStr = """{"someField":1,"someOtherField":"a"}"""
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedStr.fromJson[ClassWithFields].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
-        },
-        test("should not use discriminator by default") {
-          val expectedStr     = """{"CaseObj":{}}"""
-          val expectedObj: ST = ST.CaseObj
-
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedStr.fromJson[ST].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
-        },
-        test("should allow extra fields by default") {
-          val jsonStr     = """{"someField":1,"someOtherField":"a","extra":123}"""
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonStr.fromJson[ClassWithFields].toOption.get == expectedObj
-          )
-        }
-      ),
-      test("do not write nulls by default") {
-        val expectedStr = """{}"""
-        val expectedObj = OptionalField(None)
-
-        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
-
-        assertTrue(
-          expectedStr.fromJson[OptionalField].toOption.get == expectedObj,
-          expectedObj.toJson == expectedStr
-        )
-      },
-      test("write empty collections by default") {
-        case class EmptySeq(a: Seq[Int])
-
-        val expectedStr = """{"a":[]}"""
-        val expectedObj = EmptySeq(Seq.empty)
-
-        implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
-
-        assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
-      },
-      suite("AST")(
-        test("should not map field names by default") {
-          val expectedAST = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"))
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedAST.as[ClassWithFields].toOption.get == expectedObj,
-            expectedObj.toJsonAST.toOption.get == expectedAST
-          )
-        },
-        test("should not use discriminator by default") {
-          val expectedAST     = Json.Obj("CaseObj" -> Json.Obj())
-          val expectedObj: ST = ST.CaseObj
-
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedAST.as[ST].toOption.get == expectedObj,
-            expectedObj.toJsonAST.toOption.get == expectedAST
-          )
-        },
-        test("should allow extra fields by default") {
-          val jsonAST     = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"), "extra" -> Json.Num(1))
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonAST.as[ClassWithFields].toOption.get == expectedObj
-          )
-        },
-        test("do not write nulls by default") {
-          val jsonAST     = Json.Obj()
-          val expectedObj = OptionalField(None)
-
-          implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonAST.as[OptionalField].toOption.get == expectedObj,
-            expectedObj.toJsonAST == Right(jsonAST)
-          )
-        },
-        test("write empty collections by default") {
-          case class EmptySeq(a: Seq[Int])
-
-          val expectedStr = """{"a":[]}"""
-          val expectedObj = EmptySeq(Seq.empty)
-
-          implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
-
-          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
-        }
-      )
-    ),
-    suite("overrides")(
+    suite("annotations overrides")(
       suite("string")(
         test("should override field name mapping") {
+          @jsonMemberNames(SnakeCase)
+          case class ClassWithFields(someField: Int, someOtherField: String)
+
           val expectedStr = """{"some_field":1,"some_other_field":"a"}"""
           val expectedObj = ClassWithFields(1, "a")
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(fieldNameMapping = SnakeCase)
           implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -149,12 +28,18 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("should specify discriminator") {
+          @jsonDiscriminator("$type")
+          sealed trait ST
+
+          object ST {
+            case object CaseObj          extends ST
+            case class CaseClass(i: Int) extends ST
+
+            implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+          }
+
           val expectedStr     = """{"$type":"CaseClass","i":1}"""
           val expectedObj: ST = ST.CaseClass(i = 1)
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"))
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
 
           assertTrue(
             expectedStr.fromJson[ST].toOption.get == expectedObj,
@@ -162,12 +47,19 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("should override sum type mapping") {
+          @jsonHintNames(SnakeCase)
+          @jsonDiscriminator("$type")
+          sealed trait ST
+
+          object ST {
+            case object CaseObj          extends ST
+            case class CaseClass(i: Int) extends ST
+
+            implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+          }
+
           val expectedStr     = """{"$type":"case_class","i":1}"""
           val expectedObj: ST = ST.CaseClass(i = 1)
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"), sumTypeMapping = SnakeCase)
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
 
           assertTrue(
             expectedStr.fromJson[ST].toOption.get == expectedObj,
@@ -175,10 +67,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("should prevent extra fields") {
+          @jsonNoExtraFields
+          case class ClassWithFields(someField: Int, someOtherField: String)
+
           val jsonStr = """{"someField":1,"someOtherField":"a","extra":123}"""
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(allowExtraFields = false)
           implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -186,11 +79,12 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("use explicit null values") {
+          @jsonExplicitNull
+          case class OptionalField(a: Option[Int])
+
           val expectedStr = """{"a":null}"""
           val expectedObj = OptionalField(None)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitNulls = true)
           implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -199,13 +93,12 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("do not write empty collections") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptySeq(a: Seq[Int])
 
           val expectedStr = """{}"""
           val expectedObj = EmptySeq(Seq.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
@@ -213,11 +106,12 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
       ),
       suite("AST")(
         test("should override field name mapping") {
+          @jsonMemberNames(SnakeCase)
+          case class ClassWithFields(someField: Int, someOtherField: String)
+
           val expectedAST = Json.Obj("some_field" -> Json.Num(1), "some_other_field" -> Json.Str("a"))
           val expectedObj = ClassWithFields(1, "a")
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(fieldNameMapping = SnakeCase)
           implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -226,12 +120,18 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("should specify discriminator") {
+          @jsonDiscriminator("$type")
+          sealed trait ST
+
+          object ST {
+            case object CaseObj          extends ST
+            case class CaseClass(i: Int) extends ST
+
+            implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+          }
+
           val expectedAST     = Json.Obj("$type" -> Json.Str("CaseClass"), "i" -> Json.Num(1))
           val expectedObj: ST = ST.CaseClass(i = 1)
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"))
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
 
           assertTrue(
             expectedAST.as[ST].toOption.get == expectedObj,
@@ -239,10 +139,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("should prevent extra fields") {
+          @jsonNoExtraFields
+          case class ClassWithFields(someField: Int, someOtherField: String)
+
           val jsonAST = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"), "extra" -> Json.Num(1))
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(allowExtraFields = false)
           implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -250,23 +151,23 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("use explicit null values") {
+          @jsonExplicitNull
+          case class OptionalField(a: Option[Int])
+
           val jsonAST     = Json.Obj("a" -> Json.Null)
           val expectedObj = OptionalField(None)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitNulls = true)
           implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
 
           assertTrue(jsonAST.as[OptionalField].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
         },
         test("do not write empty collections") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptySeq(a: Seq[Int])
 
           val jsonAST     = Json.Obj("a" -> Json.Arr())
           val expectedObj = EmptySeq(Seq.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
           assertTrue(jsonAST.as[EmptySeq].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
@@ -276,34 +177,31 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
     suite("explicit empty collections")(
       suite("should write empty collections if set to true")(
         test("for an array") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyArray(a: Array[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyArray(Array.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptySeq(a: Seq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySeq(Seq.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyChunk(a: Chunk[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyChunk(Chunk.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
@@ -313,8 +211,6 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -323,12 +219,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a linear seq") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -337,78 +232,71 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list set") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyListSet(a: immutable.ListSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a tree set") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyTreeSet(a: immutable.TreeSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a list") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyList(a: List[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyList(List.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyList].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a vector") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyVector(a: Vector[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyVector(Vector.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a set") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptySet(a: Set[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySet(Set.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a hash set") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyHashSet(a: immutable.HashSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a sorted set") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptySortedSet(a: immutable.SortedSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -417,34 +305,31 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a map") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyMap(a: Map[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyMap(Map.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a hash map") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyHashMap(a: immutable.HashMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a mutable map") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyMutableMap(a: mutable.Map[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -453,12 +338,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a sorted map") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptySortedMap(a: collection.SortedMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -467,12 +351,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list map") {
+          @jsonExplicitEmptyCollection(true)
           case class EmptyListMap(a: immutable.ListMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyListMap(immutable.ListMap.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
@@ -480,45 +363,41 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
       ),
       suite("should not write empty collections if set to false")(
         test("for an array") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyArray(a: Array[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyArray(Array.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptySeq(a: Seq[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptySeq(Seq.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyChunk(a: Chunk[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyChunk(Chunk.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for an indexed seq") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyIndexedSeq(a: IndexedSeq[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -527,12 +406,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a linear seq") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -541,34 +419,31 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list set") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyListSet(a: immutable.ListSet[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a treeSet") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyTreeSet(a: immutable.TreeSet[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a list") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyList(a: List[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyList(List.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -577,45 +452,41 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a vector") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyVector(a: Vector[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyVector(Vector.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a set") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptySet(a: Set[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptySet(Set.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a hash set") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyHashSet(a: immutable.HashSet[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a sorted set") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptySortedSet(a: immutable.SortedSet[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -624,12 +495,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a map") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyMap(a: Map[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptyMap(Map.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -638,23 +508,21 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a hashMap") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyHashMap(a: immutable.HashMap[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a mutable map") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyMutableMap(a: mutable.Map[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -663,12 +531,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a sorted map") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptySortedMap(a: collection.SortedMap[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -677,12 +544,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list map") {
+          @jsonExplicitEmptyCollection(false)
           case class EmptyListMap(a: immutable.ListMap[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptyListMap(immutable.ListMap.empty)
 
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
           implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)

--- a/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
@@ -124,12 +124,15 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
         test("write empty collections by default") {
           case class EmptySeq(a: Seq[Int])
 
-          val expectedStr = """{"a":[]}"""
+          val jsonAST = Json.Obj("a" -> Json.Arr())
           val expectedObj = EmptySeq(Seq.empty)
 
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            jsonAST.as[EmptySeq].toOption.get == expectedObj,
+            expectedObj.toJsonAST == Right(jsonAST)
+          )
         }
       )
     ),

--- a/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
@@ -124,7 +124,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
         test("write empty collections by default") {
           case class EmptySeq(a: Seq[Int])
 
-          val jsonAST = Json.Obj("a" -> Json.Arr())
+          val jsonAST     = Json.Obj("a" -> Json.Arr())
           val expectedObj = EmptySeq(Seq.empty)
 
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen


### PR DESCRIPTION
Decoding now always fills missing empty collection (same behaviour as missing nulls). I think it would be nice of decoding nulls and empty collections can also be done strict amd take into account the configs but this requires more work which I would like to attempt in a separate PR.