### PR TITLE
Strip invalid values in error messages

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -157,20 +157,20 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): B =
         f(self.unsafeDecode(trace, in)) match {
-          case Left(err) => Lexer.error(err, trace)
           case Right(b)  => b
+          case Left(err) => Lexer.error(err, trace)
         }
 
       override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): B =
         f(self.unsafeFromJsonAST(trace, json)) match {
-          case Left(err) => Lexer.error(err, trace)
           case Right(b)  => b
+          case Left(err) => Lexer.error(err, trace)
         }
 
       override def unsafeDecodeMissing(trace: List[JsonError]): B =
         f(self.unsafeDecodeMissing(trace)) match {
-          case Left(err) => Lexer.error(err, trace)
           case Right(b)  => b
+          case Left(err) => Lexer.error(err, trace)
         }
 
     }
@@ -271,7 +271,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): String =
       json match {
         case Json.Str(value) => value
-        case _               => Lexer.error("Not a string value", trace)
+        case _               => Lexer.error("expected string", trace)
       }
   }
 
@@ -283,14 +283,24 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): Boolean =
       json match {
         case Json.Bool(value) => value
-        case _                => Lexer.error("Not a bool value", trace)
+        case _                => Lexer.error("expected boolean", trace)
       }
   }
 
-  implicit val char: JsonDecoder[Char] = string.mapOrFail {
-    case str if str.length == 1 => Right(str(0))
-    case _                      => Left("expected one character")
+  implicit val char: JsonDecoder[Char] = new JsonDecoder[Char] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): Char = {
+      val s = Lexer.string(trace, in)
+      if (s.length == 1) s.charAt(0)
+      else Lexer.error("expected single character string", trace)
+    }
+
+    override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): Char =
+      json match {
+        case Json.Str(s) if s.length == 1 => s.charAt(0)
+        case _                            => Lexer.error("expected single character string", trace)
+      }
   }
+
   implicit val symbol: JsonDecoder[Symbol] = string.map(Symbol(_))
 
   implicit val byte: JsonDecoder[Byte]                       = number(Lexer.byte, _.byteValueExact())
@@ -481,10 +491,10 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def chunk[A: JsonDecoder]: JsonDecoder[Chunk[A]] =
     new JsonDecoder[Chunk[A]] {
+      private[this] val decoder = JsonDecoder[A]
 
       override def unsafeDecodeMissing(trace: List[JsonError]): Chunk[A] = Chunk.empty
 
-      val decoder = JsonDecoder[A]
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Chunk[A] =
         builder(trace, in, zio.ChunkBuilder.make[A]())
 
@@ -710,64 +720,83 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
 
   private[this] def javaTimeDecoder[A](f: String => A): JsonDecoder[A] = new JsonDecoder[A] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
-      parseJavaTime(trace, string.unsafeDecode(trace, in))
+      parseJavaTime(trace, Lexer.string(trace, in).toString)
 
-    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): A =
-      parseJavaTime(trace, string.unsafeFromJsonAST(trace, json))
+    override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): A =
+      json match {
+        case Json.Str(value) => parseJavaTime(trace, value)
+        case _               => Lexer.error("expected string", trace)
+      }
 
     // Commonized handling for decoding from string to java.time Class
     @inline
     private[this] def parseJavaTime(trace: List[JsonError], s: String): A =
       try f(s)
       catch {
-        case zre: ZoneRulesException => Lexer.error(s"$s is not a valid ISO-8601 format, ${zre.getMessage}", trace)
-        case dtpe: DateTimeParseException =>
-          Lexer.error(s"$s is not a valid ISO-8601 format, ${dtpe.getMessage}", trace)
-        case dte: DateTimeException => Lexer.error(s"$s is not a valid ISO-8601 format, ${dte.getMessage}", trace)
-        case ex: Exception          => Lexer.error(ex.getMessage, trace)
+        case ex: DateTimeException       => error(s, ex, trace)
+        case ex: DateTimeParseException  => error(s, ex, trace)
+        case ex: ZoneRulesException      => error(s, ex, trace)
+        case _: IllegalArgumentException => Lexer.error(s"${strip(s)} is not a valid ISO-8601 format", trace)
       }
