### PR TITLE
More efficient encoding of product types

### DIFF
--- a/zio-json/jvm/src/test/scala/zio/json/data/twitter/Twitter.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/data/twitter/Twitter.scala
@@ -1,7 +1,6 @@
 package zio.json.data.twitter
 
 import com.github.ghik.silencer.silent
-import io.circe
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import zio.json._

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -25,7 +25,8 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
     test("Derives for a sum sealed trait Enumeration type") {
       sealed trait Foo derives JsonDecoder
       object Foo:
-        @jsonHint("Barrr") case object Bar extends Foo
+        @jsonHint("Barrr")
+        case object Bar extends Foo
         case object Baz extends Foo
         case object Qux extends Foo
 
@@ -36,7 +37,8 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
       @jsonDiscriminator("$type")
       sealed trait Foo derives JsonDecoder
       object Foo:
-        @jsonHint("Barrr") case object Bar extends Foo
+        @jsonHint("Barrr")
+        case object Bar extends Foo
         case object Baz extends Foo
         case object Qux extends Foo
 

--- a/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala-3/zio/json/DerivedDecoderSpec.scala
@@ -10,52 +10,46 @@ object DerivedDecoderSpec extends ZIOSpecDefault {
     test("Derives for a product type") {
       case class Foo(bar: String) derives JsonDecoder
 
-      val result = "{\"bar\": \"hello\"}".fromJson[Foo]
-
-      assertTrue(result == Right(Foo("hello")))
+      assertTrue("{\"bar\": \"hello\"}".fromJson[Foo] == Right(Foo("hello")))
     },
     test("Derives for a sum enum Enumeration type") {
+      @jsonHintNames(SnakeCase)
       enum Foo derives JsonDecoder:
         case Bar
         case Baz
         case Qux
 
-      val result = "\"Qux\"".fromJson[Foo]
-
-      assertTrue(result == Right(Foo.Qux))
+      assertTrue("\"qux\"".fromJson[Foo] == Right(Foo.Qux))
+      assertTrue("\"bar\"".fromJson[Foo] == Right(Foo.Bar))
     },
     test("Derives for a sum sealed trait Enumeration type") {
       sealed trait Foo derives JsonDecoder
       object Foo:
-        case object Bar extends Foo
+        @jsonHint("Barrr") case object Bar extends Foo
         case object Baz extends Foo
         case object Qux extends Foo
 
-      val result = "\"Qux\"".fromJson[Foo]
-
-      assertTrue(result == Right(Foo.Qux))
+      assertTrue("\"Qux\"".fromJson[Foo] == Right(Foo.Qux))
+      assertTrue("\"Barrr\"".fromJson[Foo] == Right(Foo.Bar))
     },
     test("Derives for a sum sealed trait Enumeration type with discriminator") {
       @jsonDiscriminator("$type")
       sealed trait Foo derives JsonDecoder
       object Foo:
-        case object Bar extends Foo
+        @jsonHint("Barrr") case object Bar extends Foo
         case object Baz extends Foo
         case object Qux extends Foo
 
-      val result = """{"$type":"Qux"}""".fromJson[Foo]
-
-      assertTrue(result == Right(Foo.Qux))
+      assertTrue("""{"$type":"Qux"}""".fromJson[Foo] == Right(Foo.Qux))
+      assertTrue("""{"$type":"Barrr"}""".fromJson[Foo] == Right(Foo.Bar))
     },
-    test("Derives for a sum ADT type") {
+    test("Derives for a recursive sum ADT type") {
       enum Foo derives JsonDecoder:
         case Bar
         case Baz(baz: String)
         case Qux(foo: Foo)
 
-      val result = "{\"Qux\":{\"foo\":{\"Bar\":{}}}}".fromJson[Foo]
-
-      assertTrue(result == Right(Foo.Qux(Foo.Bar)))
+      assertTrue("{\"Qux\":{\"foo\":{\"Bar\":{}}}}".fromJson[Foo] == Right(Foo.Qux(Foo.Bar)))
     },
     test("Derives and decodes for a union of string-based literals") {
       case class Foo(aOrB: "A" | "B", optA: Option["A"]) derives JsonDecoder


### PR DESCRIPTION
Below are throughput results of benchmarks for encoding of product types using Scala 3 and JDK 21 on Intel® Core™ i7-11800H CPU @ 2.3GHz (max 4.6GHz).

#### Before
```txt
[info] Benchmark                                      Mode  Cnt       Score       Error  Units
[info] GeoJSONBenchmarks.encodeZio                   thrpt    5   16105.304 ±   289.126  ops/s
[info] GoogleMapsAPIBenchmarks.encodeZio             thrpt    5   21405.929 ±   277.589  ops/s
[info] SyntheticBenchmarks.encodeZio                 thrpt    5  416011.468 ±  1860.251  ops/s
[info] TwitterAPIBenchmarks.encodeZio                thrpt    5   21569.984 ±   162.640  ops/s
```

#### After
```txt
[info] Benchmark                                      Mode  Cnt       Score      Error  Units
[info] GeoJSONBenchmarks.encodeZio                   thrpt    5   16492.856 ±  168.934  ops/s
[info] GoogleMapsAPIBenchmarks.encodeZio             thrpt    5   23977.509 ± 1471.230  ops/s
[info] SyntheticBenchmarks.encodeZio                 thrpt    5  473714.207 ± 6140.838  ops/s
[info] TwitterAPIBenchmarks.encodeZio                thrpt    5   23682.642 ±  238.536  ops/s
```