### PR TITLE
Reduce instantiation time and memory footprint for all implementations of `JsonEncoder` trait

### DIFF
--- a/zio-json/jvm/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/JsonEncoderPlatformSpecific.scala
@@ -74,9 +74,9 @@ trait JsonEncoderPlatformSpecific[A] { self: JsonEncoder[A] =>
       }
     }
 
-  final val encodeJsonLinesPipeline: ZPipeline[Any, Throwable, A, Char] =
+  final lazy val encodeJsonLinesPipeline: ZPipeline[Any, Throwable, A, Char] =
     encodeJsonDelimitedPipeline(None, Some('\n'), None)
 
-  final val encodeJsonArrayPipeline: ZPipeline[Any, Throwable, A, Char] =
+  final lazy val encodeJsonArrayPipeline: ZPipeline[Any, Throwable, A, Char] =
     encodeJsonDelimitedPipeline(Some('['), Some(','), Some(']'))
 }


### PR DESCRIPTION
Below is a zoomed fragment of the flame graph for CPU cycles burned when encoding a list of 128 primitives:
 
![image](https://github.com/user-attachments/assets/92c3886d-20d2-43af-9afb-44f0a7ce3187)
