### PR TITLE
fix: always evaluate default values (in case it is a method)

### DIFF
--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -36,7 +36,7 @@ Now we can parse JSON into our object
 
 ### Automatic Derivation and case class default field values
 
-If a case class field is defined with a default value and the field is not present or `null`, the default value will be used.
+If a case class field is defined with a default value and the field is not present or `null`, the default value will be used (or evaluated when it is a method).
 
 Say we have a Scala `case class`
 

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -260,10 +260,10 @@ object DeriveJsonDecoder {
           }
           (names, aliases)
         }
-        private[this] val len      = names.length
-        private[this] val matrix   = new StringMatrix(names, aliases)
-        private[this] val spans    = names.map(JsonError.ObjectAccess)
-        private[this] val defaults = ctx.parameters.map(_.default).toArray
+        private[this] val len           = names.length
+        private[this] val matrix        = new StringMatrix(names, aliases)
+        private[this] val spans         = names.map(JsonError.ObjectAccess)
+        private[this] lazy val defaults = ctx.parameters.map(_.evaluateDefault).toArray
         private[this] lazy val tcs =
           ctx.parameters.map(_.typeclass).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
         private[this] lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
@@ -292,7 +292,7 @@ object DeriveJsonDecoder {
                       true
                     }
                   ) tcs(idx).unsafeDecode(spans(idx) :: trace, in)
-                  else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default.get
+                  else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default.get()
                   else Lexer.error("expected 'null'", spans(idx) :: trace)
               } else if (no_extra) Lexer.error("invalid extra field", trace)
               else Lexer.skipValue(trace, in)
@@ -302,7 +302,7 @@ object DeriveJsonDecoder {
             if (ps(idx) == null) {
               val default = defaults(idx)
               ps(idx) =
-                if (default ne None) default.get
+                if (default ne None) default.get()
                 else tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
             }
             idx += 1
@@ -321,7 +321,7 @@ object DeriveJsonDecoder {
                     if (ps(idx) != null) Lexer.error("duplicate", trace)
                     val default = defaults(idx)
                     ps(idx) =
-                      if ((default ne None) && (value eq Json.Null)) default.get
+                      if ((default ne None) && (value eq Json.Null)) default.get()
                       else tcs(idx).unsafeFromJsonAST(spans(idx) :: trace, value)
                   case _ =>
                     if (no_extra) Lexer.error("invalid extra field", trace)
@@ -332,7 +332,7 @@ object DeriveJsonDecoder {
                 if (ps(idx) == null) {
                   val default = defaults(idx)
                   ps(idx) =
-                    if (default ne None) default.get
+                    if (default ne None) default.get()
                     else tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
                 }
                 idx += 1

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -283,7 +283,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
         private val len = names.length
         private val matrix = new StringMatrix(names, aliases)
         private val spans = names.map(JsonError.ObjectAccess(_))
-        private val defaults = IArray.genericWrapArray(ctx.params.map(_.default)).toArray
+        private lazy val defaults = IArray.genericWrapArray(ctx.params.map(_.evaluateDefault)).toArray
         private lazy val tcs =
           IArray.genericWrapArray(ctx.params.map(_.typeclass)).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
         private lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
@@ -301,7 +301,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                   in.retract()
                   true
                 }) tcs(idx).unsafeDecode(spans(idx) :: trace, in)
-                else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default.get
+                else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default.get()
                 else Lexer.error("expected 'null'", spans(idx) :: trace)
               } else if (no_extra) Lexer.error("invalid extra field", trace)
               else Lexer.skipValue(trace, in)
@@ -312,7 +312,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
             if (ps(idx) == null) {
               val default = defaults(idx)
               ps(idx) =
-                if (default ne None) default.get
+                if (default ne None) default.get()
                 else tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
             }
             idx += 1
@@ -330,7 +330,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                     if (ps(idx) != null) Lexer.error("duplicate", trace)
                     val default = defaults(idx)
                     ps(idx) =
-                      if ((default ne None) && (value eq Json.Null)) default.get
+                      if ((default ne None) && (value eq Json.Null)) default.get()
                       else tcs(idx).unsafeFromJsonAST(spans(idx) :: trace, value)
                   case _ =>
                     if (no_extra) Lexer.error("invalid extra field", trace)
@@ -341,7 +341,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                 if (ps(idx) == null) {
                   val default = defaults(idx)
                   ps(idx) =
-                    if (default ne None) default.get
+                    if (default ne None) default.get()
                     else tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
                 }
                 idx += 1

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -167,23 +167,15 @@ object DecoderSpec extends ZIOSpecDefault {
             implicit lazy val decoder: JsonDecoder[DefaultDynamic] = DeriveJsonDecoder.gen[DefaultDynamic]
           }
 
