### PR TITLE
More efficient parsing of optional values

### DIFF
--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -295,100 +295,68 @@ final class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriva
         lazy val namesMap: Map[String, Int] =
           (names.zipWithIndex ++ aliases).toMap
 
+        private[this] def error(message: String, trace: List[JsonError]): Nothing =
+          throw UnsafeJson(JsonError.Message(message) :: trace)
+
         def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
           Lexer.char(trace, in, '{')
-
-          val ps: Array[Any] = Array.ofDim(len)
-
+          val ps = new Array[Any](len)
           if (Lexer.firstField(trace, in))
             while({
-              var trace_ = trace
               val field  = Lexer.field(trace, in, matrix)
               if (field != -1) {
-                trace_ = spans(field) :: trace
-                if (ps(field) != null)
-                  throw UnsafeJson(JsonError.Message("duplicate") :: trace)
-                if (defaults(field).isDefined) {
-                  val opt = JsonDecoder.option(tcs(field)).unsafeDecode(trace_, in)
-                  ps(field) = opt.getOrElse(defaults(field).get)
-                } else
-                  ps(field) = tcs(field).unsafeDecode(trace_, in)
-              } else if (no_extra) {
-                throw UnsafeJson(
-                  JsonError.Message(s"invalid extra field") :: trace
-                )
-              } else
-                Lexer.skipValue(trace_, in)
-
+                if (ps(field) != null) error("duplicate", trace)
+                val default = defaults(field)
+                ps(field) = if ((default eq None) || in.nextNonWhitespace() != 'n' && {
+                  in.retract()
+                  true
+                }) tcs(field).unsafeDecode(spans(field) :: trace, in)
+                else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default.get
+                else error("expected 'null'", spans(field) :: trace)
+              } else if (no_extra) error("invalid extra field", trace)
+              else Lexer.skipValue(trace, in)
               Lexer.nextField(trace, in)
             }) ()
-
           var i = 0
-
           while (i < len) {
             if (ps(i) == null) {
-              if (defaults(i).isDefined) {
-                ps(i) = defaults(i).get
-              } else {
-                ps(i) = tcs(i).unsafeDecodeMissing(spans(i) :: trace)
-              }
+              ps(i) =
+                if (defaults(i) ne None) defaults(i).get
+                else tcs(i).unsafeDecodeMissing(spans(i) :: trace)
             }
             i += 1
           }
-
           ctx.rawConstruct(new ArraySeq(ps))
         }
 
-        override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): A = {
+        override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): A =
           json match {
             case Json.Obj(fields) =>
-              val ps: Array[Any] = Array.ofDim(len)
-
-              if (aliases.nonEmpty) {
-                val present = fields.map { case (key, _) => namesMap(key) }
-                if (present.distinct.size != present.size) {
-                  throw UnsafeJson(
-                    JsonError.Message("duplicate") :: trace
-                  )
-                }
-              }
-
+              val ps = new Array[Any](len)
               for ((key, value) <- fields) {
                 namesMap.get(key) match {
                   case Some(field) =>
-                    val trace_ = JsonError.ObjectAccess(key) :: trace
-                    if (defaults(field).isDefined) {
-                      val opt = JsonDecoder.option(tcs(field)).unsafeFromJsonAST(trace_, value)
-                      ps(field) = opt.getOrElse(defaults(field).get)
-                    } else {
-                      ps(field) = tcs(field).unsafeFromJsonAST(trace_, value)
+                    if (ps(field) != null) error("duplicate", trace)
+                    ps(field) = {
+                      if ((value eq Json.Null) && (defaults(field) ne None)) defaults(field).get
+                      else tcs(field).unsafeFromJsonAST(spans(field) :: trace, value)
                     }
-                  case None =>
-                    if (no_extra) {
-                      throw UnsafeJson(
-                        JsonError.Message(s"invalid extra field") :: trace
-                      )
-                    }
+                  case _ =>
+                    if (no_extra) error("invalid extra field", trace)
                 }
               }
-
               var i = 0
               while (i < len) {
                 if (ps(i) == null) {
-                  if (defaults(i).isDefined) {
-                    ps(i) = defaults(i).get
-                  } else {
-                    ps(i) = tcs(i).unsafeDecodeMissing(JsonError.ObjectAccess(names(i)) :: trace)
-                  }
+                  ps(i) =
+                    if (defaults(i) ne None) defaults(i).get
+                    else tcs(i).unsafeDecodeMissing(spans(i) :: trace)
                 }
                 i += 1
               }
-
               ctx.rawConstruct(new ArraySeq(ps))
-
-            case _ => throw UnsafeJson(JsonError.Message("Not an object") :: trace)
+            case _ => error("Not an object", trace)
           }
-        }
       }
     }
   }


### PR DESCRIPTION
Codecs generated by zio-json for case classes have inefficiency that during parsing for each optional field a new instance of `JsonDecoder.option` is created that allocates a small array of chars and a `Some` instance.

Both parsing methods from strings and ASTs were improved, but I have benchmarks for parsing from strings only.

Below are throughput results for real-world message samples using Scala 3 and JDK 21 on Intel® Core™ i7-11800H CPU @ 2.3GHz (max 4.6GHz).

#### Before
```txt
Benchmark                        (size)   Mode  Cnt        Score       Error  Units
GeoJSONReading.zioJson              N/A  thrpt    5     7776.653 ±   216.260  ops/s
GitHubActionsAPIReading.zioJson     N/A  thrpt    5   275023.115 ±  7134.200  ops/s
GoogleMapsAPIReading.zioJson        N/A  thrpt    5    17293.129 ±   620.785  ops/s
OpenRTBReading.zioJson              N/A  thrpt    5   141680.282 ±  4050.499  ops/s
TwitterAPIReading.zioJson           N/A  thrpt    5    14615.513 ±   869.314  ops/s
```

#### After
```txt
Benchmark                        (size)   Mode  Cnt        Score       Error  Units
GeoJSONReading.zioJson              N/A  thrpt    5     7915.853 ±   204.287  ops/s
GitHubActionsAPIReading.zioJson     N/A  thrpt    5   278922.406 ±   847.529  ops/s
GoogleMapsAPIReading.zioJson        N/A  thrpt    5    18011.900 ±  1391.679  ops/s
OpenRTBReading.zioJson              N/A  thrpt    5   152497.736 ±  3224.405  ops/s
TwitterAPIReading.zioJson           N/A  thrpt    5    15905.385 ±   500.720  ops/s
```