+
+    @noinline
+    private[this] def error(s: String, ex: Exception, trace: List[JsonError]): Nothing =
+      Lexer.error(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}", trace)
   }
 
   // Commonized handling for decoding from string to java.time Class
   private[json] def parseJavaTime[A](f: String => A, s: String): Either[String, A] =
-    try {
-      Right(f(s))
-    } catch {
-      case zre: ZoneRulesException      => Left(s"$s is not a valid ISO-8601 format, ${zre.getMessage}")
-      case dtpe: DateTimeParseException => Left(s"$s is not a valid ISO-8601 format, ${dtpe.getMessage}")
-      case dte: DateTimeException       => Left(s"$s is not a valid ISO-8601 format, ${dte.getMessage}")
-      case ex: Exception                => Left(ex.getMessage)
+    try Right(f(s))
+    catch {
+      case ex: DateTimeException =>
+        Left(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}")
+      case ex: DateTimeParseException =>
+        Left(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}")
+      case ex: ZoneRulesException =>
+        Left(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}")
+      case _: IllegalArgumentException =>
+        Left(s"${strip(s)} is not a valid ISO-8601 format")
     }
 
   implicit val uuid: JsonDecoder[UUID] = new JsonDecoder[UUID] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): UUID =
-      parseUUID(trace, string.unsafeDecode(trace, in))
+      parseUUID(trace, Lexer.string(trace, in).toString)
 
-    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): UUID =
-      parseUUID(trace, string.unsafeFromJsonAST(trace, json))
+    override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): UUID =
+      json match {
+        case Json.Str(value) => parseUUID(trace, value)
+        case _               => Lexer.error("expected string", trace)
+      }
 
     @inline
     private[this] def parseUUID(trace: List[JsonError], s: String): UUID =
       try UUIDParser.unsafeParse(s)
       catch {
-        case iae: IllegalArgumentException => Lexer.error(s"Invalid UUID: ${iae.getMessage}", trace)
+        case _: IllegalArgumentException => Lexer.error(s"Invalid UUID: ${strip(s)}", trace)
       }
   }
 
   implicit val currency: JsonDecoder[java.util.Currency] = new JsonDecoder[java.util.Currency] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): java.util.Currency =
-      parseCurrency(trace, string.unsafeDecode(trace, in))
+      parseCurrency(trace, Lexer.string(trace, in).toString)
 
-    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): java.util.Currency =
-      parseCurrency(trace, string.unsafeFromJsonAST(trace, json))
+    override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): java.util.Currency =
+      json match {
+        case Json.Str(value) => parseCurrency(trace, value)
+        case _               => Lexer.error("expected string", trace)
+      }
 
     @inline
     private[this] def parseCurrency(trace: List[JsonError], s: String): java.util.Currency =
       try java.util.Currency.getInstance(s)
       catch {
-        case iae: IllegalArgumentException => Lexer.error(s"Invalid Currency: ${iae.getMessage}", trace)
+        case _: IllegalArgumentException => Lexer.error(s"Invalid Currency: ${strip(s)}", trace)
       }
   }
+
+  private[json] def strip(s: String, len: Int = 50): String =
+    if (s.length <= len) s
+    else s.substring(0, len) + "..."
 }
 
 private[json] trait DecoderLowPriority4 extends DecoderLowPriorityVersionSpecific {

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -698,8 +698,6 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
   this: JsonDecoder.type =>
 
   import java.time.{ DateTimeException, _ }
-  import java.time.format.DateTimeParseException
-  import java.time.zone.ZoneRulesException
 
   implicit val dayOfWeek: JsonDecoder[DayOfWeek]           = javaTimeDecoder(s => DayOfWeek.valueOf(s.toUpperCase))
   implicit val duration: JsonDecoder[Duration]             = javaTimeDecoder(parsers.unsafeParseDuration)
@@ -733,15 +731,11 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
     private[this] def parseJavaTime(trace: List[JsonError], s: String): A =
       try f(s)
       catch {
-        case ex: DateTimeException       => error(s, ex, trace)
-        case ex: DateTimeParseException  => error(s, ex, trace)
-        case ex: ZoneRulesException      => error(s, ex, trace)
-        case _: IllegalArgumentException => Lexer.error(s"${strip(s)} is not a valid ISO-8601 format", trace)
+        case ex: DateTimeException =>
+          Lexer.error(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}", trace)
+        case _: IllegalArgumentException =>
+          Lexer.error(s"${strip(s)} is not a valid ISO-8601 format", trace)
       }
-
-    @noinline
-    private[this] def error(s: String, ex: Exception, trace: List[JsonError]): Nothing =
-      Lexer.error(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}", trace)
   }
 
   // Commonized handling for decoding from string to java.time Class
