### PR TITLE
Fix traces of decoding error for tuples

### DIFF
--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -54,6 +54,13 @@ object DecoderSpec extends ZIOSpecDefault {
             forall(isRight(isRight(equalTo(2))))
           )
         },
+        test("tuples") {
+          assert("""["a",3]""".fromJson[(String, Int)])(isRight(equalTo(("a", 3))))
+          assert("""["a","b"]""".fromJson[(String, Int)])(isLeft(equalTo("[1](expected a number, got 'b')")))
+          assert("""[[0.1,0.2],[0.3,0.4],[-0.3,-]]""".fromJson[Seq[(Double, Double)]])(
+            isLeft(equalTo("[2][1](expected a Double)"))
+          )
+        },
         test("parameterless products") {
           import exampleproducts._
 


### PR DESCRIPTION
It also improves performance of tuple decoding.

Below are throughput results tested for real-world GeoJSON samples with Scala 3 and JDK 21 on Intel® Core™ i7-11800H CPU @ 2.3GHz (max 4.6GHz):

#### Before
```txt
[info] Benchmark                                      Mode  Cnt       Score       Error  Units
[info] GeoJSONBenchmarks.decodeZioError              thrpt    5   12897.669 ±    98.106  ops/s
[info] GeoJSONBenchmarks.decodeZioSuccess1           thrpt    5   14591.771 ±   261.160  ops/s
[info] GeoJSONBenchmarks.decodeZioSuccess2           thrpt    5   12657.956 ±   310.780  ops/s
```

#### After
```txt
[info] Benchmark                                      Mode  Cnt       Score      Error  Units
[info] GeoJSONBenchmarks.decodeZioError              thrpt    5   14904.517 ±  319.763  ops/s
[info] GeoJSONBenchmarks.decodeZioSuccess1           thrpt    5   16310.939 ±  276.229  ops/s
[info] GeoJSONBenchmarks.decodeZioSuccess2           thrpt    5   13015.005 ±  112.156  ops/s
```

