### PR TITLE
Faster parsing of JSON keys and values

### DIFF
--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -266,7 +266,7 @@ object DecoderPlatformSpecificSpec extends ZIOSpecDefault {
             }
             assert(decoder.decodeJson("true"))(equalTo(Right(true.asInstanceOf[AnyVal]))) &&
             assert(decoder.decodeJson("42"))(equalTo(Right(42.asInstanceOf[AnyVal]))) &&
-            assert(decoder.decodeJson("\"a string\""))(equalTo(Left("(expected a number, got a)")))
+            assert(decoder.decodeJson("\"a string\""))(equalTo(Left("(expected a number, got 'a')")))
           }
         )
       )

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -28,6 +28,18 @@ object Lexer {
 
   val NumberMaxBits: Int = 256
 
+  @noinline
+  def error(msg: String, trace: List[JsonError]): Nothing =
+    throw UnsafeJson(JsonError.Message(msg) :: trace)
+
+  @noinline
+  private[json] def error(expected: String, got: Char, trace: List[JsonError]): Nothing =
+    throw UnsafeJson(JsonError.Message(s"expected $expected got '$got'") :: trace)
+
+  @noinline
+  private[json] def error(c: Char, trace: List[JsonError]): Nothing =
+    error(s"invalid '\\$c' in string", trace)
+
   // True if we got a string (implies a retraction), False for }
   def firstField(trace: List[JsonError], in: RetractReader): Boolean =
     (in.nextNonWhitespace(): @switch) match {
@@ -35,10 +47,7 @@ object Lexer {
         in.retract()
         true
       case '}' => false
-      case c =>
-        throw UnsafeJson(
-          JsonError.Message(s"expected string or '}' got '$c'") :: trace
-        )
+      case c   => error("string or '}'", c, trace)
     }
 
   // True if we got a comma, and False for }
@@ -46,10 +55,7 @@ object Lexer {
     (in.nextNonWhitespace(): @switch) match {
       case ',' => true
       case '}' => false
-      case c =>
-        throw UnsafeJson(
-          JsonError.Message(s"expected ',' or '}' got '$c'") :: trace
-        )
+      case c   => error("',' or '}'", c, trace)
     }
 
   // True if we got anything besides a ], False for ]
@@ -65,10 +71,7 @@ object Lexer {
     (in.nextNonWhitespace(): @switch) match {
       case ',' => true
       case ']' => false
-      case c =>
-        throw UnsafeJson(
-          JsonError.Message(s"expected ',' or ']' got '$c'") :: trace
-        )
+      case c   => error("',' or ']'", c, trace)
     }
 
   // avoids allocating lots of strings (they are often the bulk of incoming
@@ -90,21 +93,34 @@ object Lexer {
     in: OneCharReader,
     matrix: StringMatrix
   ): Int = {
-    val stream = streamingString(trace, in)
-
-    var i: Int   = 0
-    var bs: Long = matrix.initial
-    var c: Int   = -1
-    while ({ c = stream.read(); c != -1 }) {
+    var c = in.nextNonWhitespace()
+    if (c != '"') error("'\"'", c, trace)
+    var bs = matrix.initial
+    var i  = 0
+    while ({
+      c = in.readChar()
+      c != '"'
+    }) {
+      if (c == '\\') {
+        (in.readChar(): @switch) match {
+          case '"'  => c = '"'
+          case '\\' => c = '\\'
+          case '/'  => c = '/'
+          case 'b'  => c = '\b'
+          case 'f'  => c = '\f'
+          case 'n'  => c = '\n'
+          case 'r'  => c = '\r'
+          case 't'  => c = '\t'
+          case 'u'  => c = nextHex4(trace, in)
+          case _    => error(c, trace)
+        }
+      } else if (c < ' ') error("invalid control in string", trace)
       bs = matrix.update(bs, i, c)
       i += 1
     }
     bs = matrix.exact(bs, i)
     matrix.first(bs)
   }
-
-  private[this] val alse: Array[Char] = "alse".toCharArray
-  private[this] val rue: Array[Char]  = "rue".toCharArray
 
   def skipValue(trace: List[JsonError], in: RetractReader): Unit =
     (in.nextNonWhitespace(): @switch) match {
@@ -116,7 +132,7 @@ object Lexer {
         skipString(in, evenBackSlashes = true)
       case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
         skipNumber(in)
-      case c => throw UnsafeJson(JsonError.Message(s"unexpected '$c'") :: trace)
+      case c => error(s"unexpected '$c'", trace)
     }
 
   def skipNumber(in: RetractReader): Unit = {
@@ -169,36 +185,104 @@ object Lexer {
     in: OneCharReader
   ): java.io.Reader = {
     char(trace, in, '"')
-    new EscapedString(trace, in)
+    new OneCharReader {
+      def close(): Unit = in.close()
+
+      private[this] var escaped = false
+
+      @tailrec
+      override def read(): Int = {
+        val c = in.readChar()
+        if (escaped) {
+          escaped = false
+          ((c: @switch) match {
+            case '"' | '\\' | '/' => c
+            case 'b'              => '\b'
+            case 'f'              => '\f'
+            case 'n'              => '\n'
+            case 'r'              => '\r'
+            case 't'              => '\t'
+            case 'u'              => Lexer.nextHex4(trace, in)
+            case _                => Lexer.error(c, trace)
+          }).toInt
+        } else if (c == '\\') {
+          escaped = true
+          read()
+        } else if (c == '"') -1 // this is the EOS for the caller
+        else if (c < ' ') Lexer.error("invalid control in string", trace)
+        else c.toInt
+      }
+
+      // callers expect to get an EOB so this is rare
+      def readChar(): Char = {
+        val v = read()
+        if (v == -1) throw new UnexpectedEnd
+        v.toChar
+      }
+    }
   }
 
   def string(trace: List[JsonError], in: OneCharReader): CharSequence = {
-    char(trace, in, '"')
-    val stream = new EscapedString(trace, in)
-
+    var c = in.nextNonWhitespace()
+    if (c != '"') error("'\"'", c, trace)
     val sb = new FastStringBuilder(64)
-    while (true) {
-      val c = stream.read()
-      if (c == -1)
-        return sb.buffer // mutable thing escapes, but cannot be changed
-      sb.append(c.toChar)
+    while ({
+      c = in.readChar()
+      c != '"'
+    }) {
+      if (c == '\\') {
+        (in.readChar(): @switch) match {
+          case '"'  => c = '"'
+          case '\\' => c = '\\'
+          case '/'  => c = '/'
+          case 'b'  => c = '\b'
+          case 'f'  => c = '\f'
+          case 'n'  => c = '\n'
+          case 'r'  => c = '\r'
+          case 't'  => c = '\t'
+          case 'u'  => c = nextHex4(trace, in)
+          case _    => error(c, trace)
+        }
+      } else if (c < ' ') error("invalid control in string", trace)
+      sb.append(c)
     }
-    throw UnsafeJson(JsonError.Message("impossible string") :: trace)
+    sb.buffer
   }
 
-  def boolean(trace: List[JsonError], in: OneCharReader): Boolean =
-    (in.nextNonWhitespace(): @switch) match {
+  // consumes 4 hex characters after current
+  @noinline
+  def nextHex4(trace: List[JsonError], in: OneCharReader): Char = {
+    var i, accum = 0
+    while (i < 4) {
+      val c = in.readChar()
+      accum <<= 4
+      accum += {
+        if ('0' <= c && c <= '9') c - '0'
+        else if ('A' <= c && c <= 'F') c - 'A' + 10
+        else if ('a' <= c && c <= 'f') c - 'a' + 10
+        else error("invalid charcode in string", trace)
+      }
+      i += 1
+    }
+    accum.toChar
+  }
+
+  def boolean(trace: List[JsonError], in: OneCharReader): Boolean = {
+    val c1 = in.nextNonWhitespace()
+    val c2 = in.readChar()
+    val c3 = in.readChar()
+    val c4 = in.readChar()
+    (c1: @switch) match {
       case 't' =>
-        readChars(trace, in, rue, "true")
+        if (c2 != 'r' || c3 != 'u' || c4 != 'e') error(s"expected 'true'", trace)
         true
       case 'f' =>
-        readChars(trace, in, alse, "false")
+        if (in.readChar() != 'e' || c2 != 'a' || c3 != 'l' || c4 != 's') error(s"expected 'false'", trace)
         false
       case c =>
-        throw UnsafeJson(
-          JsonError.Message(s"expected 'true' or 'false' got $c") :: trace
-        )
+        error("'true' or 'false'", c, trace)
     }
+  }
 
   def byte(trace: List[JsonError], in: RetractReader): Byte = {
     checkNumber(trace, in)
@@ -207,8 +291,7 @@ object Lexer {
       in.retract()
       i
     } catch {
-      case UnsafeNumbers.UnsafeNumber =>
-        throw UnsafeJson(JsonError.Message("expected a Byte") :: trace)
+      case UnsafeNumbers.UnsafeNumber => error("expected a Byte", trace)
     }
   }
 
@@ -219,8 +302,7 @@ object Lexer {
       in.retract()
       i
     } catch {
-      case UnsafeNumbers.UnsafeNumber =>
-        throw UnsafeJson(JsonError.Message("expected a Short") :: trace)
+      case UnsafeNumbers.UnsafeNumber => error("expected a Short", trace)
     }
   }
 
@@ -231,8 +313,7 @@ object Lexer {
       in.retract()
       i
     } catch {
-      case UnsafeNumbers.UnsafeNumber =>
-        throw UnsafeJson(JsonError.Message("expected an Int") :: trace)
+      case UnsafeNumbers.UnsafeNumber => error("expected an Int", trace)
     }
   }
 
@@ -243,8 +324,7 @@ object Lexer {
       in.retract()
       i
     } catch {
-      case UnsafeNumbers.UnsafeNumber =>
-        throw UnsafeJson(JsonError.Message("expected a Long") :: trace)
+      case UnsafeNumbers.UnsafeNumber => error("expected a Long", trace)
     }
   }
 
@@ -258,8 +338,7 @@ object Lexer {
       in.retract()
       i
     } catch {
-      case UnsafeNumbers.UnsafeNumber =>
-        throw UnsafeJson(JsonError.Message(s"expected a $NumberMaxBits bit BigInteger") :: trace)
+      case UnsafeNumbers.UnsafeNumber => error(s"expected a $NumberMaxBits bit BigInteger", trace)
     }
   }
 
@@ -270,8 +349,7 @@ object Lexer {
       in.retract()
       i
     } catch {
-      case UnsafeNumbers.UnsafeNumber =>
-        throw UnsafeJson(JsonError.Message("expected a Float") :: trace)
+      case UnsafeNumbers.UnsafeNumber => error("expected a Float", trace)
     }
   }
 
@@ -282,8 +360,7 @@ object Lexer {
       in.retract()
       i
     } catch {
-      case UnsafeNumbers.UnsafeNumber =>
-        throw UnsafeJson(JsonError.Message("expected a Double") :: trace)
+      case UnsafeNumbers.UnsafeNumber => error("expected a Double", trace)
     }
   }
 
@@ -297,8 +374,7 @@ object Lexer {
       in.retract()
       i
     } catch {
-      case UnsafeNumbers.UnsafeNumber =>
-        throw UnsafeJson(JsonError.Message(s"expected a $NumberMaxBits BigDecimal") :: trace)
+      case UnsafeNumbers.UnsafeNumber => error(s"expected a $NumberMaxBits BigDecimal", trace)
     }
   }
 
@@ -306,10 +382,7 @@ object Lexer {
   private def checkNumber(trace: List[JsonError], in: RetractReader): Unit = {
     (in.nextNonWhitespace(): @switch) match {
       case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => ()
-      case c =>
-        throw UnsafeJson(
-          JsonError.Message(s"expected a number, got $c") :: trace
-        )
+      case c                                                               => error("a number,", c, trace)
     }
     in.retract()
   }
@@ -317,8 +390,7 @@ object Lexer {
   // optional whitespace and then an expected character
   @inline def char(trace: List[JsonError], in: OneCharReader, c: Char): Unit = {
     val got = in.nextNonWhitespace()
-    if (got != c)
-      throw UnsafeJson(JsonError.Message(s"expected '$c' got '$got'") :: trace)
+    if (got != c) error(s"'$c'", got, trace)
   }
 
   @inline def charOnly(
@@ -327,8 +399,7 @@ object Lexer {
     c: Char
   ): Unit = {
     val got = in.readChar()
-    if (got != c)
-      throw UnsafeJson(JsonError.Message(s"expected '$c' got '$got'") :: trace)
+    if (got != c) error(s"'$c'", got, trace)
   }
 
   // non-positional for performance
@@ -347,78 +418,10 @@ object Lexer {
   ): Unit = {
     var i: Int = 0
     while (i < expect.length) {
-      if (in.readChar() != expect(i))
-        throw UnsafeJson(JsonError.Message(s"expected '$errMsg'") :: trace)
+      if (in.readChar() != expect(i)) error(s"expected '$errMsg'", trace)
       i += 1
     }
   }
-
-}
-
-// A Reader for the contents of a string, taking care of the escaping.
-//
-// `read` can throw extra exceptions on badly formed input.
-private final class EscapedString(trace: List[JsonError], in: OneCharReader) extends java.io.Reader with OneCharReader {
-
-  def close(): Unit = in.close()
-
-  private[this] var escaped = false
-
-  override def read(): Int = {
-    val c = in.readChar()
-    if (escaped) {
-      escaped = false
-      (c: @switch) match {
-        case '"' | '\\' | '/' => c.toInt
-        case 'b'              => '\b'.toInt
-        case 'f'              => '\f'.toInt
-        case 'n'              => '\n'.toInt
-        case 'r'              => '\r'.toInt
-        case 't'              => '\t'.toInt
-        case 'u'              => nextHex4()
-        case _ =>
-          throw UnsafeJson(
-            JsonError.Message(s"invalid '\\${c.toChar}' in string") :: trace
-          )
-      }
-    } else if (c == '\\') {
-      escaped = true
-      read()
-    } else if (c == '"') -1 // this is the EOS for the caller
-    else if (c < ' ')
-      throw UnsafeJson(JsonError.Message("invalid control in string") :: trace)
-    else c.toInt
-  }
-
-  // callers expect to get an EOB so this is rare
-  def readChar(): Char = {
-    val v = read()
-    if (v == -1) throw new UnexpectedEnd
-    v.toChar
-  }
-
-  // consumes 4 hex characters after current
-  def nextHex4(): Int = {
-    var i: Int     = 0
-    var accum: Int = 0
-    while (i < 4) {
-      var c: Int = in.read()
-      if (c == -1)
-        throw UnsafeJson(JsonError.Message("unexpected EOB in string") :: trace)
-      c =
-        if ('0' <= c && c <= '9') c - '0'
-        else if ('A' <= c && c <= 'F') c - 'A' + 10
-        else if ('a' <= c && c <= 'f') c - 'a' + 10
-        else
-          throw UnsafeJson(
-            JsonError.Message("invalid charcode in string") :: trace
-          )
-      accum = accum * 16 + c
-      i += 1
-    }
-    accum
-  }
-
 }
 
 // A data structure encoding a simple algorithm for Trie pruning: Given a list
@@ -453,7 +456,7 @@ final class StringMatrix(xs: Array[String], aliases: Array[(String, Int)] = Arra
   }
   private[this] val height: Int = lengths.max
   private[this] val matrix: Array[Char] = {
-    var w      = width
+    val w      = width
     val m      = new Array[Char](height * w)
     val xsLen  = xs.length
     var string = 0
@@ -491,17 +494,26 @@ final class StringMatrix(xs: Array[String], aliases: Array[(String, Int)] = Arra
 
   // must be called with increasing `char` (starting with bitset obtained from a
   // call to 'initial', char = 0)
-  def update(bitset: Long, char: Int, c: Int): Long =
+  def update(bitset: Long, char: Int, c: Char): Long =
     if (char < height) {
-      var remaining, latest = bitset
-      val w                 = width
-      val m                 = matrix
-      val base              = char * w
-      while (remaining != 0L) {
-        val string = java.lang.Long.numberOfTrailingZeros(remaining)
-        val bit    = 1L << string
-        remaining ^= bit
-        if (m(base + string) != c) latest ^= bit
+      val w      = width
+      val m      = matrix
+      val base   = char * w
+      var latest = bitset
+      if (initial == bitset) { // special case when it is dense since it is simple
+        var string = 0
+        while (string < w) {
+          if (m(base + string) != c) latest ^= 1L << string
+          string += 1
+        }
+      } else {
+        var remaining = bitset
+        while (remaining != 0L) {
+          val string = java.lang.Long.numberOfTrailingZeros(remaining)
+          val bit    = 1L << string
+          remaining ^= bit
+          if (m(base + string) != c) latest ^= bit
+        }
       }
       latest
     } else 0L // too long

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -424,86 +424,103 @@ private final class EscapedString(trace: List[JsonError], in: OneCharReader) ext
 // A data structure encoding a simple algorithm for Trie pruning: Given a list
 // of strings, and a sequence of incoming characters, find the strings that
 // match, by manually maintaining a bitset. Empty strings are not allowed.
-final class StringMatrix(val xs: Array[String], aliases: Array[(String, Int)] = Array.empty) {
-  require(xs.forall(_.nonEmpty))
+final class StringMatrix(xs: Array[String], aliases: Array[(String, Int)] = Array.empty) {
   require(xs.nonEmpty)
-  require(aliases.forall(_._1.nonEmpty))
-  require(aliases.forall(p => p._2 >= 0 && p._2 < xs.length))
 
-  val width: Int = xs.length + aliases.length
+  private[this] val width: Int = xs.length + aliases.length
 
   require(width <= 64)
 
-  val lengths: Array[Int] = Array.tabulate[Int](width) { string =>
-    if (string < xs.length) xs(string).length
-    else aliases(string - xs.length)._1.length
-  }
-  val height: Int   = lengths.max
   val initial: Long = -1L >>> (64 - width)
-  private val matrix: Array[Char] = {
-    val m      = Array.fill[Char](width * height)(0xffff)
+
+  private[this] val lengths: Array[Int] = {
+    val ls     = new Array[Int](width)
+    val xsLen  = xs.length
     var string = 0
-    while (string < width) {
+    while (string < xsLen) {
+      val l = xs(string).length
+      if (l == 0) require(false)
+      ls(string) = l
+      string += 1
+    }
+    while (string < ls.length) {
+      val l = aliases(string - xsLen)._1.length
+      if (l == 0) require(false)
+      ls(string) = l
+      string += 1
+    }
+    ls
+  }
+  private[this] val height: Int = lengths.max
+  private[this] val matrix: Array[Char] = {
+    var w      = width
+    val m      = new Array[Char](height * w)
+    val xsLen  = xs.length
+    var string = 0
+    while (string < w) {
       val s =
-        if (string < xs.length) xs(string)
-        else aliases(string - xs.length)._1
-      val len  = s.length
-      var char = 0
+        if (string < xsLen) xs(string)
+        else aliases(string - xsLen)._1
+      val len        = s.length
+      var char, base = 0
       while (char < len) {
-        m(width * char + string) = s.charAt(char)
+        m(base + string) = s.charAt(char)
+        base += w
         char += 1
       }
       string += 1
     }
     m
   }
-  private val resolve: Array[Byte] = Array.tabulate[Byte](width) { string =>
-    if (string < xs.length) string.toByte
-    else aliases(string - xs.length)._2.toByte
+  private[this] val resolvers: Array[Byte] = {
+    val rs     = new Array[Byte](width)
+    val xsLen  = xs.length
+    var string = 0
+    while (string < xsLen) {
+      rs(string) = string.toByte
+      string += 1
+    }
+    while (string < rs.length) {
+      val x = aliases(string - xsLen)._2
+      if (x < 0 || x > xsLen) require(false)
+      rs(string) = x.toByte
+      string += 1
+    }
+    rs
   }
 
   // must be called with increasing `char` (starting with bitset obtained from a
   // call to 'initial', char = 0)
   def update(bitset: Long, char: Int, c: Int): Long =
-    if (char >= height) 0L    // too long
-    else if (bitset == 0L) 0L // everybody lost
-    else {
-      var latest = bitset
-      val base   = width * char
-      if (bitset == initial) { // special case when it is dense since it is simple
-        var string = 0
-        while (string < width) {
-          if (matrix(base + string) != c) latest ^= 1L << string
-          string += 1
-        }
-      } else {
-        var remaining = bitset
-        while (remaining != 0L) {
-          val string = java.lang.Long.numberOfTrailingZeros(remaining)
-          val bit    = 1L << string
-          if (matrix(base + string) != c) latest ^= bit
-          remaining ^= bit
-        }
-      }
-      latest
-    }
-
-  // excludes entries that are not the given exact length
-  def exact(bitset: Long, length: Int): Long =
-    if (length > height) 0L // too long
-    else {
-      var latest    = bitset
-      var remaining = bitset
+    if (char < height) {
+      var remaining, latest = bitset
+      val w                 = width
+      val m                 = matrix
+      val base              = char * w
       while (remaining != 0L) {
         val string = java.lang.Long.numberOfTrailingZeros(remaining)
         val bit    = 1L << string
-        if (lengths(string) != length) latest ^= bit
         remaining ^= bit
+        if (m(base + string) != c) latest ^= bit
       }
       latest
-    }
+    } else 0L // too long
+
+  // excludes entries that are not the given exact length
+  def exact(bitset: Long, length: Int): Long =
+    if (length <= height) {
+      var remaining, latest = bitset
+      val ls                = lengths
+      while (remaining != 0L) {
+        val string = java.lang.Long.numberOfTrailingZeros(remaining)
+        val bit    = 1L << string
+        remaining ^= bit
+        if (ls(string) != length) latest ^= bit
+      }
+      latest
+    } else 0L // too long
 
   def first(bitset: Long): Int =
-    if (bitset == 0L) -1
-    else resolve(java.lang.Long.numberOfTrailingZeros(bitset)) // never returns 64
+    if (bitset != 0L) resolvers(java.lang.Long.numberOfTrailingZeros(bitset)).toInt // never returns 64
+    else -1
 }

--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -101,21 +101,21 @@ private[zio] final class FastStringReader(s: CharSequence) extends RetractReader
   override def read(): Int = {
     i += 1
     if (i > len) -1
-    else history(i - 1).toInt // -1 is faster than assigning a temp value
+    else s.charAt(i - 1).toInt // -1 is faster than assigning a temp value
   }
   override def readChar(): Char = {
     i += 1
     if (i > len) throw new UnexpectedEnd
-    else history(i - 1)
+    s.charAt(i - 1)
   }
   override def nextNonWhitespace(): Char = {
     while ({
       {
         i += 1
         if (i > len) throw new UnexpectedEnd
-      }; isWhitespace(history(i - 1))
+      }; isWhitespace(s.charAt(i - 1))
     }) ()
-    history(i - 1)
+    s.charAt(i - 1)
   }
 
   def retract(): Unit = i -= 1
@@ -179,7 +179,7 @@ private[zio] sealed trait PlaybackReader extends OneCharReader {
 private[zio] final class WithRecordingReader(in: OneCharReader, initial: Int)
     extends RecordingReader
     with PlaybackReader {
-  private[this] var tape: Array[Char] = Array.ofDim(Math.max(initial, 1))
+  private[this] var tape: Array[Char] = new Array(Math.max(initial, 1))
   private[this] var eob: Int          = -1
   private[this] var writing: Int      = 0
   private[this] var reading: Int      = -1
@@ -209,7 +209,7 @@ private[zio] final class WithRecordingReader(in: OneCharReader, initial: Int)
         tape(writing) = v
         writing += 1
         if (writing == tape.length)
-          tape = Arrays.copyOf(tape, tape.length * 2)
+          tape = Arrays.copyOf(tape, tape.length << 1)
       }
       v
     }

--- a/zio-json/shared/src/main/scala/zio/json/internal/writers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/writers.scala
@@ -48,9 +48,9 @@ private[zio] final class FastStringBuilder(initial: Int) {
   private[this] var chars: Array[Char] = new Array[Char](initial)
   private[this] var i: Int             = 0
 
+  @inline
   def append(c: Char): Unit = {
-    if (i == chars.length)
-      chars = Arrays.copyOf(chars, chars.length * 2)
+    if (i == chars.length) chars = Arrays.copyOf(chars, chars.length << 1)
     chars(i) = c
     i += 1
   }

--- a/zio-json/shared/src/test/scala/zio/json/internal/StringMatrixSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/internal/StringMatrixSpec.scala
@@ -48,7 +48,7 @@ object StringMatrixSpec extends ZIOSpecDefault {
         val asserts = xs.indices.map { i =>
           val test = xs(i)
           var bs = test.zipWithIndex.foldLeft(m.initial) { case (bs, (c, i)) =>
-            m.update(bs, i, c.toInt)
+            m.update(bs, i, c)
           }
           bs = m.exact(bs, test.length)
           m.first(bs) == i
@@ -102,7 +102,7 @@ object StringMatrixSpec extends ZIOSpecDefault {
         val asserts = aliases.indices.map { i =>
           val test = aliases(i)._1
           var bs = test.zipWithIndex.foldLeft(m.initial) { case (bs, (c, i)) =>
-            m.update(bs, i, c.toInt)
+            m.update(bs, i, c)
           }
           bs = m.exact(bs, test.length)
           m.first(bs) == aliases(i)._2
@@ -135,7 +135,7 @@ object StringMatrixSpec extends ZIOSpecDefault {
     var bs = test.foldLeft(m.initial) {
       var i = 0
       (bs, c) =>
-        val nm = m.update(bs, i, c.toInt)
+        val nm = m.update(bs, i, c)
         i += 1
         nm
     }


### PR DESCRIPTION
Throughput results of benchmarks with Scala 3 and JDK 21 on  Intel® Core™ i7-11800H CPU @ 2.3GHz (max 4.6GHz):

#### Before
```txt
[info] Benchmark                                      Mode  Cnt       Score       Error  Units
[info] GeoJSONBenchmarks.decodeZioError              thrpt    5   16200.519 ±   312.776  ops/s
[info] GeoJSONBenchmarks.decodeZioSuccess1           thrpt    5   17924.347 ±   208.695  ops/s
[info] GeoJSONBenchmarks.decodeZioSuccess2           thrpt    5   17678.354 ±   177.548  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioAttack0      thrpt    5   11334.455 ±    38.612  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioAttack1      thrpt    5    6144.397 ±   139.723  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioAttack2      thrpt    5    5456.460 ±   207.014  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioAttack3      thrpt    5  492285.367 ± 11761.973  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioErrorNumber  thrpt    5  432311.981 ±  2727.887  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioErrorParse   thrpt    5  477694.997 ± 12120.825  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioSuccess1     thrpt    5   17233.271 ±   365.678  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioSuccess2     thrpt    5   20418.746 ±   931.101  ops/s
[info] SyntheticBenchmarks.decodeZioSuccess          thrpt    5  276475.412 ±  5687.885  ops/s
[info] TwitterAPIBenchmarks.decodeZioError           thrpt    5   22128.339 ±   286.065  ops/s
[info] TwitterAPIBenchmarks.decodeZioSuccess1        thrpt    5   19991.568 ±   209.185  ops/s
[info] TwitterAPIBenchmarks.decodeZioSuccess2        thrpt    5   23367.624 ±   591.587  ops/s
```

#### After
```txt
[info] Benchmark                                      Mode  Cnt       Score       Error  Units
[info] GeoJSONBenchmarks.decodeZioError              thrpt    5   16321.687 ±   157.689  ops/s
[info] GeoJSONBenchmarks.decodeZioSuccess1           thrpt    5   18241.112 ±   612.451  ops/s
[info] GeoJSONBenchmarks.decodeZioSuccess2           thrpt    5   18265.269 ±    78.513  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioAttack0      thrpt    5   11904.624 ±   121.668  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioAttack1      thrpt    5    6220.986 ±   126.065  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioAttack2      thrpt    5    5988.469 ±   326.777  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioAttack3      thrpt    5  548296.620 ± 13544.874  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioErrorNumber  thrpt    5  544227.275 ± 10796.618  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioErrorParse   thrpt    5  533653.843 ± 12759.383  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioSuccess1     thrpt    5   19434.736 ±   420.116  ops/s
[info] GoogleMapsAPIBenchmarks.decodeZioSuccess2     thrpt    5   24509.136 ±   177.702  ops/s
[info] SyntheticBenchmarks.decodeZioSuccess          thrpt    5  285596.883 ±  9773.178  ops/s
[info] TwitterAPIBenchmarks.decodeZioError           thrpt    5   23355.620 ±   778.279  ops/s
[info] TwitterAPIBenchmarks.decodeZioSuccess1        thrpt    5   21478.223 ±  1196.832  ops/s
[info] TwitterAPIBenchmarks.decodeZioSuccess2        thrpt    5   26812.829 ±   662.305  ops/s
```

To check results on your environment use the following command:
```sh
sbt -java-home <path-to-jdk> ++<scala-version> "zioJsonJVM/Jmh/run .*Zio"
```