@@ -749,10 +743,6 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
     try Right(f(s))
     catch {
       case ex: DateTimeException =>
-        Left(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}")
-      case ex: DateTimeParseException =>
-        Left(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}")
-      case ex: ZoneRulesException =>
         Left(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}")
       case _: IllegalArgumentException =>
         Left(s"${strip(s)} is not a valid ISO-8601 format")

--- a/zio-json/shared/src/main/scala/zio/json/JsonFieldDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonFieldDecoder.scala
@@ -49,30 +49,28 @@ object JsonFieldDecoder {
     def unsafeDecodeField(trace: List[JsonError], in: String): String = in
   }
 
-  implicit val int: JsonFieldDecoder[Int] =
-    JsonFieldDecoder[String].mapOrFail { str =>
-      try {
-        Right(str.toInt)
-      } catch {
-        case n: NumberFormatException => Left(s"Invalid Int: '$str': $n")
+  implicit val int: JsonFieldDecoder[Int] = new JsonFieldDecoder[Int] {
+    def unsafeDecodeField(trace: List[JsonError], in: String): Int =
+      try in.toInt
+      catch {
+        case _: NumberFormatException => Lexer.error(s"Invalid Int: ${strip(in)}", trace)
       }
-    }
+  }
 
-  implicit val long: JsonFieldDecoder[Long] =
-    JsonFieldDecoder[String].mapOrFail { str =>
-      try {
-        Right(str.toLong)
-      } catch {
-        case n: NumberFormatException => Left(s"Invalid Long: '$str': $n")
+  implicit val long: JsonFieldDecoder[Long] = new JsonFieldDecoder[Long] {
+    def unsafeDecodeField(trace: List[JsonError], in: String): Long =
+      try in.toLong
+      catch {
+        case _: NumberFormatException => Lexer.error(s"Invalid Long: ${strip(in)}", trace)
       }
-    }
+  }
 
-  implicit val uuid: JsonFieldDecoder[java.util.UUID] = mapStringOrFail { str =>
-    try {
-      Right(UUIDParser.unsafeParse(str))
-    } catch {
-      case iae: IllegalArgumentException => Left(s"Invalid UUID: ${iae.getMessage}")
-    }
+  implicit val uuid: JsonFieldDecoder[java.util.UUID] = new JsonFieldDecoder[java.util.UUID] {
+    def unsafeDecodeField(trace: List[JsonError], in: String): java.util.UUID =
+      try UUIDParser.unsafeParse(in)
+      catch {
+        case _: IllegalArgumentException => Lexer.error(s"Invalid UUID: ${strip(in)}", trace)
+      }
   }
 
   // use this instead of `string.mapOrFail` in supertypes (to prevent class initialization error at runtime)
@@ -84,4 +82,8 @@ object JsonFieldDecoder {
           case Right(value) => value
         }
     }
+
+  private[json] def strip(s: String, len: Int = 50): String =
+    if (s.length <= len) s
+    else s.substring(0, len) + "..."
 }

--- a/zio-json/shared/src/main/scala/zio/json/uuid/UUIDParser.scala
+++ b/zio-json/shared/src/main/scala/zio/json/uuid/UUIDParser.scala
@@ -73,7 +73,7 @@ private[json] object UUIDParser {
       val lsb2 = parseNibbles(ch2n, input, 24)
       val lsb3 = parseNibbles(ch2n, input, 28)
       val lsb4 = parseNibbles(ch2n, input, 32)
-      if ((msb1 | msb2 | msb3 | msb4 | lsb1 | lsb2 | lsb3 | lsb4) < 0) invalidUUIDError(input)
+      if ((msb1 | msb2 | msb3 | msb4 | lsb1 | lsb2 | lsb3 | lsb4) < 0) invalidUUIDError()
       new java.util.UUID(msb1 << 48 | msb2 << 32 | msb3 << 16 | msb4, lsb1 << 48 | lsb2 << 32 | lsb3 << 16 | lsb4)
     }
 
@@ -90,7 +90,7 @@ private[json] object UUIDParser {
 
   private[this] def unsafeParseExtended(input: String): java.util.UUID = {
     val len = input.length
-    if (len > 36) invalidUUIDError("UUID string too large")
+    if (len > 36) invalidUUIDError()
     val dash1 = input.indexOf('-', 0)
     val dash2 = input.indexOf('-', dash1 + 1)
     val dash3 = input.indexOf('-', dash2 + 1)
@@ -102,7 +102,7 @@ private[json] object UUIDParser {
     // - if dash1 is -1, dash4 will be -1
     // - if dash1 is positive but dash2 is -1, dash4 will be -1
     // - if dash1 and dash2 is positive, dash3 will be -1, dash4 will be positive, but so will dash5
-    if (dash4 < 0 || dash5 >= 0) invalidUUIDError(input)
+    if (dash4 < 0 || dash5 >= 0) invalidUUIDError()
 
     val ch2n     = CharToNumeric
     val section1 = parseSection(ch2n, input, 0, dash1, 0xfffffff00000000L)
@@ -121,18 +121,18 @@ private[json] object UUIDParser {
     endIndex: Int,
     zeroMask: Long
   ): Long = {
-    if (beginIndex >= endIndex || beginIndex + 16 < endIndex) invalidUUIDError(input)
+    if (beginIndex >= endIndex || beginIndex + 16 < endIndex) invalidUUIDError()
     var result = 0L
     var i      = beginIndex
     while (i < endIndex) {
       result = (result << 4) | ch2n(input.charAt(i))
       i += 1
     }
-    if ((result & zeroMask) != 0) invalidUUIDError(input)
+    if ((result & zeroMask) != 0) invalidUUIDError()
     result
   }
 
   @noinline
-  private[this] def invalidUUIDError(input: String): Nothing =
-    throw new IllegalArgumentException(input) with NoStackTrace
+  private[this] def invalidUUIDError(): Nothing =
+    throw new IllegalArgumentException with NoStackTrace
 }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -256,6 +256,18 @@ object DecoderSpec extends ZIOSpecDefault {
           val jsonStr  = JsonEncoder[Map[String, String]].encodeJson(expected, None)
           assert(jsonStr.fromJson[Map[String, String]])(isRight(equalTo(expected)))
         },
+        test("Map with Int keys") {
+          assert("""{"1234567890": "value"}""".fromJson[Map[Int, String]])(
+            isRight(equalTo(Map(1234567890 -> "value")))
+          ) &&
+          assert("""{"xxx": "value"}""".fromJson[Map[Int, String]])(isLeft(containsString("Invalid Int: xxx")))
+        },
+        test("Map with Long keys") {
+          assert("""{"1234567890123456789": "value"}""".fromJson[Map[Long, String]])(
+            isRight(equalTo(Map(1234567890123456789L -> "value")))
+          ) &&
+          assert("""{"xxx": "value"}""".fromJson[Map[Long, String]])(isLeft(containsString("Invalid Long: xxx")))
+        },
         test("Map with UUID keys") {
           def expectedMap(str: String): Map[UUID, String] = Map(UUID.fromString(str) -> "value")
 
@@ -376,6 +388,19 @@ object DecoderSpec extends ZIOSpecDefault {
       suite("fromJsonAST")(
         test("BigDecimal") {
           assert(Json.Num(123).as[BigDecimal])(isRight(equalTo(BigDecimal(123))))
+        },
+        test("boolean") {
+          assert(Json.Bool(true).as[Boolean])(isRight(equalTo(true))) &&
+          assert(Json.Str("true").as[Boolean])(isLeft(equalTo("(expected boolean)")))
+        },
+        test("string") {
+          assert(Json.Str("xxx").as[String])(isRight(equalTo("xxx"))) &&
+          assert(Json.Bool(true).as[String])(isLeft(equalTo("(expected string)")))
+        },
+        test("char") {
+          assert(Json.Str("x").as[Char])(isRight(equalTo('x'))) &&
+          assert(Json.Str("xxx").as[Char])(isLeft(equalTo("(expected single character string)"))) &&
+          assert(Json.Bool(true).as[Char])(isLeft(equalTo("(expected single character string)")))
         },
         test("eithers") {
           val bernies =

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -280,7 +280,9 @@ object DecoderSpec extends ZIOSpecDefault {
             isRight(equalTo(expectedMap("00000000-0000-0000-0000-000000000000")))
           ) &&
           assert(bad1.fromJson[Map[UUID, String]])(isLeft(containsString("Invalid UUID: "))) &&
-          assert(bad2.fromJson[Map[UUID, String]])(isLeft(containsString("Invalid UUID: UUID string too large"))) &&
+          assert(bad2.fromJson[Map[UUID, String]])(
+            isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-9832-4e70afe4b0f80"))
+          ) &&
           assert(bad3.fromJson[Map[UUID, String]])(
             isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-983-4e70afe4b0f80"))
           ) &&
@@ -328,7 +330,7 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(ok2.fromJson[UUID])(isRight(equalTo(UUID.fromString("64D7C38D-00FD-0014-0032-0070AfE4B0f8")))) &&
           assert(ok3.fromJson[UUID])(isRight(equalTo(UUID.fromString("00000000-0000-0000-0000-000000000000")))) &&
           assert(bad1.fromJson[UUID])(isLeft(containsString("Invalid UUID: "))) &&
-          assert(bad2.fromJson[UUID])(isLeft(containsString("Invalid UUID: UUID string too large"))) &&
+          assert(bad2.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-9832-4e70afe4b0f80"))) &&
           assert(bad3.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-983-4e70afe4b0f80"))) &&
           assert(bad4.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd--9832-4e70afe4b0f8"))) &&
           assert(bad5.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-XXXX-9832-4e70afe4b0f8"))) &&
@@ -405,7 +407,7 @@ object DecoderSpec extends ZIOSpecDefault {
           import exampleproducts._
 
           assert(Json.Obj("is" -> Json.Arr(Json.Obj("str" -> Json.Num(1)))).as[Outer])(
-            isLeft(equalTo(".is[0].str(Not a string value)"))
+            isLeft(equalTo(".is[0].str(expected string)"))
           )
         },
         test("default field value") {
@@ -549,7 +551,7 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(ok2.as[UUID])(isRight(equalTo(UUID.fromString("64D7C38D-00FD-0014-0032-0070AFE4B0f8")))) &&
           assert(ok3.as[UUID])(isRight(equalTo(UUID.fromString("00000000-0000-0000-0000-000000000000")))) &&
           assert(bad1.as[UUID])(isLeft(containsString("Invalid UUID: "))) &&
-          assert(bad2.as[UUID])(isLeft(containsString("Invalid UUID: UUID string too large"))) &&
+          assert(bad2.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-9832-4e70afe4b0f80"))) &&
           assert(bad3.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-983-4e70afe4b0f80"))) &&
           assert(bad4.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd--9832-4e70afe4b0f8"))) &&
           assert(bad5.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-XXXX-9832-4e70afe4b0f8"))) &&

--- a/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -342,11 +342,7 @@ object JavaTimeSpec extends ZIOSpecDefault {
       suite("Decoder Sad Path")(
         test("DayOfWeek") {
           assert(stringify("foody").fromJson[DayOfWeek])(
-            isLeft(
-              equalTo("(No enum constant java.time.DayOfWeek.FOODY)") || // JVM
-                equalTo("(Unrecognized day of week name: FOODY)") ||     // Scala.js 2.
-                equalTo("(enum case not found: FOODY)")                  // Scala.js 3.
-            )
+            isLeft(equalTo("(foody is not a valid ISO-8601 format)"))
           )
         },
         test("Duration") {
@@ -1496,11 +1492,7 @@ object JavaTimeSpec extends ZIOSpecDefault {
         },
         test("Month") {
           assert(stringify("FebTober").fromJson[Month])(
-            isLeft(
-              equalTo("(No enum constant java.time.Month.FEBTOBER)") || // JVM
-                equalTo("(Unrecognized month name: FEBTOBER)") ||       // Scala.js 2.
-                equalTo("(enum case not found: FEBTOBER)")              // Scala.js 3.
-            )
+            isLeft(equalTo("(FebTober is not a valid ISO-8601 format)"))
           )
         },
         test("MonthDay") {


### PR DESCRIPTION
Also, it speeds up decoding of `Char`, `java.util.UUID`, `java.util.Currency`, and `java.time._` values and decoding of `Int`, `Long`, and `java.util.UUID` keys