### PR TITLE
More efficient decoding of `UUID`, `Currency`, and `java.time._` values

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
@@ -1572,6 +1572,7 @@ private[json] object parsers {
 
   private[this] def charError(ch: Char, pos: Int) = error(s"expected '$ch'", pos)
 
-  private[this] def error(msg: String, pos: Int) =
+  @noinline
+  private[this] def error(msg: String, pos: Int): Nothing =
     throw new DateTimeException(msg + " at index " + pos) with NoStackTrace
 }

--- a/zio-json/shared/src/main/scala/zio/json/uuid/UUIDParser.scala
+++ b/zio-json/shared/src/main/scala/zio/json/uuid/UUIDParser.scala
@@ -16,6 +16,7 @@
 package zio.json.uuid
 
 import scala.annotation.nowarn
+import scala.util.control.NoStackTrace
 
 // A port of https://github.com/openjdk/jdk/commit/ebadfaeb2e1cc7b5ce5f101cd8a539bc5478cf5b with optimizations applied
 private[json] object UUIDParser {
@@ -89,7 +90,7 @@ private[json] object UUIDParser {
 
   private[this] def unsafeParseExtended(input: String): java.util.UUID = {
     val len = input.length
-    if (len > 36) throw new IllegalArgumentException("UUID string too large")
+    if (len > 36) invalidUUIDError("UUID string too large")
     val dash1 = input.indexOf('-', 0)
     val dash2 = input.indexOf('-', dash1 + 1)
     val dash3 = input.indexOf('-', dash2 + 1)
@@ -131,6 +132,7 @@ private[json] object UUIDParser {
     result
   }
 
-  private[this] def invalidUUIDError(input: String): IllegalArgumentException =
-    throw new IllegalArgumentException(input)
+  @noinline
+  private[this] def invalidUUIDError(input: String): Nothing =
+    throw new IllegalArgumentException(input) with NoStackTrace
 }


### PR DESCRIPTION
It reduces allocations and improves throughput on 5-6%:

![image](https://github.com/user-attachments/assets/6f76d59a-89d1-49f0-8848-39060e97cc54)

Also, it makes more efficient throwing of `UUID` decoding errors by making them stack-less.