-          val res1 = """{}""".stripMargin.fromJson[DefaultDynamic]
-          val res2 = """{}""".stripMargin.fromJson[DefaultDynamic]
-          val res = ZIO.fromEither {
-            for {
-              json1 <- res1
-              json2 <- res2
-            } yield (json1, json2)
-          }
+          def res = """{}""".stripMargin.fromJson[DefaultDynamic]
 
           for {
-            dynamics <- res
-            finalRes <-
-              assert(res1)(isRight) && assert(res2)(isRight) &&
-                assertTrue(dynamics._1.randomNumber != dynamics._2.randomNumber) &&
-                assertTrue(dynamics._1.instant != dynamics._2.instant)
-          } yield finalRes
-        },
+            dynamics1 <- ZIO.fromEither(res)
+            _         <- ZIO.sleep(2.millis)
+            dynamics2 <- ZIO.fromEither(res)
+          } yield assertTrue(dynamics1.randomNumber != dynamics2.randomNumber) &&
+            assertTrue(dynamics1.instant != dynamics2.instant)
+        } @@ TestAspect.withLiveClock,
         test("sum encoding") {
           import examplesum._
 

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -157,6 +157,33 @@ object DecoderSpec extends ZIOSpecDefault {
           assert("""{}""".fromJson[DefaultString])(isRight(equalTo(DefaultString("")))) &&
           assert("""{"s": null}""".fromJson[DefaultString])(isRight(equalTo(DefaultString(""))))
         },
+        test("dynamic default value") {
+          case class DefaultDynamic(
+            randomNumber: Double = scala.math.random(),
+            instant: java.time.Instant = java.time.Instant.now()
+          )
+
+          object DefaultDynamic {
+            implicit lazy val decoder: JsonDecoder[DefaultDynamic] = DeriveJsonDecoder.gen[DefaultDynamic]
+          }
+
+          val res1 = """{}""".stripMargin.fromJson[DefaultDynamic]
+          val res2 = """{}""".stripMargin.fromJson[DefaultDynamic]
+          val res = ZIO.fromEither {
+            for {
+              json1 <- res1
+              json2 <- res2
+            } yield (json1, json2)
+          }
+
+          for {
+            dynamics <- res
+            finalRes <-
+              assert(res1)(isRight) && assert(res2)(isRight) &&
+                assertTrue(dynamics._1.randomNumber != dynamics._2.randomNumber) &&
+                assertTrue(dynamics._1.instant != dynamics._2.instant)
+          } yield finalRes
+        },
         test("sum encoding") {
           import examplesum._
 
@@ -441,6 +468,25 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(Json.Obj().as[DefaultString])(isRight(equalTo(DefaultString("")))) &&
           assert(Json.Obj("s" -> Json.Null).as[DefaultString])(isRight(equalTo(DefaultString(""))))
         },
+        test("dynamic default value") {
+          case class DefaultDynamic(
+            randomNumber: Double = scala.math.random(),
+            instant: java.time.Instant = java.time.Instant.now()
+          )
+
+          object DefaultDynamic {
+            implicit lazy val decoder: JsonDecoder[DefaultDynamic] = DeriveJsonDecoder.gen[DefaultDynamic]
+          }
+
+          for {
+            dynamics1 <- ZIO.fromEither(Json.Obj().as[DefaultDynamic])
+            _         <- ZIO.sleep(2.millis) // ensure java.time.Instant is different
+            dynamics2 <- ZIO.fromEither(Json.Obj().as[DefaultDynamic])
+          } yield assertTrue(
+            dynamics1.randomNumber != dynamics2.randomNumber,
+            dynamics1.instant != dynamics2.instant
+          )
+        } @@ TestAspect.withLiveClock,
         test("aliases") {
           import exampleproducts._
 


### PR DESCRIPTION
This PR attempts to fix the same as #1119 but as simple as possible without annotations. Credits to @Andrapyre, author of #1119, who made some magnolia changes in May 2024 to add `evaluateDefault`. I guess in preparation for usage, among others, in zio-json.
I do not know why his PR in zio-json was not picked up. It went quite stale. Hopefully this PR or the old PR can be picked up because it seems like an important fix.

Closes #1055

Note: I do not claim the bounty as prework was already done but it is unclear if the work was rejected, failed or just never looked at.

