### PR TITLE
feat: explicitEmptyCollections V2, for more json (or less)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,10 +218,10 @@ Mango(None).toJson
 
 ## Empty Collections, explicitEmptyCollections
 
-By default `empty collections` (all supported collection types and case classes) are included from the JSON output an decoding requires empty collections to be present. This behavior can be changed by using the `@jsonExplicitEmptyCollections(whenEncoding = false, whenDecoding = false)` annotation on a case class, field or setting `JsonCodecConfiguration.explicitEmptyCollections` to `ExplicitEmptyCollections(whenEncoding = false, whenDecoding = false)`. The result is that empty collections are omitted from the JSON output and when decoding empty collections are created. It is also possible to have different values for encoding and decoding by using `@jsonExplicitEmptyCollections(whenEncoding = true, whenDecoding = false)` or `@jsonExplicitEmptyCollections(whenEncoding = false, whenDecoding = true)`.
+By default `empty collections` (all supported collection types and case classes) are included from the JSON output an decoding requires empty collections to be present. This behavior can be changed by using the `@jsonExplicitEmptyCollections(encoding = false, decoding = false)` annotation on a case class, field or setting `JsonCodecConfiguration.explicitEmptyCollections` to `ExplicitEmptyCollections(encoding = false, decoding = false)`. The result is that empty collections are omitted from the JSON output and when decoding empty collections are created. It is also possible to have different values for encoding and decoding by using `@jsonExplicitEmptyCollections(encoding = true, decoding = false)` or `@jsonExplicitEmptyCollections(encoding = false, decoding = true)`.
 
 ```scala mdoc
-@jsonExplicitEmptyCollections(whenEncoding = false, whenDecoding = false)
+@jsonExplicitEmptyCollections(encoding = false, decoding = false)
 case class Pineapple(leaves: List[String])
 
 object Pineapple {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,10 +218,10 @@ Mango(None).toJson
 
 ## Empty Collections, explicitEmptyCollections
 
-By default `empty collections` (all supported collection types and case classes) are included from the JSON output an decoding requires empty collections to be present. This behavior can be changed by using the `@jsonExplicitEmptyCollections(false)` annotation on a case class, field or setting `JsonCodecConfiguration.explicitEmptyCollections` to `false`. The result is that empty collections are omitted from the JSON output and when decoding empty collections are created.
+By default `empty collections` (all supported collection types and case classes) are included from the JSON output an decoding requires empty collections to be present. This behavior can be changed by using the `@jsonExplicitEmptyCollections(whenEncoding = false, whenDecoding = false)` annotation on a case class, field or setting `JsonCodecConfiguration.explicitEmptyCollections` to `ExplicitEmptyCollections(whenEncoding = false, whenDecoding = false)`. The result is that empty collections are omitted from the JSON output and when decoding empty collections are created. It is also possible to have different values for encoding and decoding by using `@jsonExplicitEmptyCollections(whenEncoding = true, whenDecoding = false)` or `@jsonExplicitEmptyCollections(whenEncoding = false, whenDecoding = true)`.
 
 ```scala mdoc
-@jsonExplicitEmptyCollections(false)
+@jsonExplicitEmptyCollections(whenEncoding = false, whenDecoding = false)
 case class Pineapple(leaves: List[String])
 
 object Pineapple {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,6 +197,14 @@ The following two expressions result in an equal value:
 
 The `@jsonAliases` annotation supports multiple aliases. The annotation has no effect on encoding.
 
+## Nulls, explicitNulls
+
+By default `null` values are omitted from the JSON output. This behavior can be changed by using the `@jsonExplicitNulls` annotation on a case class or settings `JsonCodecConfiguration.explicitNulls` to `true`.
+
+## Empty Collections, explicitEmptyCollections
+
+By default `empty collections` (all supported collection types and case classes) are included from the JSON output an decoding requires empty collections to be present. This behavior can be changed by using the `@jsonExplicitEmptyCollections(false)` annotation on a case class or settings `JsonCodecConfiguration.explicitEmptyCollections` to `false`. The result is that empty collections are omitted from the JSON output and when decoding empty collections are created.
+
 ## @jsonDerive
 
 **Requires zio-json-macros**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,11 +199,40 @@ The `@jsonAliases` annotation supports multiple aliases. The annotation has no e
 
 ## Nulls, explicitNulls
 
-By default `null` values are omitted from the JSON output. This behavior can be changed by using the `@jsonExplicitNulls` annotation on a case class or settings `JsonCodecConfiguration.explicitNulls` to `true`.
+By default `null` values are omitted from the JSON output. This behavior can be changed by using the `@jsonExplicitNull` annotation on a case class, field or setting `JsonCodecConfiguration.explicitNulls` to `true`.
+Missing nulls on decoding are always allowed.
+
+```scala mdoc
+@jsonExplicitNull
+case class Mango(ripeness: Option[Int])
+
+object Mango {
+  implicit val codec: JsonCodec[Mango] = DeriveJsonCodec.gen[Mango]
+}
+```
+The following expression results in a JSON document with a `null` value:
+```scala mdoc
+Mango(None).toJson
+"""{}""".fromJson[Mango]
+```
 
 ## Empty Collections, explicitEmptyCollections
 
-By default `empty collections` (all supported collection types and case classes) are included from the JSON output an decoding requires empty collections to be present. This behavior can be changed by using the `@jsonExplicitEmptyCollections(false)` annotation on a case class or settings `JsonCodecConfiguration.explicitEmptyCollections` to `false`. The result is that empty collections are omitted from the JSON output and when decoding empty collections are created.
+By default `empty collections` (all supported collection types and case classes) are included from the JSON output an decoding requires empty collections to be present. This behavior can be changed by using the `@jsonExplicitEmptyCollections(false)` annotation on a case class, field or setting `JsonCodecConfiguration.explicitEmptyCollections` to `false`. The result is that empty collections are omitted from the JSON output and when decoding empty collections are created.
+
+```scala mdoc
+@jsonExplicitEmptyCollections(false)
+case class Pineapple(leaves: List[String])
+
+object Pineapple {
+  implicit val codec: JsonCodec[Pineapple] = DeriveJsonCodec.gen[Pineapple]
+}
+```
+The following expression results in a JSON document with an empty collection:
+```scala mdoc
+Pineapple(Nil).toJson
+"""{}""".fromJson[Pineapple]
+```
 
 ## @jsonDerive
 

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -27,7 +27,8 @@ final class jsonExplicitNull extends Annotation
 /**
  * When disabled keys with empty collections will be omitted from the JSON.
  */
-final case class jsonExplicitEmptyCollections(enabled: Boolean = true) extends Annotation
+final case class jsonExplicitEmptyCollections(whenEncoding: Boolean = true, whenDecoding: Boolean = true)
+    extends Annotation
 
 /**
  * If used on a sealed class, will determine the name of the field for disambiguating classes.
@@ -274,9 +275,9 @@ object DeriveJsonDecoder {
         private[this] lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
 
         private[this] val explicitEmptyCollections =
-          ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
-            enabled
-          }.getOrElse(config.explicitEmptyCollections)
+          ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
+            a.whenDecoding
+          }.getOrElse(config.explicitEmptyCollections.whenDecoding)
 
         private[this] val missingValueDecoder =
           if (explicitEmptyCollections) {
@@ -505,17 +506,17 @@ object DeriveJsonEncoder {
         private[this] val explicitNulls =
           config.explicitNulls || ctx.annotations.exists(_.isInstanceOf[jsonExplicitNull])
         private[this] val explicitEmptyCollections =
-          ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
-            enabled
-          }.getOrElse(config.explicitEmptyCollections)
+          ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
+            a.whenEncoding
+          }.getOrElse(config.explicitEmptyCollections.whenEncoding)
 
         private[this] lazy val fields: Array[FieldEncoder[Any, Param[JsonEncoder, A]]] = params.map { p =>
           val name = p.annotations.collectFirst { case jsonField(name) =>
             name
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
           val withExplicitNulls = explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-          val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
-            enabled
+          val withExplicitEmptyCollections = p.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
+            a.whenEncoding
           }.getOrElse(explicitEmptyCollections)
           new FieldEncoder(
             p,

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -19,6 +19,9 @@ final case class jsonField(name: String) extends Annotation
  */
 final case class jsonAliases(alias: String, aliases: String*) extends Annotation
 
+/**
+ * Empty option fields will be encoded as `null`.
+ */
 final class jsonExplicitNull extends Annotation
 
 /**

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -19,10 +19,12 @@ final case class jsonField(name: String) extends Annotation
  */
 final case class jsonAliases(alias: String, aliases: String*) extends Annotation
 
-/**
- * Empty option fields will be encoded as `null`.
- */
 final class jsonExplicitNull extends Annotation
+
+/**
+ * When disabled keys with empty collections will be omitted from the JSON.
+ */
+final case class jsonExplicitEmptyCollection(enabled: Boolean = true) extends Annotation
 
 /**
  * If used on a sealed class, will determine the name of the field for disambiguating classes.
@@ -211,7 +213,8 @@ object DeriveJsonDecoder {
     }.isDefined || !config.allowExtraFields
 
     if (ctx.parameters.isEmpty)
-      new JsonDecoder[A] {
+      new CollectionJsonDecoder[A] {
+        override def unsafeDecodeMissing(trace: List[JsonError]): A = ctx.rawConstruct(Nil)
 
         def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
           if (no_extra) {
@@ -231,7 +234,7 @@ object DeriveJsonDecoder {
           }
       }
     else
-      new JsonDecoder[A] {
+      new CollectionJsonDecoder[A] {
         private[this] val (names, aliases): (Array[String], Array[(String, Int)]) = {
           val names          = new Array[String](ctx.parameters.size)
           val aliasesBuilder = Array.newBuilder[(String, Int)]
@@ -266,6 +269,47 @@ object DeriveJsonDecoder {
         private[this] lazy val tcs =
           ctx.parameters.map(_.typeclass).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
         private[this] lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
+
+        // private[this] val explicitNulls =
+        //   config.explicitNulls || ctx.annotations.collectFirst { case jsonExplicitNull => () }.isDefined
+        private[this] val explicitEmptyCollections =
+          ctx.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+            enabled
+          }.getOrElse(config.explicitEmptyCollections)
+
+        private[this] def allowMissingValueDecoder(d: JsonDecoder[_]): Boolean = d match {
+          case d: CollectionJsonDecoder[_] if !explicitEmptyCollections => true
+          // case d: OptionJsonDecoder[_] if !explicitNulls => true
+          case d: OptionJsonDecoder[_] => true
+          case d: MappedJsonDecoder[_] => allowMissingValueDecoder(d.underlying)
+          case d                       => false
+        }
+        private[this] val missingValueDecoder =
+          if (!explicitEmptyCollections)
+            (idx: Int, trace: List[JsonError]) => tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+          else {
+            lazy val missingValueDecoderMap =
+              tcs.map(d => if (allowMissingValueDecoder(d)) Some(d) else None).toIndexedSeq
+            (idx: Int, trace: List[JsonError]) =>
+              missingValueDecoderMap(idx)
+                .map(_.unsafeDecodeMissing(spans(idx) :: trace))
+                .getOrElse(Lexer.error("missing", spans(idx) :: trace))
+          }
+
+        override def unsafeDecodeMissing(trace: List[JsonError]): A = {
+          val ps  = new Array[Any](len)
+          var idx = 0
+          while (idx < len) {
+            if (ps(idx) == null) {
+              val default = defaults(idx)
+              ps(idx) =
+                if (default ne None) default.get
+                else missingValueDecoder(idx, trace)
+            }
+            idx += 1
+          }
+          ctx.rawConstruct(new ArraySeq(ps))
+        }
 
         override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
           Lexer.char(trace, in, '{')
@@ -302,7 +346,7 @@ object DeriveJsonDecoder {
               val default = defaults(idx)
               ps(idx) =
                 if (default ne None) default.get()
-                else tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+                else missingValueDecoder(idx, trace)
             }
             idx += 1
           }
@@ -332,7 +376,7 @@ object DeriveJsonDecoder {
                   val default = defaults(idx)
                   ps(idx) =
                     if (default ne None) default.get()
-                    else tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+                    else missingValueDecoder(idx, trace)
                 }
                 idx += 1
               }
@@ -433,6 +477,8 @@ object DeriveJsonEncoder {
     if (ctx.parameters.isEmpty)
       new JsonEncoder[A] {
 
+        override def isEmpty(a: A): Boolean = true
+
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write("{}")
 
         override final def toJsonAST(a: A): Either[String, Json] =
@@ -449,25 +495,79 @@ object DeriveJsonEncoder {
         private[this] val params = ctx.parameters
           .filter(p => p.annotations.collectFirst { case _: jsonExclude => () }.isEmpty)
           .toArray
-        private[this] val names =
-          params.map { p =>
-            p.annotations.collectFirst { case jsonField(name) =>
-              name
-            }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
-          }
+
         private[this] val explicitNulls =
           config.explicitNulls || ctx.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-        private[this] lazy val fields = params.map {
-          var idx = 0
-          p =>
-            val field = (
-              p,
-              names(idx),
-              p.typeclass.asInstanceOf[JsonEncoder[Any]],
-              explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-            )
-            idx += 1
-            field
+        private[this] val explicitEmptyCollections =
+          ctx.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+            enabled
+          }.getOrElse(config.explicitEmptyCollections)
+
+        private[this] class Field[T](
+          val p: Param[JsonEncoder, A],
+          val name: String,
+          val encoder: JsonEncoder[T],
+          withExplicitNulls: Boolean,
+          withExplicitEmptyCollections: Boolean
+        ) {
+          private[this] val _encodeOrSkip: T => (() => Unit) => Unit =
+            (withExplicitNulls, withExplicitEmptyCollections) match {
+              case (true, true) => _ => encode => encode()
+              case (false, false) => { t => encode =>
+                if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else ()
+              }
+              case (true, false) => { t => encode =>
+                if (!encoder.isEmpty(t)) encode() else ()
+              }
+              case (false, true) => { t => encode =>
+                if (!encoder.isNothing(t)) encode() else ()
+              }
+            }
+          def encodeOrSkip(t: T)(encode: () => Unit): Unit = _encodeOrSkip(t)(encode)
+
+          private[this] val _encodeOrDefault: T => (
+            Either[String, Chunk[(String, Json)]],
+            () => Either[String, Chunk[(String, Json)]]
+          ) => Either[String, Chunk[(String, Json)]] =
+            (withExplicitNulls, withExplicitEmptyCollections) match {
+              case (true, true) => _ => (_, encode) => encode()
+              case (false, false) => { t => (default, encode) =>
+                if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else default
+              }
+              case (true, false) => { t => (default, encode) =>
+                if (!encoder.isEmpty(t)) encode() else default
+              }
+              case (false, true) => { t => (default, encode) =>
+                if (!encoder.isNothing(t)) encode() else default
+              }
+            }
+          def encodeOrDefault(t: T)(
+            encode: () => Either[String, Chunk[(String, Json)]],
+            default: Either[String, Chunk[(String, Json)]]
+          ): Either[String, Chunk[(String, Json)]] =
+            _encodeOrDefault(t)(default, encode)
+        }
+
+        private[this] lazy val fields: Array[Field[Any]] = params.map { p =>
+          val name = p.annotations.collectFirst { case jsonField(name) =>
+            name
+          }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
+          val withExplicitNulls = explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
+          val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+            enabled
+          }.getOrElse(explicitEmptyCollections)
+          new Field(
+            p,
+            name,
+            p.typeclass.asInstanceOf[JsonEncoder[Any]],
+            withExplicitNulls = withExplicitNulls,
+            withExplicitEmptyCollections = withExplicitEmptyCollections
+          )
+        }
+
+        override def isEmpty(a: A): Boolean = fields.forall { field =>
+          val paramValue = field.p.dereference(a)
+          field.encoder.isEmpty(paramValue) || field.encoder.isNothing(paramValue)
         }
 
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = {
@@ -479,20 +579,17 @@ object DeriveJsonEncoder {
           var prevFields = false // whether any fields have been written
           while (idx < fields.length) {
             val field = fields(idx)
-            val p     = field._1.dereference(a)
-            if ({
-              val isNothing = field._3.isNothing(p)
-              !isNothing || field._4
-            }) {
+            val p     = field.p.dereference(a)
+            field.encodeOrSkip(p) { () =>
               // if we have at least one field already, we need a comma
               if (prevFields) {
                 out.write(',')
                 JsonEncoder.pad(indent_, out)
               }
-              JsonEncoder.string.unsafeEncode(field._2, indent_, out)
+              JsonEncoder.string.unsafeEncode(field.name, indent_, out)
               if (indent.isEmpty) out.write(':')
               else out.write(" : ")
-              field._3.unsafeEncode(p, indent_, out)
+              field.encoder.unsafeEncode(p, indent_, out)
               prevFields = true // record that we have at least one field so far
             }
             idx += 1
@@ -502,18 +599,17 @@ object DeriveJsonEncoder {
         }
 
         override final def toJsonAST(a: A): Either[String, Json] =
-          ctx.parameters
-            .foldLeft[Either[String, Chunk[(String, Json)]]](Right(Chunk.empty)) { case (c, param) =>
-              val name = param.annotations.collectFirst { case jsonField(name) =>
-                name
-              }.getOrElse(nameTransform(param.label))
-              val writeNulls = explicitNulls || param.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-              c.flatMap { chunk =>
-                param.typeclass.toJsonAST(param.dereference(a)).map { value =>
-                  if (!writeNulls && value == Json.Null) chunk
-                  else chunk :+ name -> value
-                }
-              }
+          fields
+            .foldLeft[Either[String, Chunk[(String, Json)]]](Right(Chunk.empty)) { case (c, field) =>
+              val param      = field.p
+              val paramValue = field.p.dereference(a).asInstanceOf[param.PType]
+              field.encodeOrDefault(paramValue)(
+                () =>
+                  c.flatMap { chunk =>
+                    param.typeclass.toJsonAST(paramValue).map(value => chunk :+ field.name -> value)
+                  },
+                c
+              )
             }
             .map(Json.Obj.apply)
       }

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -273,31 +273,34 @@ object DeriveJsonDecoder {
           ctx.parameters.map(_.typeclass).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
         private[this] lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
 
-        // private[this] val explicitNulls =
-        //   config.explicitNulls || ctx.annotations.collectFirst { case jsonExplicitNull => () }.isDefined
         private[this] val explicitEmptyCollections =
           ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(config.explicitEmptyCollections)
 
-        private[this] def allowMissingValueDecoder(d: JsonDecoder[_]): Boolean = d match {
-          case d: CollectionJsonDecoder[_] if !explicitEmptyCollections => true
-          // case d: OptionJsonDecoder[_] if !explicitNulls => true
-          case d: OptionJsonDecoder[_] => true
-          case d: MappedJsonDecoder[_] => allowMissingValueDecoder(d.underlying)
-          case d                       => false
-        }
         private[this] val missingValueDecoder =
-          if (!explicitEmptyCollections)
-            (idx: Int, trace: List[JsonError]) => tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
-          else {
-            lazy val missingValueDecoderMap =
-              tcs.map(d => if (allowMissingValueDecoder(d)) Some(d) else None).toIndexedSeq
-            (idx: Int, trace: List[JsonError]) =>
-              missingValueDecoderMap(idx)
-                .map(_.unsafeDecodeMissing(spans(idx) :: trace))
-                .getOrElse(Lexer.error("missing", spans(idx) :: trace))
+          if (explicitEmptyCollections) {
+            lazy val missingValueDecoders = tcs.map { d =>
+              if (allowMissingValueDecoder(d)) d
+              else null
+            }
+            (idx: Int, trace: List[JsonError]) => {
+              val trace_  = spans(idx) :: trace
+              val decoder = missingValueDecoders(idx)
+              if (decoder eq null) Lexer.error("missing", trace_)
+              decoder.unsafeDecodeMissing(trace_)
+            }
+          } else { (idx: Int, trace: List[JsonError]) =>
+            tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
           }
+
+        @tailrec
+        private[this] def allowMissingValueDecoder(d: JsonDecoder[_]): Boolean = d match {
+          case _: OptionJsonDecoder[_]     => true
+          case _: CollectionJsonDecoder[_] => !explicitEmptyCollections
+          case d: MappedJsonDecoder[_]     => allowMissingValueDecoder(d.underlying)
+          case _                           => false
+        }
 
         override def unsafeDecodeMissing(trace: List[JsonError]): A = {
           val ps  = new Array[Any](len)

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -27,8 +27,7 @@ final class jsonExplicitNull extends Annotation
 /**
  * When disabled keys with empty collections will be omitted from the JSON.
  */
-final case class jsonExplicitEmptyCollections(encoding: Boolean = true, decoding: Boolean = true)
-    extends Annotation
+final case class jsonExplicitEmptyCollections(encoding: Boolean = true, decoding: Boolean = true) extends Annotation
 
 /**
  * If used on a sealed class, will determine the name of the field for disambiguating classes.

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -268,7 +268,7 @@ object DeriveJsonDecoder {
         private[this] val len      = names.length
         private[this] val matrix   = new StringMatrix(names, aliases)
         private[this] val spans    = names.map(JsonError.ObjectAccess)
-        private[this] val defaults = ctx.parameters.map(_.evaluateDefault).toArray
+        private[this] val defaults = ctx.parameters.map(_.evaluateDefault.orNull).toArray
         private[this] lazy val tcs =
           ctx.parameters.map(_.typeclass).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
         private[this] lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
@@ -309,7 +309,7 @@ object DeriveJsonDecoder {
             if (ps(idx) == null) {
               val default = defaults(idx)
               ps(idx) =
-                if (default ne None) default.get
+                if (default ne null) default()
                 else missingValueDecoder(idx, trace)
             }
             idx += 1
@@ -336,12 +336,12 @@ object DeriveJsonDecoder {
                 val default = defaults(idx)
                 ps(idx) =
                   if (
-                    (default eq None) || in.nextNonWhitespace() != 'n' && {
+                    (default eq null) || in.nextNonWhitespace() != 'n' && {
                       in.retract()
                       true
                     }
                   ) tcs(idx).unsafeDecode(spans(idx) :: trace, in)
-                  else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default.get()
+                  else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default()
                   else Lexer.error("expected 'null'", spans(idx) :: trace)
               } else if (no_extra) Lexer.error("invalid extra field", trace)
               else Lexer.skipValue(trace, in)
@@ -351,7 +351,7 @@ object DeriveJsonDecoder {
             if (ps(idx) == null) {
               val default = defaults(idx)
               ps(idx) =
-                if (default ne None) default.get()
+                if (default ne null) default()
                 else missingValueDecoder(idx, trace)
             }
             idx += 1
@@ -370,7 +370,7 @@ object DeriveJsonDecoder {
                     if (ps(idx) != null) Lexer.error("duplicate", trace)
                     val default = defaults(idx)
                     ps(idx) =
-                      if ((default ne None) && (value eq Json.Null)) default.get()
+                      if ((default ne null) && (value eq Json.Null)) default()
                       else tcs(idx).unsafeFromJsonAST(spans(idx) :: trace, value)
                   case _ =>
                     if (no_extra) Lexer.error("invalid extra field", trace)
@@ -381,7 +381,7 @@ object DeriveJsonDecoder {
                 if (ps(idx) == null) {
                   val default = defaults(idx)
                   ps(idx) =
-                    if (default ne None) default.get()
+                    if (default ne null) default()
                     else missingValueDecoder(idx, trace)
                 }
                 idx += 1

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -27,7 +27,7 @@ final class jsonExplicitNull extends Annotation
 /**
  * When disabled keys with empty collections will be omitted from the JSON.
  */
-final case class jsonExplicitEmptyCollections(whenEncoding: Boolean = true, whenDecoding: Boolean = true)
+final case class jsonExplicitEmptyCollections(encoding: Boolean = true, decoding: Boolean = true)
     extends Annotation
 
 /**
@@ -276,8 +276,8 @@ object DeriveJsonDecoder {
 
         private[this] val explicitEmptyCollections =
           ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
-            a.whenDecoding
-          }.getOrElse(config.explicitEmptyCollections.whenDecoding)
+            a.decoding
+          }.getOrElse(config.explicitEmptyCollections.decoding)
 
         private[this] val missingValueDecoder =
           if (explicitEmptyCollections) {
@@ -507,8 +507,8 @@ object DeriveJsonEncoder {
           config.explicitNulls || ctx.annotations.exists(_.isInstanceOf[jsonExplicitNull])
         private[this] val explicitEmptyCollections =
           ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
-            a.whenEncoding
-          }.getOrElse(config.explicitEmptyCollections.whenEncoding)
+            a.encoding
+          }.getOrElse(config.explicitEmptyCollections.encoding)
 
         private[this] lazy val fields: Array[FieldEncoder[Any, Param[JsonEncoder, A]]] = params.map { p =>
           val name = p.annotations.collectFirst { case jsonField(name) =>
@@ -516,7 +516,7 @@ object DeriveJsonEncoder {
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
           val withExplicitNulls = explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
           val withExplicitEmptyCollections = p.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
-            a.whenEncoding
+            a.encoding
           }.getOrElse(explicitEmptyCollections)
           new FieldEncoder(
             p,

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -4,7 +4,7 @@ import magnolia1._
 import zio.Chunk
 import zio.json.JsonDecoder.JsonError
 import zio.json.ast.Json
-import zio.json.internal.{ Lexer, RetractReader, StringMatrix, Write }
+import zio.json.internal.{ FieldEncoder, Lexer, RetractReader, StringMatrix, Write }
 
 import scala.annotation._
 import scala.language.experimental.macros
@@ -506,52 +506,7 @@ object DeriveJsonEncoder {
             enabled
           }.getOrElse(config.explicitEmptyCollections)
 
-        private[this] class Field[T](
-          val p: Param[JsonEncoder, A],
-          val name: String,
-          val encoder: JsonEncoder[T],
-          withExplicitNulls: Boolean,
-          withExplicitEmptyCollections: Boolean
-        ) {
-          private[this] val _encodeOrSkip: T => (() => Unit) => Unit =
-            (withExplicitNulls, withExplicitEmptyCollections) match {
-              case (true, true) => _ => encode => encode()
-              case (false, false) => { t => encode =>
-                if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else ()
-              }
-              case (true, false) => { t => encode =>
-                if (!encoder.isEmpty(t)) encode() else ()
-              }
-              case (false, true) => { t => encode =>
-                if (!encoder.isNothing(t)) encode() else ()
-              }
-            }
-          def encodeOrSkip(t: T)(encode: () => Unit): Unit = _encodeOrSkip(t)(encode)
-
-          private[this] val _encodeOrDefault: T => (
-            Either[String, Chunk[(String, Json)]],
-            () => Either[String, Chunk[(String, Json)]]
-          ) => Either[String, Chunk[(String, Json)]] =
-            (withExplicitNulls, withExplicitEmptyCollections) match {
-              case (true, true) => _ => (_, encode) => encode()
-              case (false, false) => { t => (default, encode) =>
-                if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else default
-              }
-              case (true, false) => { t => (default, encode) =>
-                if (!encoder.isEmpty(t)) encode() else default
-              }
-              case (false, true) => { t => (default, encode) =>
-                if (!encoder.isNothing(t)) encode() else default
-              }
-            }
-          def encodeOrDefault(t: T)(
-            encode: () => Either[String, Chunk[(String, Json)]],
-            default: Either[String, Chunk[(String, Json)]]
-          ): Either[String, Chunk[(String, Json)]] =
-            _encodeOrDefault(t)(default, encode)
-        }
-
-        private[this] lazy val fields: Array[Field[Any]] = params.map { p =>
+        private[this] lazy val fields: Array[FieldEncoder[Any, Param[JsonEncoder, A]]] = params.map { p =>
           val name = p.annotations.collectFirst { case jsonField(name) =>
             name
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
@@ -559,7 +514,7 @@ object DeriveJsonEncoder {
           val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(explicitEmptyCollections)
-          new Field(
+          new FieldEncoder(
             p,
             name,
             p.typeclass.asInstanceOf[JsonEncoder[Any]],

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -24,7 +24,7 @@ final class jsonExplicitNull extends Annotation
 /**
  * When disabled keys with empty collections will be omitted from the JSON.
  */
-final case class jsonExplicitEmptyCollection(enabled: Boolean = true) extends Annotation
+final case class jsonExplicitEmptyCollections(enabled: Boolean = true) extends Annotation
 
 /**
  * If used on a sealed class, will determine the name of the field for disambiguating classes.
@@ -273,7 +273,7 @@ object DeriveJsonDecoder {
         // private[this] val explicitNulls =
         //   config.explicitNulls || ctx.annotations.collectFirst { case jsonExplicitNull => () }.isDefined
         private[this] val explicitEmptyCollections =
-          ctx.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+          ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(config.explicitEmptyCollections)
 
@@ -499,7 +499,7 @@ object DeriveJsonEncoder {
         private[this] val explicitNulls =
           config.explicitNulls || ctx.annotations.exists(_.isInstanceOf[jsonExplicitNull])
         private[this] val explicitEmptyCollections =
-          ctx.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+          ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(config.explicitEmptyCollections)
 
@@ -553,7 +553,7 @@ object DeriveJsonEncoder {
             name
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
           val withExplicitNulls = explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-          val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+          val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(explicitEmptyCollections)
           new Field(

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -33,6 +33,11 @@ final case class jsonAliases(alias: String, aliases: String*) extends Annotation
 final class jsonExplicitNull extends Annotation
 
 /**
+ * When disabled keys with empty collections will be omitted from the JSON.
+ */
+final case class jsonExplicitEmptyCollection(enabled: Boolean = true) extends Annotation
+
+/**
  * If used on a sealed class, will determine the name of the field for
  * disambiguating classes.
  *
@@ -209,7 +214,7 @@ final class jsonNoExtraFields extends Annotation
  */
 final class jsonExclude extends Annotation
 
-private class CaseObjectDecoder[Typeclass[*], A](val ctx: CaseClass[Typeclass, A], no_extra: Boolean) extends JsonDecoder[A] {
+private class CaseObjectDecoder[Typeclass[*], A](val ctx: CaseClass[Typeclass, A], no_extra: Boolean) extends CollectionJsonDecoder[A] {
   def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
     if (no_extra) {
       Lexer.char(trace, in, '{')
@@ -217,6 +222,8 @@ private class CaseObjectDecoder[Typeclass[*], A](val ctx: CaseClass[Typeclass, A
     } else Lexer.skipValue(trace, in)
     ctx.rawConstruct(Nil)
   }
+
+  override def unsafeDecodeMissing(trace: List[JsonError]): A = ctx.rawConstruct(Nil)
 
   override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): A =
     json match {
@@ -243,7 +250,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
     if (ctx.params.isEmpty) {
       new CaseObjectDecoder(ctx, no_extra)
     } else {
-      new JsonDecoder[A] {
+      new CollectionJsonDecoder[A] {
         private val (names, aliases): (Array[String], Array[(String, Int)]) = {
           val names = Array.ofDim[String](ctx.params.size)
           val aliasesBuilder = Array.newBuilder[(String, Int)]
@@ -283,6 +290,43 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
           IArray.genericWrapArray(ctx.params.map(_.typeclass)).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
         private lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
 
+        // private[this] val explicitNulls =
+        //   config.explicitNulls || ctx.annotations.collectFirst { case jsonExplicitNull => () }.isDefined
+        private[this] val explicitEmptyCollections =
+          ctx.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+            enabled
+          }.getOrElse(config.explicitEmptyCollections)
+
+        private[this] def allowMissingValueDecoder(d: JsonDecoder[_]): Boolean = d match {
+          case d: CollectionJsonDecoder[_] if !explicitEmptyCollections => true
+          // case d: OptionJsonDecoder[_] if !explicitNulls => true
+          case d: OptionJsonDecoder[_] => true
+          case d: MappedJsonDecoder[_] => allowMissingValueDecoder(d.underlying)
+          case d                       => false
+        }
+
+        private[this] val missingValueDecoder = 
+          if (!explicitEmptyCollections) (idx: Int, trace: List[JsonError]) => tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+          else {
+            lazy val missingValueDecoderMap = tcs.map(d => if (allowMissingValueDecoder(d)) Some(d) else None).toIndexedSeq
+            (idx: Int, trace: List[JsonError]) => missingValueDecoderMap(idx).map(_.unsafeDecodeMissing(spans(idx) :: trace)).getOrElse(Lexer.error("missing", spans(idx) :: trace))
+          }
+
+        override def unsafeDecodeMissing(trace: List[JsonError]): A = {
+          val ps  = new Array[Any](len)
+          var idx = 0
+          while (idx < len) {
+            if (ps(idx) == null) {
+              val default = defaults(idx)
+              ps(idx) =
+                if (default ne None) default.get
+                else missingValueDecoder(idx, trace)
+            }
+            idx += 1
+          }
+          ctx.rawConstruct(new ArraySeq(ps))
+        }
+          
         override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
           Lexer.char(trace, in, '{')
           val ps = new Array[Any](len)
@@ -308,7 +352,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
               val default = defaults(idx)
               ps(idx) =
                 if (default ne None) default.get()
-                else tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+                else missingValueDecoder(idx, trace)
             }
             idx += 1
           }
@@ -337,7 +381,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                   val default = defaults(idx)
                   ps(idx) =
                     if (default ne None) default.get()
-                    else tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+                    else missingValueDecoder(idx, trace)
                 }
                 idx += 1
               }
@@ -466,6 +510,8 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
 
 private lazy val caseObjectEncoder = new JsonEncoder[Any] {
 
+  override def isEmpty(a: Any): Boolean = true
+
   def unsafeEncode(a: Any, indent: Option[Int], out: Write): Unit =
     out.write("{}")
 
@@ -506,19 +552,78 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
             case jsonField(name) => name
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
         }.toArray
+
         private val explicitNulls = config.explicitNulls || ctx.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-        private lazy val fields = params.map {
-          var idx = 0
-          p =>
-            val field = (
-              p, 
-              names(idx), 
-              p.typeclass.asInstanceOf[JsonEncoder[Any]],
-              explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-            )
-            idx += 1
-            field
-        }.toArray
+        private val explicitEmptyCollections = ctx.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+          enabled
+        }.getOrElse(config.explicitEmptyCollections)
+        
+        private[this] class Field[T](
+          val p: CaseClass.Param[JsonEncoder, A],
+          val name: String,
+          val encoder: JsonEncoder[T],
+          withExplicitNulls: Boolean,
+          withExplicitEmptyCollections: Boolean
+        ) {
+          private[this] val _encodeOrSkip: T => (() => Unit) => Unit =
+            (withExplicitNulls, withExplicitEmptyCollections) match {
+              case (true, true) => _ => encode => encode()
+              case (false, false) => { t => encode =>
+                if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else ()
+              }
+              case (true, false) => { t => encode =>
+                if (!encoder.isEmpty(t)) encode() else ()
+              }
+              case (false, true) => { t => encode =>
+                if (!encoder.isNothing(t)) encode() else ()
+              }
+            }
+          def encodeOrSkip(t: T)(encode: () => Unit): Unit = _encodeOrSkip(t)(encode)
+
+          private[this] val _encodeOrDefault: T => (
+            Either[String, Chunk[(String, Json)]],
+            () => Either[String, Chunk[(String, Json)]]
+          ) => Either[String, Chunk[(String, Json)]] =
+            (withExplicitNulls, withExplicitEmptyCollections) match {
+              case (true, true) => _ => (_, encode) => encode()
+              case (false, false) => { t => (default, encode) =>
+                if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else default
+              }
+              case (true, false) => { t => (default, encode) =>
+                if (!encoder.isEmpty(t)) encode() else default
+              }
+              case (false, true) => { t => (default, encode) =>
+                if (!encoder.isNothing(t)) encode() else default
+              }
+            }
+          def encodeOrDefault(t: T)(
+            encode: () => Either[String, Chunk[(String, Json)]],
+            default: Either[String, Chunk[(String, Json)]]
+          ): Either[String, Chunk[(String, Json)]] =
+            _encodeOrDefault(t)(default, encode)
+        }
+
+        private[this] lazy val fields: Array[Field[Any]] = params.map { p =>
+          val name = p.annotations.collectFirst { case jsonField(name) =>
+            name
+          }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
+          val withExplicitNulls = explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
+          val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+            enabled
+          }.getOrElse(explicitEmptyCollections)
+          new Field(
+            p,
+            name,
+            p.typeclass.asInstanceOf[JsonEncoder[Any]],
+            withExplicitNulls = withExplicitNulls,
+            withExplicitEmptyCollections = withExplicitEmptyCollections
+          )
+        }
+
+        override def isEmpty(a: A): Boolean =           fields.forall { field =>
+            val paramValue = field.p.deref(a)
+            field.encoder.isEmpty(paramValue) || field.encoder.isNothing(paramValue)
+          }
 
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = {
           out.write('{')
@@ -529,20 +634,17 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
           var prevFields = false
           while (idx < fields.length) {
             val field = fields(idx)
-            val p     = field._1.deref(a)
-            if ({
-              val isNothing = field._3.isNothing(p)
-              !isNothing || field._4
-            }) {
+            val p     = field.p.deref(a)
+            field.encodeOrSkip(p) { () =>
               // if we have at least one field already, we need a comma
               if (prevFields) {
                 out.write(',')
                 JsonEncoder.pad(indent_, out)
               }
-              JsonEncoder.string.unsafeEncode(field._2, indent_, out)
+              JsonEncoder.string.unsafeEncode(field.name, indent_, out)
               if (indent.isEmpty) out.write(':')
               else out.write(" : ")
-              field._3.unsafeEncode(p, indent_, out)
+              field.encoder.unsafeEncode(p, indent_, out)
               prevFields = true // at least one field so far
             }
             idx += 1
@@ -552,18 +654,17 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
         }
 
         override final def toJsonAST(a: A): Either[String, Json] = {
-          ctx.params
-            .foldLeft[Either[String, Chunk[(String, Json)]]](Right(Chunk.empty)) { case (c, param) =>
-              val name = param.annotations.collectFirst { case jsonField(name) =>
-                name
-              }.getOrElse(nameTransform(param.label))
-              val writeNulls = explicitNulls || param.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-              c.flatMap { chunk =>
-                param.typeclass.toJsonAST(param.deref(a)).map { value =>
-                  if (!writeNulls && value == Json.Null) chunk
-                  else chunk :+ name -> value
-                }
-              }
+          fields
+            .foldLeft[Either[String, Chunk[(String, Json)]]](Right(Chunk.empty)) { case (c, field) =>
+              val param = field.p
+              val paramValue = param.deref(a)
+              field.encodeOrDefault(paramValue)(
+                () =>
+                  c.flatMap { chunk =>
+                    param.typeclass.toJsonAST(paramValue).map(value => chunk :+ field.name -> value)
+                  },
+                c
+              )
             }
             .map(Json.Obj.apply)
         }

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -284,7 +284,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
         private val len = names.length
         private val matrix = new StringMatrix(names, aliases)
         private val spans = names.map(JsonError.ObjectAccess(_))
-        private val defaults = IArray.genericWrapArray(ctx.params.map(_.evaluateDefault)).toArray
+        private val defaults = IArray.genericWrapArray(ctx.params.map(_.evaluateDefault.orNull)).toArray
         private lazy val tcs =
           IArray.genericWrapArray(ctx.params.map(_.typeclass)).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
         private lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
@@ -325,7 +325,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
             if (ps(idx) == null) {
               val default = defaults(idx)
               ps(idx) =
-                if (default ne None) default.get
+                if (default ne null) default()
                 else missingValueDecoder(idx, trace)
             }
             idx += 1
@@ -342,11 +342,11 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
               if (idx != -1) {
                 if (ps(idx) != null) Lexer.error("duplicate", trace)
                 val default = defaults(idx)
-                ps(idx) = if ((default eq None) || in.nextNonWhitespace() != 'n' && {
+                ps(idx) = if ((default eq null) || in.nextNonWhitespace() != 'n' && {
                   in.retract()
                   true
                 }) tcs(idx).unsafeDecode(spans(idx) :: trace, in)
-                else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default.get()
+                else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default()
                 else Lexer.error("expected 'null'", spans(idx) :: trace)
               } else if (no_extra) Lexer.error("invalid extra field", trace)
               else Lexer.skipValue(trace, in)
@@ -357,7 +357,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
             if (ps(idx) == null) {
               val default = defaults(idx)
               ps(idx) =
-                if (default ne None) default.get()
+                if (default ne null) default()
                 else missingValueDecoder(idx, trace)
             }
             idx += 1
@@ -375,7 +375,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                     if (ps(idx) != null) Lexer.error("duplicate", trace)
                     val default = defaults(idx)
                     ps(idx) =
-                      if ((default ne None) && (value eq Json.Null)) default.get()
+                      if ((default ne null) && (value eq Json.Null)) default()
                       else tcs(idx).unsafeFromJsonAST(spans(idx) :: trace, value)
                   case _ =>
                     if (no_extra) Lexer.error("invalid extra field", trace)
@@ -386,7 +386,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                 if (ps(idx) == null) {
                   val default = defaults(idx)
                   ps(idx) =
-                    if (default ne None) default.get()
+                    if (default ne null) default()
                     else missingValueDecoder(idx, trace)
                 }
                 idx += 1

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -34,7 +34,7 @@ final class jsonExplicitNull extends Annotation
 /**
  * When disabled keys with empty collections will be omitted from the JSON.
  */
-final case class jsonExplicitEmptyCollections(enabled: Boolean = true) extends Annotation
+final case class jsonExplicitEmptyCollections(whenEncoding: Boolean = true, whenDecoding: Boolean = true) extends Annotation
 
 /**
  * If used on a sealed class, will determine the name of the field for
@@ -290,9 +290,9 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
         private lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
 
         private[this] val explicitEmptyCollections =
-          ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
-            enabled
-          }.getOrElse(config.explicitEmptyCollections)
+          ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
+            a.whenDecoding
+          }.getOrElse(config.explicitEmptyCollections.whenDecoding)
 
         private[this] val missingValueDecoder =
           if (explicitEmptyCollections) {
@@ -560,17 +560,17 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
         }.toArray
 
         private val explicitNulls = config.explicitNulls || ctx.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-        private val explicitEmptyCollections = ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
-          enabled
-        }.getOrElse(config.explicitEmptyCollections)
+        private val explicitEmptyCollections = ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
+          a.whenEncoding
+        }.getOrElse(config.explicitEmptyCollections.whenEncoding)
 
         private[this] lazy val fields: Array[FieldEncoder[Any, CaseClass.Param[JsonEncoder, A]]] = params.map { p =>
           val name = p.annotations.collectFirst { case jsonField(name) =>
             name
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
           val withExplicitNulls = explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-          val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
-            enabled
+          val withExplicitEmptyCollections = p.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
+            a.whenEncoding
           }.getOrElse(explicitEmptyCollections)
           new FieldEncoder(
             p,

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -1,6 +1,5 @@
 package zio.json
 
-import zio.json.ast.Json
 import scala.annotation.*
 import magnolia1.*
 import scala.deriving.Mirror
@@ -10,7 +9,7 @@ import zio.Chunk
 
 import zio.json.JsonDecoder.JsonError
 import zio.json.ast.Json
-import zio.json.internal.{ Lexer, RetractReader, StringMatrix, Write }
+import zio.json.internal.{ FieldEncoder, Lexer, RetractReader, StringMatrix, Write }
 
 import scala.annotation._
 import scala.collection.mutable
@@ -557,53 +556,8 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
         private val explicitEmptyCollections = ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
           enabled
         }.getOrElse(config.explicitEmptyCollections)
-        
-        private[this] class Field[T](
-          val p: CaseClass.Param[JsonEncoder, A],
-          val name: String,
-          val encoder: JsonEncoder[T],
-          withExplicitNulls: Boolean,
-          withExplicitEmptyCollections: Boolean
-        ) {
-          private[this] val _encodeOrSkip: T => (() => Unit) => Unit =
-            (withExplicitNulls, withExplicitEmptyCollections) match {
-              case (true, true) => _ => encode => encode()
-              case (false, false) => { t => encode =>
-                if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else ()
-              }
-              case (true, false) => { t => encode =>
-                if (!encoder.isEmpty(t)) encode() else ()
-              }
-              case (false, true) => { t => encode =>
-                if (!encoder.isNothing(t)) encode() else ()
-              }
-            }
-          def encodeOrSkip(t: T)(encode: () => Unit): Unit = _encodeOrSkip(t)(encode)
 
-          private[this] val _encodeOrDefault: T => (
-            Either[String, Chunk[(String, Json)]],
-            () => Either[String, Chunk[(String, Json)]]
-          ) => Either[String, Chunk[(String, Json)]] =
-            (withExplicitNulls, withExplicitEmptyCollections) match {
-              case (true, true) => _ => (_, encode) => encode()
-              case (false, false) => { t => (default, encode) =>
-                if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else default
-              }
-              case (true, false) => { t => (default, encode) =>
-                if (!encoder.isEmpty(t)) encode() else default
-              }
-              case (false, true) => { t => (default, encode) =>
-                if (!encoder.isNothing(t)) encode() else default
-              }
-            }
-          def encodeOrDefault(t: T)(
-            encode: () => Either[String, Chunk[(String, Json)]],
-            default: Either[String, Chunk[(String, Json)]]
-          ): Either[String, Chunk[(String, Json)]] =
-            _encodeOrDefault(t)(default, encode)
-        }
-
-        private[this] lazy val fields: Array[Field[Any]] = params.map { p =>
+        private[this] lazy val fields: Array[FieldEncoder[Any, CaseClass.Param[JsonEncoder, A]]] = params.map { p =>
           val name = p.annotations.collectFirst { case jsonField(name) =>
             name
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
@@ -611,7 +565,7 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
           val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(explicitEmptyCollections)
-          new Field(
+          new FieldEncoder(
             p,
             name,
             p.typeclass.asInstanceOf[JsonEncoder[Any]],

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -34,7 +34,7 @@ final class jsonExplicitNull extends Annotation
 /**
  * When disabled keys with empty collections will be omitted from the JSON.
  */
-final case class jsonExplicitEmptyCollections(whenEncoding: Boolean = true, whenDecoding: Boolean = true) extends Annotation
+final case class jsonExplicitEmptyCollections(encoding: Boolean = true, decoding: Boolean = true) extends Annotation
 
 /**
  * If used on a sealed class, will determine the name of the field for
@@ -291,8 +291,8 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
 
         private[this] val explicitEmptyCollections =
           ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
-            a.whenDecoding
-          }.getOrElse(config.explicitEmptyCollections.whenDecoding)
+            a.decoding
+          }.getOrElse(config.explicitEmptyCollections.decoding)
 
         private[this] val missingValueDecoder =
           if (explicitEmptyCollections) {
@@ -561,8 +561,8 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
 
         private val explicitNulls = config.explicitNulls || ctx.annotations.exists(_.isInstanceOf[jsonExplicitNull])
         private val explicitEmptyCollections = ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
-          a.whenEncoding
-        }.getOrElse(config.explicitEmptyCollections.whenEncoding)
+          a.encoding
+        }.getOrElse(config.explicitEmptyCollections.encoding)
 
         private[this] lazy val fields: Array[FieldEncoder[Any, CaseClass.Param[JsonEncoder, A]]] = params.map { p =>
           val name = p.annotations.collectFirst { case jsonField(name) =>
@@ -570,7 +570,7 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
           val withExplicitNulls = explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
           val withExplicitEmptyCollections = p.annotations.collectFirst { case a: jsonExplicitEmptyCollections =>
-            a.whenEncoding
+            a.encoding
           }.getOrElse(explicitEmptyCollections)
           new FieldEncoder(
             p,

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -289,27 +289,34 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
           IArray.genericWrapArray(ctx.params.map(_.typeclass)).toArray.asInstanceOf[Array[JsonDecoder[Any]]]
         private lazy val namesMap = (names.zipWithIndex ++ aliases).toMap
 
-        // private[this] val explicitNulls =
-        //   config.explicitNulls || ctx.annotations.collectFirst { case jsonExplicitNull => () }.isDefined
         private[this] val explicitEmptyCollections =
           ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(config.explicitEmptyCollections)
 
-        private[this] def allowMissingValueDecoder(d: JsonDecoder[_]): Boolean = d match {
-          case d: CollectionJsonDecoder[_] if !explicitEmptyCollections => true
-          // case d: OptionJsonDecoder[_] if !explicitNulls => true
-          case d: OptionJsonDecoder[_] => true
-          case d: MappedJsonDecoder[_] => allowMissingValueDecoder(d.underlying)
-          case d                       => false
-        }
-
-        private[this] val missingValueDecoder = 
-          if (!explicitEmptyCollections) (idx: Int, trace: List[JsonError]) => tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
-          else {
-            lazy val missingValueDecoderMap = tcs.map(d => if (allowMissingValueDecoder(d)) Some(d) else None).toIndexedSeq
-            (idx: Int, trace: List[JsonError]) => missingValueDecoderMap(idx).map(_.unsafeDecodeMissing(spans(idx) :: trace)).getOrElse(Lexer.error("missing", spans(idx) :: trace))
+        private[this] val missingValueDecoder =
+          if (explicitEmptyCollections) {
+            lazy val missingValueDecoders = tcs.map { d =>
+              if (allowMissingValueDecoder(d)) d
+              else null
+            }
+            (idx: Int, trace: List[JsonError]) => {
+              val trace_ = spans(idx) :: trace
+              val decoder = missingValueDecoders(idx)
+              if (decoder eq null) Lexer.error("missing", trace_)
+              decoder.unsafeDecodeMissing(trace_)
+            }
+          } else {
+            (idx: Int, trace: List[JsonError]) => tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
           }
+
+        @tailrec
+        private[this] def allowMissingValueDecoder(d: JsonDecoder[_]): Boolean = d match {
+          case _: OptionJsonDecoder[_] => true
+          case _: CollectionJsonDecoder[_] => !explicitEmptyCollections
+          case d: MappedJsonDecoder[_] => allowMissingValueDecoder(d.underlying)
+          case _                       => false
+        }
 
         override def unsafeDecodeMissing(trace: List[JsonError]): A = {
           val ps  = new Array[Any](len)

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -35,7 +35,7 @@ final class jsonExplicitNull extends Annotation
 /**
  * When disabled keys with empty collections will be omitted from the JSON.
  */
-final case class jsonExplicitEmptyCollection(enabled: Boolean = true) extends Annotation
+final case class jsonExplicitEmptyCollections(enabled: Boolean = true) extends Annotation
 
 /**
  * If used on a sealed class, will determine the name of the field for
@@ -293,7 +293,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
         // private[this] val explicitNulls =
         //   config.explicitNulls || ctx.annotations.collectFirst { case jsonExplicitNull => () }.isDefined
         private[this] val explicitEmptyCollections =
-          ctx.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+          ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(config.explicitEmptyCollections)
 
@@ -554,7 +554,7 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
         }.toArray
 
         private val explicitNulls = config.explicitNulls || ctx.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-        private val explicitEmptyCollections = ctx.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+        private val explicitEmptyCollections = ctx.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
           enabled
         }.getOrElse(config.explicitEmptyCollections)
         
@@ -608,7 +608,7 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
             name
           }.getOrElse(if (transformNames) nameTransform(p.label) else p.label)
           val withExplicitNulls = explicitNulls || p.annotations.exists(_.isInstanceOf[jsonExplicitNull])
-          val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollection(enabled) =>
+          val withExplicitEmptyCollections = p.annotations.collectFirst { case jsonExplicitEmptyCollections(enabled) =>
             enabled
           }.getOrElse(explicitEmptyCollections)
           new Field(

--- a/zio-json/shared/src/main/scala/zio/json/JsonCodecConfiguration.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonCodecConfiguration.scala
@@ -7,7 +7,7 @@ import zio.json.JsonCodecConfiguration.SumTypeHandling.WrapperWithClassNameField
  * When disabled for decoding, keys with empty collections will be omitted from the JSON. When disabled for encoding,
  * missing keys will default to empty collections.
  */
-case class ExplicitEmptyCollections(whenEncoding: Boolean = true, whenDecoding: Boolean = true)
+case class ExplicitEmptyCollections(encoding: Boolean = true, decoding: Boolean = true)
 
 /**
  * Implicit codec derivation configuration.

--- a/zio-json/shared/src/main/scala/zio/json/JsonCodecConfiguration.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonCodecConfiguration.scala
@@ -4,6 +4,12 @@ import zio.json.JsonCodecConfiguration.SumTypeHandling
 import zio.json.JsonCodecConfiguration.SumTypeHandling.WrapperWithClassNameField
 
 /**
+ * When disabled for decoding, keys with empty collections will be omitted from the JSON. When disabled for encoding,
+ * missing keys will default to empty collections.
+ */
+case class ExplicitEmptyCollections(whenEncoding: Boolean = true, whenDecoding: Boolean = true)
+
+/**
  * Implicit codec derivation configuration.
  *
  * @param sumTypeHandling
@@ -21,7 +27,7 @@ final case class JsonCodecConfiguration(
   allowExtraFields: Boolean = true,
   sumTypeMapping: JsonMemberFormat = IdentityFormat,
   explicitNulls: Boolean = false,
-  explicitEmptyCollections: Boolean = true
+  explicitEmptyCollections: ExplicitEmptyCollections = ExplicitEmptyCollections()
 ) {
   def this(
     sumTypeHandling: SumTypeHandling,
@@ -35,7 +41,7 @@ final case class JsonCodecConfiguration(
     allowExtraFields,
     sumTypeMapping,
     explicitNulls,
-    true
+    ExplicitEmptyCollections()
   )
 
   def copy(
@@ -44,7 +50,7 @@ final case class JsonCodecConfiguration(
     allowExtraFields: Boolean = true,
     sumTypeMapping: JsonMemberFormat = IdentityFormat.asInstanceOf[JsonMemberFormat],
     explicitNulls: Boolean = false,
-    explicitEmptyCollections: Boolean = true
+    explicitEmptyCollections: ExplicitEmptyCollections = ExplicitEmptyCollections()
   ) = new JsonCodecConfiguration(
     sumTypeHandling,
     fieldNameMapping,
@@ -66,7 +72,7 @@ final case class JsonCodecConfiguration(
     allowExtraFields,
     sumTypeMapping,
     explicitNulls,
-    true
+    ExplicitEmptyCollections()
   )
 }
 
@@ -83,7 +89,7 @@ object JsonCodecConfiguration {
     allowExtraFields,
     sumTypeMapping,
     explicitNulls,
-    true
+    ExplicitEmptyCollections()
   )
 
   implicit val default: JsonCodecConfiguration = JsonCodecConfiguration()

--- a/zio-json/shared/src/main/scala/zio/json/JsonCodecConfiguration.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonCodecConfiguration.scala
@@ -14,33 +14,77 @@ import zio.json.JsonCodecConfiguration.SumTypeHandling.WrapperWithClassNameField
  *   see [[jsonNoExtraFields]]
  * @param sumTypeMapping
  *   see [[jsonHintNames]]
- * @param explicitNulls
- *   see [[jsonExplicitNull]]
  */
 final case class JsonCodecConfiguration(
   sumTypeHandling: SumTypeHandling = WrapperWithClassNameField,
   fieldNameMapping: JsonMemberFormat = IdentityFormat,
   allowExtraFields: Boolean = true,
   sumTypeMapping: JsonMemberFormat = IdentityFormat,
-  explicitNulls: Boolean = false
+  explicitNulls: Boolean = false,
+  explicitEmptyCollections: Boolean = true
 ) {
+  def this(
+    sumTypeHandling: SumTypeHandling,
+    fieldNameMapping: JsonMemberFormat,
+    allowExtraFields: Boolean,
+    sumTypeMapping: JsonMemberFormat,
+    explicitNulls: Boolean
+  ) = this(
+    sumTypeHandling,
+    fieldNameMapping,
+    allowExtraFields,
+    sumTypeMapping,
+    explicitNulls,
+    true
+  )
 
   def copy(
     sumTypeHandling: SumTypeHandling = WrapperWithClassNameField.asInstanceOf[SumTypeHandling],
     fieldNameMapping: JsonMemberFormat = IdentityFormat.asInstanceOf[JsonMemberFormat],
     allowExtraFields: Boolean = true,
     sumTypeMapping: JsonMemberFormat = IdentityFormat.asInstanceOf[JsonMemberFormat],
-    explicitNulls: Boolean = false
+    explicitNulls: Boolean = false,
+    explicitEmptyCollections: Boolean = true
   ) = new JsonCodecConfiguration(
     sumTypeHandling,
     fieldNameMapping,
     allowExtraFields,
     sumTypeMapping,
-    explicitNulls
+    explicitNulls,
+    explicitEmptyCollections
+  )
+
+  def copy(
+    sumTypeHandling: SumTypeHandling,
+    fieldNameMapping: JsonMemberFormat,
+    allowExtraFields: Boolean,
+    sumTypeMapping: JsonMemberFormat,
+    explicitNulls: Boolean
+  ) = new JsonCodecConfiguration(
+    sumTypeHandling,
+    fieldNameMapping,
+    allowExtraFields,
+    sumTypeMapping,
+    explicitNulls,
+    true
   )
 }
 
 object JsonCodecConfiguration {
+  def apply(
+    sumTypeHandling: SumTypeHandling,
+    fieldNameMapping: JsonMemberFormat,
+    allowExtraFields: Boolean,
+    sumTypeMapping: JsonMemberFormat,
+    explicitNulls: Boolean
+  ) = new JsonCodecConfiguration(
+    sumTypeHandling,
+    fieldNameMapping,
+    allowExtraFields,
+    sumTypeMapping,
+    explicitNulls,
+    true
+  )
 
   implicit val default: JsonCodecConfiguration = JsonCodecConfiguration()
 

--- a/zio-json/shared/src/main/scala/zio/json/JsonCodecConfiguration.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonCodecConfiguration.scala
@@ -72,7 +72,7 @@ final case class JsonCodecConfiguration(
     allowExtraFields,
     sumTypeMapping,
     explicitNulls,
-    ExplicitEmptyCollections()
+    this.explicitEmptyCollections
   )
 }
 

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -135,7 +135,8 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
    * Returns a new codec whose decoded values will be mapped by the specified function.
    */
   final def map[B](f: A => B): JsonDecoder[B] =
-    new JsonDecoder[B] {
+    new MappedJsonDecoder[B] {
+      private[json] def underlying: JsonDecoder[A] = self
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): B =
         f(self.unsafeDecode(trace, in))
@@ -353,7 +354,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
   // use a newtype wrapper.
 
   implicit def option[A](implicit A: JsonDecoder[A]): JsonDecoder[Option[A]] =
-    new JsonDecoder[Option[A]] { self =>
+    new OptionJsonDecoder[Option[A]] { self =>
       override def unsafeDecodeMissing(trace: List[JsonError]): Option[A] = None
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Option[A] =
@@ -468,131 +469,176 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     }
 }
 
+private[json] trait CollectionJsonDecoder[A] extends JsonDecoder[A]
+private[json] trait OptionJsonDecoder[A]     extends JsonDecoder[A]
+private[json] trait MappedJsonDecoder[A] extends JsonDecoder[A] {
+  private[json] def underlying: JsonDecoder[_]
+}
+
 private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
   this: JsonDecoder.type =>
 
-  implicit def array[A: JsonDecoder: reflect.ClassTag]: JsonDecoder[Array[A]] = new JsonDecoder[Array[A]] {
+  implicit def array[A: JsonDecoder: reflect.ClassTag]: JsonDecoder[Array[A]] =
+    new CollectionJsonDecoder[Array[A]] {
 
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): Array[A] =
-      builder(trace, in, Array.newBuilder[A])
-  }
+      override def unsafeDecodeMissing(trace: List[JsonError]): Array[A] = Array.empty
 
-  implicit def seq[A: JsonDecoder]: JsonDecoder[Seq[A]] = new JsonDecoder[Seq[A]] {
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): Array[A] =
+        builder(trace, in, Array.newBuilder[A])
+    }
 
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): Seq[A] =
-      builder(trace, in, immutable.Seq.newBuilder[A])
-  }
+  implicit def seq[A: JsonDecoder]: JsonDecoder[Seq[A]] =
+    new CollectionJsonDecoder[Seq[A]] {
 
-  implicit def chunk[A: JsonDecoder]: JsonDecoder[Chunk[A]] = new JsonDecoder[Chunk[A]] {
-    private[this] val decoder = JsonDecoder[A]
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): Chunk[A] =
-      builder(trace, in, zio.ChunkBuilder.make[A]())
+      override def unsafeDecodeMissing(trace: List[JsonError]): Seq[A] =
+        Seq.empty
 
-    override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): Chunk[A] =
-      json match {
-        case Json.Arr(elements) =>
-          elements.map {
-            var i = 0
-            json =>
-              val span = JsonError.ArrayAccess(i)
-              i += 1
-              decoder.unsafeFromJsonAST(span :: trace, json)
-          }
-        case _ => Lexer.error("Not an array", trace)
-      }
-  }
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): Seq[A] =
+        builder(trace, in, immutable.Seq.newBuilder[A])
+    }
+
+  implicit def chunk[A: JsonDecoder]: JsonDecoder[Chunk[A]] =
+    new CollectionJsonDecoder[Chunk[A]] {
+      private[this] val decoder = JsonDecoder[A]
+
+      override def unsafeDecodeMissing(trace: List[JsonError]): Chunk[A] = Chunk.empty
+
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): Chunk[A] =
+        builder(trace, in, zio.ChunkBuilder.make[A]())
+
+      override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): Chunk[A] =
+        json match {
+          case Json.Arr(elements) =>
+            elements.map {
+              var i = 0
+              json =>
+                val span = JsonError.ArrayAccess(i)
+                i += 1
+                decoder.unsafeFromJsonAST(span :: trace, json)
+            }
+          case _ => Lexer.error("Not an array", trace)
+        }
+    }
 
   implicit def nonEmptyChunk[A: JsonDecoder]: JsonDecoder[NonEmptyChunk[A]] =
     chunk[A].mapOrFail(NonEmptyChunk.fromChunk(_).toRight("Chunk was empty"))
 
   implicit def indexedSeq[A: JsonDecoder]: JsonDecoder[IndexedSeq[A]] =
-    new JsonDecoder[IndexedSeq[A]] {
+    new CollectionJsonDecoder[IndexedSeq[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): IndexedSeq[A] = IndexedSeq.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): IndexedSeq[A] =
         builder(trace, in, IndexedSeq.newBuilder[A])
     }
 
   implicit def linearSeq[A: JsonDecoder]: JsonDecoder[immutable.LinearSeq[A]] =
-    new JsonDecoder[immutable.LinearSeq[A]] {
+    new CollectionJsonDecoder[immutable.LinearSeq[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.LinearSeq[A] =
+        immutable.LinearSeq.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): LinearSeq[A] =
         builder(trace, in, immutable.LinearSeq.newBuilder[A])
     }
 
-  implicit def listSet[A: JsonDecoder]: JsonDecoder[immutable.ListSet[A]] = new JsonDecoder[immutable.ListSet[A]] {
+  implicit def listSet[A: JsonDecoder]: JsonDecoder[immutable.ListSet[A]] =
+    new CollectionJsonDecoder[immutable.ListSet[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.ListSet[A] =
+        immutable.ListSet.empty
 
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): ListSet[A] =
-      builder(trace, in, immutable.ListSet.newBuilder[A])
-  }
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): ListSet[A] =
+        builder(trace, in, immutable.ListSet.newBuilder[A])
+    }
 
   implicit def treeSet[A: JsonDecoder: Ordering]: JsonDecoder[immutable.TreeSet[A]] =
-    new JsonDecoder[immutable.TreeSet[A]] {
+    new CollectionJsonDecoder[immutable.TreeSet[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.TreeSet[A] =
+        immutable.TreeSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): TreeSet[A] =
         builder(trace, in, immutable.TreeSet.newBuilder[A])
     }
 
-  implicit def list[A: JsonDecoder]: JsonDecoder[List[A]] = new JsonDecoder[List[A]] {
+  implicit def list[A: JsonDecoder]: JsonDecoder[List[A]] =
+    new CollectionJsonDecoder[List[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): List[A] = List.empty
 
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): List[A] =
-      builder(trace, in, new mutable.ListBuffer[A])
-  }
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): List[A] =
+        builder(trace, in, new mutable.ListBuffer[A])
+    }
 
-  implicit def vector[A: JsonDecoder]: JsonDecoder[Vector[A]] = new JsonDecoder[Vector[A]] {
+  implicit def vector[A: JsonDecoder]: JsonDecoder[Vector[A]] =
+    new CollectionJsonDecoder[Vector[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): Vector[A] = Vector.empty
 
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): Vector[A] =
-      builder(trace, in, immutable.Vector.newBuilder[A])
-  }
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): Vector[A] =
+        builder(trace, in, immutable.Vector.newBuilder[A])
+    }
 
-  implicit def set[A: JsonDecoder]: JsonDecoder[Set[A]] = new JsonDecoder[Set[A]] {
+  implicit def set[A: JsonDecoder]: JsonDecoder[Set[A]] =
+    new CollectionJsonDecoder[Set[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): Set[A] = Set.empty
 
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): Set[A] =
-      builder(trace, in, Set.newBuilder[A])
-  }
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): Set[A] =
+        builder(trace, in, Set.newBuilder[A])
+    }
 
-  implicit def hashSet[A: JsonDecoder]: JsonDecoder[immutable.HashSet[A]] = new JsonDecoder[immutable.HashSet[A]] {
+  implicit def hashSet[A: JsonDecoder]: JsonDecoder[immutable.HashSet[A]] =
+    new CollectionJsonDecoder[immutable.HashSet[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.HashSet[A] =
+        immutable.HashSet.empty
 
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.HashSet[A] =
-      builder(trace, in, immutable.HashSet.newBuilder[A])
-  }
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.HashSet[A] =
+        builder(trace, in, immutable.HashSet.newBuilder[A])
+    }
 
   implicit def map[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[Map[K, V]] =
-    new JsonDecoder[Map[K, V]] {
+    new CollectionJsonDecoder[Map[K, V]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): Map[K, V] = Map.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Map[K, V] =
         keyValueBuilder(trace, in, Map.newBuilder[K, V])
     }
 
   implicit def hashMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[immutable.HashMap[K, V]] =
-    new JsonDecoder[immutable.HashMap[K, V]] {
+    new CollectionJsonDecoder[immutable.HashMap[K, V]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.HashMap[K, V] =
+        immutable.HashMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.HashMap[K, V] =
         keyValueBuilder(trace, in, immutable.HashMap.newBuilder[K, V])
     }
 
   implicit def mutableMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[mutable.Map[K, V]] =
-    new JsonDecoder[mutable.Map[K, V]] {
+    new CollectionJsonDecoder[mutable.Map[K, V]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): mutable.Map[K, V] =
+        mutable.Map.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): mutable.Map[K, V] =
         keyValueBuilder(trace, in, mutable.Map.newBuilder[K, V])
     }
 
   implicit def sortedSet[A: Ordering: JsonDecoder]: JsonDecoder[immutable.SortedSet[A]] =
-    new JsonDecoder[immutable.SortedSet[A]] {
+    new CollectionJsonDecoder[immutable.SortedSet[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.SortedSet[A] =
+        immutable.SortedSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.SortedSet[A] =
         builder(trace, in, immutable.SortedSet.newBuilder[A])
     }
 
   implicit def sortedMap[K: JsonFieldDecoder: Ordering, V: JsonDecoder]: JsonDecoder[collection.SortedMap[K, V]] =
-    new JsonDecoder[collection.SortedMap[K, V]] {
+    new CollectionJsonDecoder[collection.SortedMap[K, V]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): collection.SortedMap[K, V] =
+        collection.SortedMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): collection.SortedMap[K, V] =
         keyValueBuilder(trace, in, collection.SortedMap.newBuilder[K, V])
     }
 
   implicit def listMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[immutable.ListMap[K, V]] =
-    new JsonDecoder[immutable.ListMap[K, V]] {
+    new CollectionJsonDecoder[immutable.ListMap[K, V]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.ListMap[K, V] =
+        immutable.ListMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.ListMap[K, V] =
         keyValueBuilder(trace, in, immutable.ListMap.newBuilder[K, V])
@@ -613,18 +659,21 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 private[json] trait DecoderLowPriority2 extends DecoderLowPriority3 {
   this: JsonDecoder.type =>
 
-  implicit def iterable[A: JsonDecoder]: JsonDecoder[Iterable[A]] = new JsonDecoder[Iterable[A]] {
+  implicit def iterable[A: JsonDecoder]: JsonDecoder[Iterable[A]] =
+    new CollectionJsonDecoder[Iterable[A]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): Iterable[A] = Iterable.empty
 
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): Iterable[A] =
-      builder(trace, in, immutable.Iterable.newBuilder[A])
-  }
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): Iterable[A] =
+        builder(trace, in, immutable.Iterable.newBuilder[A])
+    }
 
   // not implicit because this overlaps with decoders for lists of tuples
   def keyValueChunk[K, A](implicit
     K: JsonFieldDecoder[K],
     A: JsonDecoder[A]
   ): JsonDecoder[Chunk[(K, A)]] =
-    new JsonDecoder[Chunk[(K, A)]] {
+    new CollectionJsonDecoder[Chunk[(K, A)]] {
+      override def unsafeDecodeMissing(trace: List[JsonError]): Chunk[(K, A)] = Chunk.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Chunk[(K, A)] =
         keyValueBuilder[K, A, ({ type lambda[X, Y] = Chunk[(X, Y)] })#lambda](

--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -39,6 +39,8 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
 
     override def isNothing(b: B): Boolean = self.isNothing(f(b))
 
+    override def isEmpty(b: B): Boolean = self.isEmpty(f(b))
+
     override final def toJsonAST(b: B): Either[String, Json] =
       self.toJsonAST(f(b))
   }
@@ -77,6 +79,11 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
    * This default may be overridden when this value may be missing within a JSON object and still be encoded.
    */
   def isNothing(a: A): Boolean = false
+
+  /**
+   * This default may be overridden when this value may be empty within a JSON object and still be encoded.
+   */
+  def isEmpty(a: A): Boolean = false
 
   /**
    * Returns this encoder but narrowed to the its given sub-type
@@ -202,6 +209,8 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
 
       override def isNothing(a: A): Boolean = encoder.isNothing(a)
 
+      override def isEmpty(a: A): Boolean = encoder.isEmpty(a)
+
       override def toJsonAST(a: A): Either[String, Json] = encoder.toJsonAST(a)
     }
 
@@ -311,8 +320,14 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
 private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
   this: JsonEncoder.type =>
 
-  implicit def array[A](implicit A: JsonEncoder[A], classTag: ClassTag[A]): JsonEncoder[Array[A]] =
+  implicit def array[A](implicit
+    A: JsonEncoder[A],
+    classTag: ClassTag[A]
+  ): JsonEncoder[Array[A]] =
     new JsonEncoder[Array[A]] {
+
+      override def isEmpty(as: Array[A]): Boolean = as.isEmpty
+
       def unsafeEncode(as: Array[A], indent: Option[Int], out: Write): Unit =
         if (as.isEmpty) out.write("[]")
         else {
@@ -374,9 +389,11 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
 
   implicit def vector[A: JsonEncoder]: JsonEncoder[Vector[A]] = iterable[A, Vector]
 
-  implicit def set[A: JsonEncoder]: JsonEncoder[Set[A]] = iterable[A, Set]
+  implicit def set[A: JsonEncoder]: JsonEncoder[Set[A]] =
+    iterable[A, Set]
 
-  implicit def hashSet[A: JsonEncoder]: JsonEncoder[immutable.HashSet[A]] = iterable[A, immutable.HashSet]
+  implicit def hashSet[A: JsonEncoder]: JsonEncoder[immutable.HashSet[A]] =
+    iterable[A, immutable.HashSet]
 
   implicit def sortedSet[A: Ordering: JsonEncoder]: JsonEncoder[immutable.SortedSet[A]] =
     iterable[A, immutable.SortedSet]
@@ -400,8 +417,13 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
 private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
   this: JsonEncoder.type =>
 
-  implicit def iterable[A, T[X] <: Iterable[X]](implicit A: JsonEncoder[A]): JsonEncoder[T[A]] =
+  implicit def iterable[A, T[X] <: Iterable[X]](implicit
+    A: JsonEncoder[A]
+  ): JsonEncoder[T[A]] =
     new JsonEncoder[T[A]] {
+
+      override def isEmpty(as: T[A]): Boolean = as.isEmpty
+
       def unsafeEncode(as: T[A], indent: Option[Int], out: Write): Unit =
         if (as.isEmpty) out.write("[]")
         else {
@@ -449,6 +471,9 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
     K: JsonFieldEncoder[K],
     A: JsonEncoder[A]
   ): JsonEncoder[T[K, A]] = new JsonEncoder[T[K, A]] {
+
+    override def isEmpty(a: T[K, A]): Boolean = a.isEmpty
+
     def unsafeEncode(kvs: T[K, A], indent: Option[Int], out: Write): Unit =
       if (kvs.isEmpty) out.write("{}")
       else {

--- a/zio-json/shared/src/main/scala/zio/json/internal/FieldEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/FieldEncoder.scala
@@ -1,0 +1,50 @@
+package zio.json
+package internal
+
+import zio.Chunk
+import zio.json.ast.Json
+
+private[json] class FieldEncoder[T, P](
+  val p: P,
+  val name: String,
+  val encoder: JsonEncoder[T],
+  withExplicitNulls: Boolean,
+  withExplicitEmptyCollections: Boolean
+) {
+  private[this] val _encodeOrSkip: T => (() => Unit) => Unit =
+    (withExplicitNulls, withExplicitEmptyCollections) match {
+      case (true, true) => _ => encode => encode()
+      case (false, false) => { t => encode =>
+        if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else ()
+      }
+      case (true, false) => { t => encode =>
+        if (!encoder.isEmpty(t)) encode() else ()
+      }
+      case (false, true) => { t => encode =>
+        if (!encoder.isNothing(t)) encode() else ()
+      }
+    }
+  def encodeOrSkip(t: T)(encode: () => Unit): Unit = _encodeOrSkip(t)(encode)
+
+  private[this] val _encodeOrDefault: T => (
+    Either[String, Chunk[(String, Json)]],
+    () => Either[String, Chunk[(String, Json)]]
+  ) => Either[String, Chunk[(String, Json)]] =
+    (withExplicitNulls, withExplicitEmptyCollections) match {
+      case (true, true) => _ => (_, encode) => encode()
+      case (false, false) => { t => (default, encode) =>
+        if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else default
+      }
+      case (true, false) => { t => (default, encode) =>
+        if (!encoder.isEmpty(t)) encode() else default
+      }
+      case (false, true) => { t => (default, encode) =>
+        if (!encoder.isNothing(t)) encode() else default
+      }
+    }
+  def encodeOrDefault(t: T)(
+    encode: () => Either[String, Chunk[(String, Json)]],
+    default: Either[String, Chunk[(String, Json)]]
+  ): Either[String, Chunk[(String, Json)]] =
+    _encodeOrDefault(t)(default, encode)
+}

--- a/zio-json/shared/src/main/scala/zio/json/internal/FieldEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/FieldEncoder.scala
@@ -12,17 +12,14 @@ private[json] class FieldEncoder[T, P](
   withExplicitEmptyCollections: Boolean
 ) {
   private[this] val _encodeOrSkip: T => (() => Unit) => Unit =
-    (withExplicitNulls, withExplicitEmptyCollections) match {
-      case (true, true) => _ => encode => encode()
-      case (false, false) => { t => encode =>
-        if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else ()
-      }
-      case (true, false) => { t => encode =>
-        if (!encoder.isEmpty(t)) encode() else ()
-      }
-      case (false, true) => { t => encode =>
-        if (!encoder.isNothing(t)) encode() else ()
-      }
+    if (withExplicitNulls && withExplicitEmptyCollections) { _ => encode =>
+      encode()
+    } else if (withExplicitNulls) { t => encode =>
+      if (!encoder.isEmpty(t)) encode() else ()
+    } else if (withExplicitEmptyCollections) { t => encode =>
+      if (!encoder.isNothing(t)) encode() else ()
+    } else { t => encode =>
+      if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else ()
     }
   def encodeOrSkip(t: T)(encode: () => Unit): Unit = _encodeOrSkip(t)(encode)
 
@@ -30,17 +27,14 @@ private[json] class FieldEncoder[T, P](
     Either[String, Chunk[(String, Json)]],
     () => Either[String, Chunk[(String, Json)]]
   ) => Either[String, Chunk[(String, Json)]] =
-    (withExplicitNulls, withExplicitEmptyCollections) match {
-      case (true, true) => _ => (_, encode) => encode()
-      case (false, false) => { t => (default, encode) =>
-        if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else default
-      }
-      case (true, false) => { t => (default, encode) =>
-        if (!encoder.isEmpty(t)) encode() else default
-      }
-      case (false, true) => { t => (default, encode) =>
-        if (!encoder.isNothing(t)) encode() else default
-      }
+    if (withExplicitNulls && withExplicitEmptyCollections) { _ => (_, encode) =>
+      encode()
+    } else if (withExplicitNulls) { t => (default, encode) =>
+      if (!encoder.isEmpty(t)) encode() else default
+    } else if (withExplicitEmptyCollections) { t => (default, encode) =>
+      if (!encoder.isNothing(t)) encode() else default
+    } else { t => (default, encode) =>
+      if (!encoder.isEmpty(t) && !encoder.isNothing(t)) encode() else default
     }
   def encodeOrDefault(t: T)(
     encode: () => Either[String, Chunk[(String, Json)]],

--- a/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
@@ -95,11 +95,10 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
         case class EmptySeq(a: Seq[Int])
 
         val expectedStr = """{}"""
-        val expectedObj = EmptySeq(Seq.empty)
 
         implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
-        assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        assertTrue(EmptySeq(Seq.empty).toJson == expectedStr)
       }
     ),
     suite("annotations overrides AST")(
@@ -163,47 +162,47 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
         @jsonExplicitEmptyCollections(false)
         case class EmptySeq(a: Seq[Int])
 
-        val jsonAST     = Json.Obj()
-        val expectedObj = EmptySeq(Seq.empty)
+        val jsonAST = Json.Obj()
 
         implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
-        assertTrue(jsonAST.as[EmptySeq].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
+        assertTrue(EmptySeq(Seq.empty).toJsonAST == Right(jsonAST))
       }
     ),
     suite("explicit empty collections")(
-      suite("should write empty collections if set to true")(
+      suite("should fill in missing empty collections and write empty collections")(
         test("for an array") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyArray(a: Array[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyArray(Array.empty)
 
           implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyArray].toOption.exists(_.a.isEmpty), expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptySeq(a: Seq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySeq(Seq.empty)
 
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptySeq].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyChunk(a: Chunk[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyChunk(Chunk.empty)
 
           implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyChunk].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for an indexed seq") {
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyIndexedSeq(a: IndexedSeq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
@@ -211,12 +210,12 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptyIndexedSeq].toOption.get == expectedObj,
+            """{}""".fromJson[EmptyIndexedSeq].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
         test("for a linear seq") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
@@ -224,72 +223,90 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptyLinearSeq].toOption.get == expectedObj,
+            """{}""".fromJson[EmptyLinearSeq].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
         test("for a list set") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyListSet(a: immutable.ListSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
 
           implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptyListSet].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         },
         test("for a tree set") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyTreeSet(a: immutable.TreeSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
 
           implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptyTreeSet].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         },
         test("for a list") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyList(a: List[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyList(List.empty)
 
           implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyList].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptyList].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         },
         test("for a vector") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyVector(a: Vector[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyVector(Vector.empty)
 
           implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptyVector].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         },
         test("for a set") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptySet(a: Set[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySet(Set.empty)
 
           implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptySet].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         },
         test("for a hash set") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyHashSet(a: immutable.HashSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
 
           implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptyHashSet].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         },
         test("for a sorted set") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptySortedSet(a: immutable.SortedSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
@@ -297,32 +314,38 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptySortedSet].toOption.get == expectedObj,
+            """{}""".fromJson[EmptySortedSet].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
         test("for a map") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyMap(a: Map[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyMap(Map.empty)
 
           implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptyMap].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         },
         test("for a hash map") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyHashMap(a: immutable.HashMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
 
           implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptyHashMap].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         },
         test("for a mutable map") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyMutableMap(a: mutable.Map[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
@@ -330,12 +353,12 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptyMutableMap].toOption.get == expectedObj,
+            """{}""".fromJson[EmptyMutableMap].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
         test("for a sorted map") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptySortedMap(a: collection.SortedMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
@@ -343,22 +366,25 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptySortedMap].toOption.get == expectedObj,
+            """{}""".fromJson[EmptySortedMap].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
         test("for a list map") {
-          @jsonExplicitEmptyCollections(true)
+          @jsonExplicitEmptyCollections(true, whenDecoding = false)
           case class EmptyListMap(a: immutable.ListMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyListMap(immutable.ListMap.empty)
 
           implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(
+            """{}""".fromJson[EmptyListMap].toOption.contains(expectedObj),
+            expectedObj.toJson == expectedStr
+          )
         }
       ),
-      suite("should not write empty collections if set to false")(
+      suite("should not write empty collections and fail missing empty collections")(
         test("for an array") {
           @jsonExplicitEmptyCollections(false)
           case class EmptyArray(a: Array[Int])
@@ -367,7 +393,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyArray].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
           @jsonExplicitEmptyCollections(false)
@@ -377,7 +403,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptySeq].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
           @jsonExplicitEmptyCollections(false)
@@ -387,7 +413,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyChunk].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for an indexed seq") {
           @jsonExplicitEmptyCollections(false)
@@ -397,10 +423,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyIndexedSeq].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyIndexedSeq].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a linear seq") {
           @jsonExplicitEmptyCollections(false)
@@ -410,10 +433,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyLinearSeq].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyLinearSeq].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a list set") {
           @jsonExplicitEmptyCollections(false)
@@ -423,7 +443,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyListSet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a treeSet") {
           @jsonExplicitEmptyCollections(false)
@@ -433,7 +453,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyTreeSet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a list") {
           @jsonExplicitEmptyCollections(false)
@@ -443,10 +463,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyList].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyList].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a vector") {
           @jsonExplicitEmptyCollections(false)
@@ -456,7 +473,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyVector].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a set") {
           @jsonExplicitEmptyCollections(false)
@@ -466,7 +483,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptySet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a hash set") {
           @jsonExplicitEmptyCollections(false)
@@ -476,7 +493,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyHashSet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a sorted set") {
           @jsonExplicitEmptyCollections(false)
@@ -486,10 +503,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptySortedSet].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptySortedSet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a map") {
           @jsonExplicitEmptyCollections(false)
@@ -499,10 +513,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyMap].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyMap].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a hashMap") {
           @jsonExplicitEmptyCollections(false)
@@ -512,7 +523,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyHashMap].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a mutable map") {
           @jsonExplicitEmptyCollections(false)
@@ -522,10 +533,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyMutableMap].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyMutableMap].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a sorted map") {
           @jsonExplicitEmptyCollections(false)
@@ -535,10 +543,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptySortedMap].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptySortedMap].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a list map") {
           @jsonExplicitEmptyCollections(false)
@@ -548,7 +553,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
 
           implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyListMap].isLeft, expectedObj.toJson == expectedStr)
         }
       )
     )

--- a/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
@@ -2,148 +2,553 @@ package zio.json
 
 import zio.json.ast.Json
 import zio.test._
+import zio.Chunk
+
+import scala.collection.immutable
+import scala.collection.mutable
 
 object AnnotationsCodecSpec extends ZIOSpecDefault {
 
-  def spec = suite("ConfigurableDeriveCodecSpec")(
+  def spec = suite("AnnotationsCodecSpec")(
     suite("annotations overrides")(
-      suite("string")(
-        test("should override field name mapping") {
-          @jsonMemberNames(SnakeCase)
-          case class ClassWithFields(someField: Int, someOtherField: String)
+      test("should override field name mapping") {
+        @jsonMemberNames(SnakeCase)
+        case class ClassWithFields(someField: Int, someOtherField: String)
 
-          val expectedStr = """{"some_field":1,"some_other_field":"a"}"""
-          val expectedObj = ClassWithFields(1, "a")
+        val expectedStr = """{"some_field":1,"some_other_field":"a"}"""
+        val expectedObj = ClassWithFields(1, "a")
 
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[ClassWithFields].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("should specify discriminator") {
+        @jsonDiscriminator("$type")
+        sealed trait ST
+
+        object ST {
+          case object CaseObj          extends ST
+          case class CaseClass(i: Int) extends ST
+
+          implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+        }
+
+        val expectedStr     = """{"$type":"CaseClass","i":1}"""
+        val expectedObj: ST = ST.CaseClass(i = 1)
+
+        assertTrue(
+          expectedStr.fromJson[ST].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("should override sum type mapping") {
+        @jsonHintNames(SnakeCase)
+        @jsonDiscriminator("$type")
+        sealed trait ST
+
+        object ST {
+          case object CaseObj          extends ST
+          case class CaseClass(i: Int) extends ST
+
+          implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+        }
+
+        val expectedStr     = """{"$type":"case_class","i":1}"""
+        val expectedObj: ST = ST.CaseClass(i = 1)
+
+        assertTrue(
+          expectedStr.fromJson[ST].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("should prevent extra fields") {
+        @jsonNoExtraFields
+        case class ClassWithFields(someField: Int, someOtherField: String)
+
+        val jsonStr = """{"someField":1,"someOtherField":"a","extra":123}"""
+
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          jsonStr.fromJson[ClassWithFields].isLeft
+        )
+      },
+      test("use explicit null values") {
+        @jsonExplicitNull
+        case class OptionalField(a: Option[Int])
+
+        val expectedStr = """{"a":null}"""
+        val expectedObj = OptionalField(None)
+
+        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[OptionalField].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("do not write empty collections") {
+        @jsonExplicitEmptyCollection(false)
+        case class EmptySeq(a: Seq[Int])
+
+        val expectedStr = """{}"""
+        val expectedObj = EmptySeq(Seq.empty)
+
+        implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
+
+        assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+      }
+    ),
+    suite("annotations overrides AST")(
+      test("should override field name mapping") {
+        @jsonMemberNames(SnakeCase)
+        case class ClassWithFields(someField: Int, someOtherField: String)
+
+        val expectedAST = Json.Obj("some_field" -> Json.Num(1), "some_other_field" -> Json.Str("a"))
+        val expectedObj = ClassWithFields(1, "a")
+
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedAST.as[ClassWithFields].toOption.get == expectedObj,
+          expectedObj.toJsonAST.toOption.get == expectedAST
+        )
+      },
+      test("should specify discriminator") {
+        @jsonDiscriminator("$type")
+        sealed trait ST
+
+        object ST {
+          case object CaseObj          extends ST
+          case class CaseClass(i: Int) extends ST
+
+          implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+        }
+
+        val expectedAST     = Json.Obj("$type" -> Json.Str("CaseClass"), "i" -> Json.Num(1))
+        val expectedObj: ST = ST.CaseClass(i = 1)
+
+        assertTrue(
+          expectedAST.as[ST].toOption.get == expectedObj,
+          expectedObj.toJsonAST.toOption.get == expectedAST
+        )
+      },
+      test("should prevent extra fields") {
+        @jsonNoExtraFields
+        case class ClassWithFields(someField: Int, someOtherField: String)
+
+        val jsonAST = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"), "extra" -> Json.Num(1))
+
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          jsonAST.as[ClassWithFields].isLeft
+        )
+      },
+      test("use explicit null values") {
+        @jsonExplicitNull
+        case class OptionalField(a: Option[Int])
+
+        val jsonAST     = Json.Obj("a" -> Json.Null)
+        val expectedObj = OptionalField(None)
+
+        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+
+        assertTrue(jsonAST.as[OptionalField].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
+      },
+      test("do not write empty collections") {
+        @jsonExplicitEmptyCollection(false)
+        case class EmptySeq(a: Seq[Int])
+
+        val jsonAST     = Json.Obj()
+        val expectedObj = EmptySeq(Seq.empty)
+
+        implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
+
+        assertTrue(jsonAST.as[EmptySeq].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
+      }
+    ),
+    suite("explicit empty collections")(
+      suite("should write empty collections if set to true")(
+        test("for an array") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyArray(a: Array[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyArray(Array.empty)
+
+          implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
+        },
+        test("for a seq") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptySeq(a: Seq[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptySeq(Seq.empty)
+
+          implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a chunk") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyChunk(a: Chunk[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyChunk(Chunk.empty)
+
+          implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for an indexed seq") {
+          case class EmptyIndexedSeq(a: IndexedSeq[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
+
+          implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[ClassWithFields].toOption.get == expectedObj,
+            expectedStr.fromJson[EmptyIndexedSeq].toOption.get == expectedObj,
             expectedObj.toJson == expectedStr
           )
         },
-        test("should specify discriminator") {
-          @jsonDiscriminator("$type")
-          sealed trait ST
+        test("for a linear seq") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
 
-          object ST {
-            case object CaseObj          extends ST
-            case class CaseClass(i: Int) extends ST
-
-            implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-          }
-
-          val expectedStr     = """{"$type":"CaseClass","i":1}"""
-          val expectedObj: ST = ST.CaseClass(i = 1)
+          implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[ST].toOption.get == expectedObj,
+            expectedStr.fromJson[EmptyLinearSeq].toOption.get == expectedObj,
             expectedObj.toJson == expectedStr
           )
         },
-        test("should override sum type mapping") {
-          @jsonHintNames(SnakeCase)
-          @jsonDiscriminator("$type")
-          sealed trait ST
+        test("for a list set") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyListSet(a: immutable.ListSet[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyListSet(immutable.ListSet.empty)
 
-          object ST {
-            case object CaseObj          extends ST
-            case class CaseClass(i: Int) extends ST
+          implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
-            implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-          }
+          assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a tree set") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyTreeSet(a: immutable.TreeSet[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
 
-          val expectedStr     = """{"$type":"case_class","i":1}"""
-          val expectedObj: ST = ST.CaseClass(i = 1)
+          implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a list") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyList(a: List[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyList(List.empty)
+
+          implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyList].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a vector") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyVector(a: Vector[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyVector(Vector.empty)
+
+          implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a set") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptySet(a: Set[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptySet(Set.empty)
+
+          implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a hash set") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyHashSet(a: immutable.HashSet[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyHashSet(immutable.HashSet.empty)
+
+          implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a sorted set") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptySortedSet(a: immutable.SortedSet[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
+
+          implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[ST].toOption.get == expectedObj,
+            expectedStr.fromJson[EmptySortedSet].toOption.get == expectedObj,
             expectedObj.toJson == expectedStr
           )
         },
-        test("should prevent extra fields") {
-          @jsonNoExtraFields
-          case class ClassWithFields(someField: Int, someOtherField: String)
+        test("for a map") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyMap(a: Map[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptyMap(Map.empty)
 
-          val jsonStr = """{"someField":1,"someOtherField":"a","extra":123}"""
+          implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
 
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonStr.fromJson[ClassWithFields].isLeft
-          )
+          assertTrue(expectedStr.fromJson[EmptyMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
-        test("use explicit null values") {
-          @jsonExplicitNull
-          case class OptionalField(a: Option[Int])
+        test("for a hash map") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyHashMap(a: immutable.HashMap[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptyHashMap(immutable.HashMap.empty)
 
-          val expectedStr = """{"a":null}"""
-          val expectedObj = OptionalField(None)
+          implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
 
-          implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+          assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a mutable map") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyMutableMap(a: mutable.Map[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptyMutableMap(mutable.Map.empty)
+
+          implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[OptionalField].toOption.get == expectedObj,
+            expectedStr.fromJson[EmptyMutableMap].toOption.get == expectedObj,
             expectedObj.toJson == expectedStr
           )
+        },
+        test("for a sorted map") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptySortedMap(a: collection.SortedMap[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptySortedMap(collection.SortedMap.empty)
+
+          implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptySortedMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a list map") {
+          @jsonExplicitEmptyCollection(true)
+          case class EmptyListMap(a: immutable.ListMap[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptyListMap(immutable.ListMap.empty)
+
+          implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         }
       ),
-      suite("AST")(
-        test("should override field name mapping") {
-          @jsonMemberNames(SnakeCase)
-          case class ClassWithFields(someField: Int, someOtherField: String)
+      suite("should not write empty collections if set to false")(
+        test("for an array") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyArray(a: Array[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyArray(Array.empty)
 
-          val expectedAST = Json.Obj("some_field" -> Json.Num(1), "some_other_field" -> Json.Str("a"))
-          val expectedObj = ClassWithFields(1, "a")
+          implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
 
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+          assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
+        },
+        test("for a seq") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptySeq(a: Seq[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptySeq(Seq.empty)
+
+          implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a chunk") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyChunk(a: Chunk[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyChunk(Chunk.empty)
+
+          implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for an indexed seq") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyIndexedSeq(a: IndexedSeq[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
+
+          implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedAST.as[ClassWithFields].toOption.get == expectedObj,
-            expectedObj.toJsonAST.toOption.get == expectedAST
+            expectedStr.fromJson[EmptyIndexedSeq].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
           )
         },
-        test("should specify discriminator") {
-          @jsonDiscriminator("$type")
-          sealed trait ST
+        test("for a linear seq") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
 
-          object ST {
-            case object CaseObj          extends ST
-            case class CaseClass(i: Int) extends ST
-
-            implicit lazy val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-          }
-
-          val expectedAST     = Json.Obj("$type" -> Json.Str("CaseClass"), "i" -> Json.Num(1))
-          val expectedObj: ST = ST.CaseClass(i = 1)
+          implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedAST.as[ST].toOption.get == expectedObj,
-            expectedObj.toJsonAST.toOption.get == expectedAST
+            expectedStr.fromJson[EmptyLinearSeq].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
           )
         },
-        test("should prevent extra fields") {
-          @jsonNoExtraFields
-          case class ClassWithFields(someField: Int, someOtherField: String)
+        test("for a list set") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyListSet(a: immutable.ListSet[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyListSet(immutable.ListSet.empty)
 
-          val jsonAST = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"), "extra" -> Json.Num(1))
+          implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+          assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a treeSet") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyTreeSet(a: immutable.TreeSet[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
+
+          implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a list") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyList(a: List[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyList(List.empty)
+
+          implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
 
           assertTrue(
-            jsonAST.as[ClassWithFields].isLeft
+            expectedStr.fromJson[EmptyList].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
           )
         },
-        test("use explicit null values") {
-          @jsonExplicitNull
-          case class OptionalField(a: Option[Int])
+        test("for a vector") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyVector(a: Vector[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyVector(Vector.empty)
 
-          val jsonAST     = Json.Obj("a" -> Json.Null)
-          val expectedObj = OptionalField(None)
+          implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
 
-          implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+          assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a set") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptySet(a: Set[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptySet(Set.empty)
 
-          assertTrue(jsonAST.as[OptionalField].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
+          implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a hash set") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyHashSet(a: immutable.HashSet[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyHashSet(immutable.HashSet.empty)
+
+          implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a sorted set") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptySortedSet(a: immutable.SortedSet[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
+
+          implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptySortedSet].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a map") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyMap(a: Map[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyMap(Map.empty)
+
+          implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a hashMap") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyHashMap(a: immutable.HashMap[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyHashMap(immutable.HashMap.empty)
+
+          implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a mutable map") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyMutableMap(a: mutable.Map[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyMutableMap(mutable.Map.empty)
+
+          implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyMutableMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a sorted map") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptySortedMap(a: collection.SortedMap[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptySortedMap(collection.SortedMap.empty)
+
+          implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptySortedMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a list map") {
+          @jsonExplicitEmptyCollection(false)
+          case class EmptyListMap(a: immutable.ListMap[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyListMap(immutable.ListMap.empty)
+
+          implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         }
       )
     )

--- a/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
@@ -172,7 +172,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
     suite("explicit empty collections")(
       suite("should fill in missing empty collections and write empty collections")(
         test("for an array") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyArray(a: Array[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyArray(Array.empty)
@@ -182,7 +182,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue("""{}""".fromJson[EmptyArray].toOption.exists(_.a.isEmpty), expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptySeq(a: Seq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySeq(Seq.empty)
@@ -192,7 +192,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue("""{}""".fromJson[EmptySeq].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyChunk(a: Chunk[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyChunk(Chunk.empty)
@@ -202,7 +202,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue("""{}""".fromJson[EmptyChunk].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for an indexed seq") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyIndexedSeq(a: IndexedSeq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
@@ -215,7 +215,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a linear seq") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
@@ -228,7 +228,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list set") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyListSet(a: immutable.ListSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
@@ -241,7 +241,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a tree set") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyTreeSet(a: immutable.TreeSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
@@ -254,7 +254,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyList(a: List[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyList(List.empty)
@@ -267,7 +267,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a vector") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyVector(a: Vector[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyVector(Vector.empty)
@@ -280,7 +280,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a set") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptySet(a: Set[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySet(Set.empty)
@@ -293,7 +293,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a hash set") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyHashSet(a: immutable.HashSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
@@ -306,7 +306,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a sorted set") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptySortedSet(a: immutable.SortedSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
@@ -319,7 +319,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a map") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyMap(a: Map[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyMap(Map.empty)
@@ -332,7 +332,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a hash map") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyHashMap(a: immutable.HashMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
@@ -345,7 +345,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a mutable map") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyMutableMap(a: mutable.Map[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
@@ -358,7 +358,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a sorted map") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptySortedMap(a: collection.SortedMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
@@ -371,7 +371,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list map") {
-          @jsonExplicitEmptyCollections(true, whenDecoding = false)
+          @jsonExplicitEmptyCollections(true, decoding = false)
           case class EmptyListMap(a: immutable.ListMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyListMap(immutable.ListMap.empty)

--- a/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/AnnotationsCodecSpec.scala
@@ -91,7 +91,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
         )
       },
       test("do not write empty collections") {
-        @jsonExplicitEmptyCollection(false)
+        @jsonExplicitEmptyCollections(false)
         case class EmptySeq(a: Seq[Int])
 
         val expectedStr = """{}"""
@@ -160,7 +160,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
         assertTrue(jsonAST.as[OptionalField].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
       },
       test("do not write empty collections") {
-        @jsonExplicitEmptyCollection(false)
+        @jsonExplicitEmptyCollections(false)
         case class EmptySeq(a: Seq[Int])
 
         val jsonAST     = Json.Obj()
@@ -174,7 +174,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
     suite("explicit empty collections")(
       suite("should write empty collections if set to true")(
         test("for an array") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyArray(a: Array[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyArray(Array.empty)
@@ -184,7 +184,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptySeq(a: Seq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySeq(Seq.empty)
@@ -194,7 +194,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyChunk(a: Chunk[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyChunk(Chunk.empty)
@@ -216,7 +216,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a linear seq") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
@@ -229,7 +229,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list set") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyListSet(a: immutable.ListSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
@@ -239,7 +239,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a tree set") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyTreeSet(a: immutable.TreeSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
@@ -249,7 +249,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a list") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyList(a: List[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyList(List.empty)
@@ -259,7 +259,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyList].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a vector") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyVector(a: Vector[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyVector(Vector.empty)
@@ -269,7 +269,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a set") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptySet(a: Set[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySet(Set.empty)
@@ -279,7 +279,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a hash set") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyHashSet(a: immutable.HashSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
@@ -289,7 +289,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a sorted set") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptySortedSet(a: immutable.SortedSet[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
@@ -302,7 +302,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a map") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyMap(a: Map[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyMap(Map.empty)
@@ -312,7 +312,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a hash map") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyHashMap(a: immutable.HashMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
@@ -322,7 +322,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a mutable map") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyMutableMap(a: mutable.Map[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
@@ -335,7 +335,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a sorted map") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptySortedMap(a: collection.SortedMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
@@ -348,7 +348,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list map") {
-          @jsonExplicitEmptyCollection(true)
+          @jsonExplicitEmptyCollections(true)
           case class EmptyListMap(a: immutable.ListMap[String, String])
           val expectedStr = """{"a":{}}"""
           val expectedObj = EmptyListMap(immutable.ListMap.empty)
@@ -360,7 +360,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
       ),
       suite("should not write empty collections if set to false")(
         test("for an array") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyArray(a: Array[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyArray(Array.empty)
@@ -370,7 +370,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptySeq(a: Seq[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptySeq(Seq.empty)
@@ -380,7 +380,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyChunk(a: Chunk[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyChunk(Chunk.empty)
@@ -390,7 +390,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for an indexed seq") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyIndexedSeq(a: IndexedSeq[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
@@ -403,7 +403,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a linear seq") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
@@ -416,7 +416,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list set") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyListSet(a: immutable.ListSet[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
@@ -426,7 +426,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a treeSet") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyTreeSet(a: immutable.TreeSet[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
@@ -436,7 +436,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a list") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyList(a: List[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyList(List.empty)
@@ -449,7 +449,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a vector") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyVector(a: Vector[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyVector(Vector.empty)
@@ -459,7 +459,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a set") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptySet(a: Set[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptySet(Set.empty)
@@ -469,7 +469,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a hash set") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyHashSet(a: immutable.HashSet[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
@@ -479,7 +479,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a sorted set") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptySortedSet(a: immutable.SortedSet[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
@@ -492,7 +492,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a map") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyMap(a: Map[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptyMap(Map.empty)
@@ -505,7 +505,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a hashMap") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyHashMap(a: immutable.HashMap[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
@@ -515,7 +515,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
         test("for a mutable map") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyMutableMap(a: mutable.Map[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
@@ -528,7 +528,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a sorted map") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptySortedMap(a: collection.SortedMap[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
@@ -541,7 +541,7 @@ object AnnotationsCodecSpec extends ZIOSpecDefault {
           )
         },
         test("for a list map") {
-          @jsonExplicitEmptyCollection(false)
+          @jsonExplicitEmptyCollections(false)
           case class EmptyListMap(a: immutable.ListMap[String, String])
           val expectedStr = """{}"""
           val expectedObj = EmptyListMap(immutable.ListMap.empty)

--- a/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
@@ -262,7 +262,9 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
         val expectedEmptyObj = EmptyObj(Empty(None))
         val expectedEmptySeq = EmptySeq(Seq.empty)
 
-        implicit val config: JsonCodecConfiguration     = JsonCodecConfiguration(explicitEmptyCollections = false)
+        implicit val config: JsonCodecConfiguration = JsonCodecConfiguration(explicitEmptyCollections =
+          ExplicitEmptyCollections(whenDecoding = false, whenEncoding = false)
+        )
         implicit val codecEmpty: JsonCodec[Empty]       = DeriveJsonCodec.gen[Empty]
         implicit val codecEmptyObj: JsonCodec[EmptyObj] = DeriveJsonCodec.gen[EmptyObj]
         implicit val codecEmptySeq: JsonCodec[EmptySeq] = DeriveJsonCodec.gen[EmptySeq]
@@ -282,9 +284,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
         val expectedSeq = EmptySeq(Seq(1))
         val expectedObj = EmptyObj(expectedSeq)
 
-        implicit val config: JsonCodecConfiguration = JsonCodecConfiguration(explicitEmptyCollections = false)
-        implicit val codec: JsonCodec[EmptySeq]     = DeriveJsonCodec.gen
-        implicit val codecObj: JsonCodec[EmptyObj]  = DeriveJsonCodec.gen
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+        implicit val codec: JsonCodec[EmptySeq]    = DeriveJsonCodec.gen
+        implicit val codecObj: JsonCodec[EmptyObj] = DeriveJsonCodec.gen
 
         assertTrue(
           expectedStr.fromJson[EmptySeq].toOption.get == expectedSeq,
@@ -358,7 +361,9 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
         val expectedEmptyObj = EmptyObj(Empty(None))
         val expectedEmptySeq = EmptySeq(Seq.empty)
 
-        implicit val config: JsonCodecConfiguration     = JsonCodecConfiguration(explicitEmptyCollections = false)
+        implicit val config: JsonCodecConfiguration = JsonCodecConfiguration(explicitEmptyCollections =
+          ExplicitEmptyCollections(whenDecoding = false, whenEncoding = false)
+        )
         implicit val emptyCodec: JsonCodec[Empty]       = DeriveJsonCodec.gen
         implicit val emptyObjCodec: JsonCodec[EmptyObj] = DeriveJsonCodec.gen
         implicit val emptySeqCodec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
@@ -372,17 +377,17 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
       }
     ),
     suite("explicit empty collections")(
-      suite("should write empty collections if set to true")(
+      suite("should fill in missing empty collections and write empty collections")(
         test("for an array") {
           case class EmptyArray(a: Array[Int])
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptyArray(Array.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyArray].toOption.exists(_.a.isEmpty), expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
           case class EmptySeq(a: Seq[Int])
@@ -390,10 +395,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySeq(Seq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptySeq].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
           case class EmptyChunk(a: Chunk[Int])
@@ -401,10 +406,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyChunk(Chunk.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyChunk].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for an indexed seq") {
           case class EmptyIndexedSeq(a: IndexedSeq[Int])
@@ -412,11 +417,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptyIndexedSeq].toOption.get == expectedObj,
+            """{}""".fromJson[EmptyIndexedSeq].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
@@ -426,11 +431,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptyLinearSeq].toOption.get == expectedObj,
+            """{}""".fromJson[EmptyLinearSeq].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
@@ -440,10 +445,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyListSet].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a tree set") {
           case class EmptyTreeSet(a: immutable.TreeSet[Int])
@@ -451,10 +456,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyTreeSet].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a list") {
           case class EmptyList(a: List[Int])
@@ -462,10 +467,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyList(List.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyList].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyList].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a vector") {
           case class EmptyVector(a: Vector[Int])
@@ -473,10 +478,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyVector(Vector.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyVector].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a set") {
           case class EmptySet(a: Set[Int])
@@ -484,10 +489,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySet(Set.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptySet].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a hash set") {
           case class EmptyHashSet(a: immutable.HashSet[Int])
@@ -495,10 +500,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyHashSet].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a sorted set") {
           case class EmptySortedSet(a: immutable.SortedSet[Int])
@@ -506,11 +511,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptySortedSet].toOption.get == expectedObj,
+            """{}""".fromJson[EmptySortedSet].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
@@ -520,10 +525,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyMap(Map.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyMap].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a hash map") {
           case class EmptyHashMap(a: immutable.HashMap[String, String])
@@ -531,10 +536,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyHashMap].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         },
         test("for a mutable map") {
           case class EmptyMutableMap(a: mutable.Map[String, String])
@@ -542,11 +547,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptyMutableMap].toOption.get == expectedObj,
+            """{}""".fromJson[EmptyMutableMap].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
@@ -556,11 +561,11 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
 
           assertTrue(
-            expectedStr.fromJson[EmptySortedMap].toOption.get == expectedObj,
+            """{}""".fromJson[EmptySortedMap].toOption.contains(expectedObj),
             expectedObj.toJson == expectedStr
           )
         },
@@ -570,23 +575,23 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyListMap(immutable.ListMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = true)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
           implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue("""{}""".fromJson[EmptyListMap].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
         }
       ),
-      suite("should not write empty collections if set to false")(
+      suite("should not write empty collections and fail missing empty collections")(
         test("for an array") {
           case class EmptyArray(a: Array[Int])
           val expectedStr = """{}"""
           val expectedObj = EmptyArray(Array.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyArray].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a seq") {
           case class EmptySeq(a: Seq[Int])
@@ -594,10 +599,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySeq(Seq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptySeq].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a chunk") {
           case class EmptyChunk(a: Chunk[Int])
@@ -605,10 +610,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyChunk(Chunk.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyChunk].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for an indexed seq") {
           case class EmptyIndexedSeq(a: IndexedSeq[Int])
@@ -616,13 +621,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyIndexedSeq].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyIndexedSeq].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a linear seq") {
           case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
@@ -630,13 +632,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyLinearSeq].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyLinearSeq].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a list set") {
           case class EmptyListSet(a: immutable.ListSet[Int])
@@ -644,10 +643,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyListSet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a treeSet") {
           case class EmptyTreeSet(a: immutable.TreeSet[Int])
@@ -655,10 +654,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyTreeSet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a list") {
           case class EmptyList(a: List[Int])
@@ -666,13 +665,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyList(List.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyList].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyList].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a vector") {
           case class EmptyVector(a: Vector[Int])
@@ -680,10 +676,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyVector(Vector.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyVector].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a set") {
           case class EmptySet(a: Set[Int])
@@ -691,10 +687,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySet(Set.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptySet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a hash set") {
           case class EmptyHashSet(a: immutable.HashSet[Int])
@@ -702,10 +698,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyHashSet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a sorted set") {
           case class EmptySortedSet(a: immutable.SortedSet[Int])
@@ -713,13 +709,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptySortedSet].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptySortedSet].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a map") {
           case class EmptyMap(a: Map[String, String])
@@ -727,13 +720,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyMap(Map.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyMap].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyMap].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a hashMap") {
           case class EmptyHashMap(a: immutable.HashMap[String, String])
@@ -741,10 +731,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyHashMap].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a mutable map") {
           case class EmptyMutableMap(a: mutable.Map[String, String])
@@ -752,13 +742,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptyMutableMap].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptyMutableMap].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a sorted map") {
           case class EmptySortedMap(a: collection.SortedMap[String, String])
@@ -766,13 +753,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[EmptySortedMap].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+          assertTrue(expectedStr.fromJson[EmptySortedMap].isLeft, expectedObj.toJson == expectedStr)
         },
         test("for a list map") {
           case class EmptyListMap(a: immutable.ListMap[String, String])
@@ -780,10 +764,10 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyListMap(immutable.ListMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = false)
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(false))
           implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
 
-          assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+          assertTrue(expectedStr.fromJson[EmptyListMap].isLeft, expectedObj.toJson == expectedStr)
         }
       )
     )

--- a/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
@@ -273,6 +273,23 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           expectedStr.fromJson[EmptyObj] == Right(expectedEmptyObj),
           expectedStr.fromJson[EmptySeq] == Right(expectedEmptySeq)
         )
+      },
+      test("decode missing empty collections with defaults") {
+        case class EmptySeq(b: Seq[Int] = Seq(1))
+        case class EmptyObj(a: EmptySeq)
+
+        val expectedStr = """{}"""
+        val expectedSeq = EmptySeq(Seq(1))
+        val expectedObj = EmptyObj(expectedSeq)
+
+        implicit val config: JsonCodecConfiguration = JsonCodecConfiguration(explicitEmptyCollections = false)
+        implicit val codec: JsonCodec[EmptySeq]     = DeriveJsonCodec.gen
+        implicit val codecObj: JsonCodec[EmptyObj]  = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[EmptySeq].toOption.get == expectedSeq,
+          expectedStr.fromJson[EmptyObj].toOption.get == expectedObj
+        )
       }
     ),
     suite("override AST defaults")(

--- a/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
@@ -3,6 +3,10 @@ package zio.json
 import zio.json.JsonCodecConfiguration.SumTypeHandling.DiscriminatorField
 import zio.json.ast.Json
 import zio.test._
+import zio.Chunk
+
+import scala.collection.immutable
+import scala.collection.mutable
 
 object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
   case class ClassWithFields(someField: Int, someOtherField: String)
@@ -18,259 +22,752 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
 
   def spec = suite("ConfigurableDeriveCodecSpec")(
     suite("defaults")(
-      suite("string")(
-        test("should not map field names by default") {
-          val expectedStr = """{"someField":1,"someOtherField":"a"}"""
-          val expectedObj = ClassWithFields(1, "a")
+      test("should not map field names by default") {
+        val expectedStr = """{"someField":1,"someOtherField":"a"}"""
+        val expectedObj = ClassWithFields(1, "a")
 
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
 
-          assertTrue(
-            expectedStr.fromJson[ClassWithFields].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
+        assertTrue(
+          expectedStr.fromJson[ClassWithFields].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("should not use discriminator by default") {
+        val expectedStr     = """{"CaseObj":{}}"""
+        val expectedObj: ST = ST.CaseObj
+
+        implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[ST].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("should allow extra fields by default") {
+        val jsonStr     = """{"someField":1,"someOtherField":"a","extra":123}"""
+        val expectedObj = ClassWithFields(1, "a")
+
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          jsonStr.fromJson[ClassWithFields].toOption.get == expectedObj
+        )
+      },
+      test("do not write nulls by default") {
+        val expectedStr = """{}"""
+        val expectedObj = OptionalField(None)
+
+        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[OptionalField].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("do not fail on missing null values") {
+        val expectedStr = """{}"""
+        val expectedObj = OptionalField(None)
+
+        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+
+        assertTrue(expectedStr.fromJson[OptionalField].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+      },
+      test("write empty collections by default") {
+        case class Empty(z: Option[Int])
+        case class EmptyObj(a: Empty)
+        case class EmptySeq(a: Seq[Int])
+
+        val expectedObjStr = """{"a":{}}"""
+        val expectedSeqStr = """{"a":[]}"""
+        val expectedObj    = EmptyObj(Empty(None))
+        val expectedSeq    = EmptySeq(Seq.empty)
+
+        implicit val emptyCodec: JsonCodec[Empty]       = DeriveJsonCodec.gen
+        implicit val emptyObjCodec: JsonCodec[EmptyObj] = DeriveJsonCodec.gen
+        implicit val emptySeqCodec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedObjStr.fromJson[EmptyObj].toOption.get == expectedObj,
+          expectedObj.toJson == expectedObjStr,
+          expectedSeqStr.fromJson[EmptySeq].toOption.get == expectedSeq,
+          expectedSeq.toJson == expectedSeqStr
+        )
+      },
+      test("fail on decoding missing empty collections by default") {
+        case class Empty(z: Option[Int])
+        case class EmptyObj(a: Empty)
+        case class EmptySeq(b: Seq[Int])
+
+        implicit val codecEmpty: JsonCodec[Empty]       = DeriveJsonCodec.gen[Empty]
+        implicit val codecEmptyObj: JsonCodec[EmptyObj] = DeriveJsonCodec.gen[EmptyObj]
+        implicit val codecEmptySeq: JsonCodec[EmptySeq] = DeriveJsonCodec.gen[EmptySeq]
+
+        assertTrue(
+          """{}""".fromJson[EmptyObj] == Left(".a(missing)"),
+          """{}""".fromJson[EmptySeq] == Left(".b(missing)")
+        )
+      }
+    ),
+    suite("AST defaults")(
+      test("should not map field names by default") {
+        val expectedAST = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"))
+        val expectedObj = ClassWithFields(1, "a")
+
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedAST.as[ClassWithFields].toOption.get == expectedObj,
+          expectedObj.toJsonAST.toOption.get == expectedAST
+        )
+      },
+      test("should not use discriminator by default") {
+        val expectedAST     = Json.Obj("CaseObj" -> Json.Obj())
+        val expectedObj: ST = ST.CaseObj
+
+        implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedAST.as[ST].toOption.get == expectedObj,
+          expectedObj.toJsonAST.toOption.get == expectedAST
+        )
+      },
+      test("should allow extra fields by default") {
+        val jsonAST     = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"), "extra" -> Json.Num(1))
+        val expectedObj = ClassWithFields(1, "a")
+
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          jsonAST.as[ClassWithFields].toOption.get == expectedObj
+        )
+      },
+      test("do not write nulls by default") {
+        val jsonAST     = Json.Obj()
+        val expectedObj = OptionalField(None)
+
+        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+
+        assertTrue(
+          jsonAST.as[OptionalField].toOption.get == expectedObj,
+          expectedObj.toJsonAST == Right(jsonAST)
+        )
+      },
+      test("write empty collections by default") {
+        case class Empty(z: Option[Int])
+        case class EmptyObj(a: Empty)
+        case class EmptySeq(a: Seq[Int])
+
+        val expectedSeqJson = Json.Obj("a" -> Json.Arr())
+        val expectedObjJson = Json.Obj("a" -> Json.Obj())
+        val expectedObj     = EmptyObj(Empty(None))
+        val expectedSeq     = EmptySeq(Seq.empty)
+
+        implicit val emptyCodec: JsonCodec[Empty]       = DeriveJsonCodec.gen
+        implicit val emptyObjCodec: JsonCodec[EmptyObj] = DeriveJsonCodec.gen
+        implicit val emptySeqCodec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedObj.toJsonAST == Right(expectedObjJson),
+          expectedSeq.toJsonAST == Right(expectedSeqJson),
+          expectedObjJson.as[EmptyObj] == Right(expectedObj),
+          expectedSeqJson.as[EmptySeq] == Right(expectedSeq)
+        )
+      },
+      test("fail on decoding missing empty collections by default") {
+        case class Empty(z: Option[Int])
+        case class EmptyObj(a: Empty)
+        case class EmptySeq(b: Seq[Int])
+
+        implicit val codecEmpty: JsonDecoder[Empty]       = DeriveJsonDecoder.gen[Empty]
+        implicit val codecEmptyObj: JsonDecoder[EmptyObj] = DeriveJsonDecoder.gen[EmptyObj]
+        implicit val codecEmptySeq: JsonDecoder[EmptySeq] = DeriveJsonDecoder.gen[EmptySeq]
+
+        assertTrue(
+          Json.Obj().as[EmptyObj] == Left(".a(missing)"),
+          Json.Obj().as[EmptySeq] == Left(".b(missing)")
+        )
+      }
+    ),
+    suite("override defaults")(
+      test("should override field name mapping") {
+        val expectedStr = """{"some_field":1,"some_other_field":"a"}"""
+        val expectedObj = ClassWithFields(1, "a")
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(fieldNameMapping = SnakeCase)
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[ClassWithFields].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("should specify discriminator") {
+        val expectedStr     = """{"$type":"CaseClass","i":1}"""
+        val expectedObj: ST = ST.CaseClass(i = 1)
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"))
+        implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[ST].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("should override sum type mapping") {
+        val expectedStr     = """{"$type":"case_class","i":1}"""
+        val expectedObj: ST = ST.CaseClass(i = 1)
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"), sumTypeMapping = SnakeCase)
+        implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[ST].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("should prevent extra fields") {
+        val jsonStr = """{"someField":1,"someOtherField":"a","extra":123}"""
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(allowExtraFields = false)
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          jsonStr.fromJson[ClassWithFields].isLeft
+        )
+      },
+      test("use explicit null values") {
+        val expectedStr = """{"a":null}"""
+        val expectedObj = OptionalField(None)
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(explicitNulls = true)
+        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedStr.fromJson[OptionalField].toOption.get == expectedObj,
+          expectedObj.toJson == expectedStr
+        )
+      },
+      test("do not write empty collections") {
+        case class Empty(z: Option[Int])
+        case class EmptyObj(a: Empty)
+        case class EmptySeq(b: Seq[Int])
+
+        val expectedStr      = """{}"""
+        val expectedEmptyObj = EmptyObj(Empty(None))
+        val expectedEmptySeq = EmptySeq(Seq.empty)
+
+        implicit val config: JsonCodecConfiguration     = JsonCodecConfiguration(explicitEmptyCollections = false)
+        implicit val codecEmpty: JsonCodec[Empty]       = DeriveJsonCodec.gen[Empty]
+        implicit val codecEmptyObj: JsonCodec[EmptyObj] = DeriveJsonCodec.gen[EmptyObj]
+        implicit val codecEmptySeq: JsonCodec[EmptySeq] = DeriveJsonCodec.gen[EmptySeq]
+
+        assertTrue(
+          expectedEmptyObj.toJson == expectedStr,
+          expectedEmptySeq.toJson == expectedStr,
+          expectedStr.fromJson[EmptyObj] == Right(expectedEmptyObj),
+          expectedStr.fromJson[EmptySeq] == Right(expectedEmptySeq)
+        )
+      }
+    ),
+    suite("override AST defaults")(
+      test("should override field name mapping") {
+        val expectedAST = Json.Obj("some_field" -> Json.Num(1), "some_other_field" -> Json.Str("a"))
+        val expectedObj = ClassWithFields(1, "a")
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(fieldNameMapping = SnakeCase)
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedAST.as[ClassWithFields].toOption.get == expectedObj,
+          expectedObj.toJsonAST.toOption.get == expectedAST
+        )
+      },
+      test("should specify discriminator") {
+        val expectedAST     = Json.Obj("$type" -> Json.Str("CaseClass"), "i" -> Json.Num(1))
+        val expectedObj: ST = ST.CaseClass(i = 1)
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"))
+        implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedAST.as[ST].toOption.get == expectedObj,
+          expectedObj.toJsonAST.toOption.get == expectedAST
+        )
+      },
+      test("should prevent extra fields") {
+        val jsonAST = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"), "extra" -> Json.Num(1))
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(allowExtraFields = false)
+        implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
+
+        assertTrue(
+          jsonAST.as[ClassWithFields].isLeft
+        )
+      },
+      test("use explicit null values") {
+        val jsonAST     = Json.Obj("a" -> Json.Null)
+        val expectedObj = OptionalField(None)
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(explicitNulls = true)
+        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+
+        assertTrue(jsonAST.as[OptionalField].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
+      },
+      test("fail on decoding missing explicit nulls") {
+        val jsonStr = """{}"""
+
+        implicit val config: JsonCodecConfiguration =
+          JsonCodecConfiguration(explicitNulls = true)
+        implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
+
+        assertTrue(jsonStr.fromJson[OptionalField].isLeft)
+      } @@ TestAspect.ignore,
+      test("do not write empty collections") {
+        case class Empty(z: Option[Int])
+        case class EmptyObj(a: Empty)
+        case class EmptySeq(b: Seq[Int])
+
+        val expectedJson     = Json.Obj()
+        val expectedEmptyObj = EmptyObj(Empty(None))
+        val expectedEmptySeq = EmptySeq(Seq.empty)
+
+        implicit val config: JsonCodecConfiguration     = JsonCodecConfiguration(explicitEmptyCollections = false)
+        implicit val emptyCodec: JsonCodec[Empty]       = DeriveJsonCodec.gen
+        implicit val emptyObjCodec: JsonCodec[EmptyObj] = DeriveJsonCodec.gen
+        implicit val emptySeqCodec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
+
+        assertTrue(
+          expectedEmptyObj.toJsonAST == Right(expectedJson),
+          expectedEmptySeq.toJsonAST == Right(expectedJson),
+          expectedJson.as[EmptyObj] == Right(expectedEmptyObj),
+          expectedJson.as[EmptySeq] == Right(expectedEmptySeq)
+        )
+      }
+    ),
+    suite("explicit empty collections")(
+      suite("should write empty collections if set to true")(
+        test("for an array") {
+          case class EmptyArray(a: Array[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyArray(Array.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
         },
-        test("should not use discriminator by default") {
-          val expectedStr     = """{"CaseObj":{}}"""
-          val expectedObj: ST = ST.CaseObj
-
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedStr.fromJson[ST].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
-        },
-        test("should allow extra fields by default") {
-          val jsonStr     = """{"someField":1,"someOtherField":"a","extra":123}"""
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonStr.fromJson[ClassWithFields].toOption.get == expectedObj
-          )
-        },
-        test("do not write nulls by default, decode missing nulls as None") {
-          val expectedStr = """{}"""
-          val expectedObj = OptionalField(None)
-
-          implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedStr.fromJson[OptionalField].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
-        },
-        test("write empty collections by default") {
+        test("for a seq") {
           case class EmptySeq(a: Seq[Int])
-
           val expectedStr = """{"a":[]}"""
           val expectedObj = EmptySeq(Seq.empty)
 
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
           assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         },
-        test("fail on decoding missing empty collections by default") {
-          case class Empty(z: Option[Int])
-          case class EmptyObj(a: Empty)
+        test("for a chunk") {
+          case class EmptyChunk(a: Chunk[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyChunk(Chunk.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for an indexed seq") {
+          case class EmptyIndexedSeq(a: IndexedSeq[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyIndexedSeq].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a linear seq") {
+          case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyLinearSeq].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a list set") {
+          case class EmptyListSet(a: immutable.ListSet[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyListSet(immutable.ListSet.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a tree set") {
+          case class EmptyTreeSet(a: immutable.TreeSet[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a list") {
+          case class EmptyList(a: List[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyList(List.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyList].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a vector") {
+          case class EmptyVector(a: Vector[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyVector(Vector.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a set") {
+          case class EmptySet(a: Set[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptySet(Set.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a hash set") {
+          case class EmptyHashSet(a: immutable.HashSet[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptyHashSet(immutable.HashSet.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a sorted set") {
+          case class EmptySortedSet(a: immutable.SortedSet[Int])
+          val expectedStr = """{"a":[]}"""
+          val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptySortedSet].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a map") {
+          case class EmptyMap(a: Map[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptyMap(Map.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a hash map") {
+          case class EmptyHashMap(a: immutable.HashMap[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptyHashMap(immutable.HashMap.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a mutable map") {
+          case class EmptyMutableMap(a: mutable.Map[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptyMutableMap(mutable.Map.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyMutableMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a sorted map") {
+          case class EmptySortedMap(a: collection.SortedMap[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptySortedMap(collection.SortedMap.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptySortedMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a list map") {
+          case class EmptyListMap(a: immutable.ListMap[String, String])
+          val expectedStr = """{"a":{}}"""
+          val expectedObj = EmptyListMap(immutable.ListMap.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = true)
+          implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        }
+      ),
+      suite("should not write empty collections if set to false")(
+        test("for an array") {
+          case class EmptyArray(a: Array[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyArray(Array.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyArray].toOption.get.a.isEmpty, expectedObj.toJson == expectedStr)
+        },
+        test("for a seq") {
           case class EmptySeq(a: Seq[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptySeq(Seq.empty)
 
-          implicit val codecEmpty: JsonCodec[Empty]       = DeriveJsonCodec.gen[Empty]
-          implicit val codecEmptyObj: JsonCodec[EmptyObj] = DeriveJsonCodec.gen[EmptyObj]
-          implicit val codecEmptySeq: JsonCodec[EmptySeq] = DeriveJsonCodec.gen[EmptySeq]
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptySeq].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a chunk") {
+          case class EmptyChunk(a: Chunk[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyChunk(Chunk.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyChunk].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for an indexed seq") {
+          case class EmptyIndexedSeq(a: IndexedSeq[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
           assertTrue(
-            """{}""".fromJson[EmptyObj] == Left(".a(missing)"),
-            """{}""".fromJson[EmptySeq] == Left(".a(missing)")
+            expectedStr.fromJson[EmptyIndexedSeq].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
           )
+        },
+        test("for a linear seq") {
+          case class EmptyLinearSeq(a: immutable.LinearSeq[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyLinearSeq].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a list set") {
+          case class EmptyListSet(a: immutable.ListSet[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyListSet(immutable.ListSet.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyListSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a treeSet") {
+          case class EmptyTreeSet(a: immutable.TreeSet[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyTreeSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a list") {
+          case class EmptyList(a: List[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyList(List.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyList].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a vector") {
+          case class EmptyVector(a: Vector[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyVector(Vector.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyVector].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a set") {
+          case class EmptySet(a: Set[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptySet(Set.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptySet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a hash set") {
+          case class EmptyHashSet(a: immutable.HashSet[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyHashSet(immutable.HashSet.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyHashSet].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a sorted set") {
+          case class EmptySortedSet(a: immutable.SortedSet[Int])
+          val expectedStr = """{}"""
+          val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptySortedSet].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a map") {
+          case class EmptyMap(a: Map[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyMap(Map.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a hashMap") {
+          case class EmptyHashMap(a: immutable.HashMap[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyHashMap(immutable.HashMap.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyHashMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
+        },
+        test("for a mutable map") {
+          case class EmptyMutableMap(a: mutable.Map[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyMutableMap(mutable.Map.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptyMutableMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a sorted map") {
+          case class EmptySortedMap(a: collection.SortedMap[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptySortedMap(collection.SortedMap.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
+
+          assertTrue(
+            expectedStr.fromJson[EmptySortedMap].toOption.get == expectedObj,
+            expectedObj.toJson == expectedStr
+          )
+        },
+        test("for a list map") {
+          case class EmptyListMap(a: immutable.ListMap[String, String])
+          val expectedStr = """{}"""
+          val expectedObj = EmptyListMap(immutable.ListMap.empty)
+
+          implicit val config: JsonCodecConfiguration =
+            JsonCodecConfiguration(explicitEmptyCollections = false)
+          implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
+
+          assertTrue(expectedStr.fromJson[EmptyListMap].toOption.get == expectedObj, expectedObj.toJson == expectedStr)
         }
-      ),
-      suite("AST")(
-        test("should not map field names by default") {
-          val expectedAST = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"))
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedAST.as[ClassWithFields].toOption.get == expectedObj,
-            expectedObj.toJsonAST.toOption.get == expectedAST
-          )
-        },
-        test("should not use discriminator by default") {
-          val expectedAST     = Json.Obj("CaseObj" -> Json.Obj())
-          val expectedObj: ST = ST.CaseObj
-
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedAST.as[ST].toOption.get == expectedObj,
-            expectedObj.toJsonAST.toOption.get == expectedAST
-          )
-        },
-        test("should allow extra fields by default") {
-          val jsonAST     = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"), "extra" -> Json.Num(1))
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonAST.as[ClassWithFields].toOption.get == expectedObj
-          )
-        },
-        test("do not write nulls by default") {
-          val jsonAST     = Json.Obj()
-          val expectedObj = OptionalField(None)
-
-          implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonAST.as[OptionalField].toOption.get == expectedObj,
-            expectedObj.toJsonAST == Right(jsonAST)
-          )
-        },
-        test("write empty collections by default") {
-          case class Empty()
-          case class EmptySeq(a: Seq[Int], b: Empty)
-
-          val jsonAST     = Json.Obj("a" -> Json.Arr(), "b" -> Json.Obj())
-          val expectedObj = EmptySeq(Seq.empty, Empty())
-
-          implicit val emptyCodec: JsonCodec[Empty] = DeriveJsonCodec.gen
-          implicit val codec: JsonCodec[EmptySeq]   = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonAST.as[EmptySeq].toOption.get == expectedObj,
-            expectedObj.toJsonAST == Right(jsonAST)
-          )
-        }
-      )
-    ),
-    suite("overrides")(
-      suite("string")(
-        test("should override field name mapping") {
-          val expectedStr = """{"some_field":1,"some_other_field":"a"}"""
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(fieldNameMapping = SnakeCase)
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedStr.fromJson[ClassWithFields].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
-        },
-        test("should specify discriminator") {
-          val expectedStr     = """{"$type":"CaseClass","i":1}"""
-          val expectedObj: ST = ST.CaseClass(i = 1)
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"))
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedStr.fromJson[ST].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
-        },
-        test("should override sum type mapping") {
-          val expectedStr     = """{"$type":"case_class","i":1}"""
-          val expectedObj: ST = ST.CaseClass(i = 1)
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"), sumTypeMapping = SnakeCase)
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedStr.fromJson[ST].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
-        },
-        test("should prevent extra fields") {
-          val jsonStr = """{"someField":1,"someOtherField":"a","extra":123}"""
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(allowExtraFields = false)
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonStr.fromJson[ClassWithFields].isLeft
-          )
-        },
-        test("use explicit null values") {
-          val expectedStr = """{"a":null}"""
-          val expectedObj = OptionalField(None)
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitNulls = true)
-          implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedStr.fromJson[OptionalField].toOption.get == expectedObj,
-            expectedObj.toJson == expectedStr
-          )
-        }
-      ),
-      suite("AST")(
-        test("should override field name mapping") {
-          val expectedAST = Json.Obj("some_field" -> Json.Num(1), "some_other_field" -> Json.Str("a"))
-          val expectedObj = ClassWithFields(1, "a")
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(fieldNameMapping = SnakeCase)
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedAST.as[ClassWithFields].toOption.get == expectedObj,
-            expectedObj.toJsonAST.toOption.get == expectedAST
-          )
-        },
-        test("should specify discriminator") {
-          val expectedAST     = Json.Obj("$type" -> Json.Str("CaseClass"), "i" -> Json.Num(1))
-          val expectedObj: ST = ST.CaseClass(i = 1)
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(sumTypeHandling = DiscriminatorField("$type"))
-          implicit val codec: JsonCodec[ST] = DeriveJsonCodec.gen
-
-          assertTrue(
-            expectedAST.as[ST].toOption.get == expectedObj,
-            expectedObj.toJsonAST.toOption.get == expectedAST
-          )
-        },
-        test("should prevent extra fields") {
-          val jsonAST = Json.Obj("someField" -> Json.Num(1), "someOtherField" -> Json.Str("a"), "extra" -> Json.Num(1))
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(allowExtraFields = false)
-          implicit val codec: JsonCodec[ClassWithFields] = DeriveJsonCodec.gen
-
-          assertTrue(
-            jsonAST.as[ClassWithFields].isLeft
-          )
-        },
-        test("use explicit null values") {
-          val jsonAST     = Json.Obj("a" -> Json.Null)
-          val expectedObj = OptionalField(None)
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitNulls = true)
-          implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
-
-          assertTrue(jsonAST.as[OptionalField].toOption.get == expectedObj, expectedObj.toJsonAST == Right(jsonAST))
-        },
-        test("fail on decoding missing explicit nulls") {
-          val jsonStr = """{}"""
-
-          implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitNulls = true)
-          implicit val codec: JsonCodec[OptionalField] = DeriveJsonCodec.gen
-
-          assertTrue(jsonStr.fromJson[OptionalField].isLeft)
-        } @@ TestAspect.ignore
       )
     )
   )

--- a/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ConfigurableDeriveCodecSpec.scala
@@ -263,7 +263,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
         val expectedEmptySeq = EmptySeq(Seq.empty)
 
         implicit val config: JsonCodecConfiguration = JsonCodecConfiguration(explicitEmptyCollections =
-          ExplicitEmptyCollections(whenDecoding = false, whenEncoding = false)
+          ExplicitEmptyCollections(decoding = false, encoding = false)
         )
         implicit val codecEmpty: JsonCodec[Empty]       = DeriveJsonCodec.gen[Empty]
         implicit val codecEmptyObj: JsonCodec[EmptyObj] = DeriveJsonCodec.gen[EmptyObj]
@@ -285,7 +285,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
         val expectedObj = EmptyObj(expectedSeq)
 
         implicit val config: JsonCodecConfiguration =
-          JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+          JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
         implicit val codec: JsonCodec[EmptySeq]    = DeriveJsonCodec.gen
         implicit val codecObj: JsonCodec[EmptyObj] = DeriveJsonCodec.gen
 
@@ -362,7 +362,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
         val expectedEmptySeq = EmptySeq(Seq.empty)
 
         implicit val config: JsonCodecConfiguration = JsonCodecConfiguration(explicitEmptyCollections =
-          ExplicitEmptyCollections(whenDecoding = false, whenEncoding = false)
+          ExplicitEmptyCollections(decoding = false, encoding = false)
         )
         implicit val emptyCodec: JsonCodec[Empty]       = DeriveJsonCodec.gen
         implicit val emptyObjCodec: JsonCodec[EmptyObj] = DeriveJsonCodec.gen
@@ -384,7 +384,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyArray(Array.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyArray] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyArray].toOption.exists(_.a.isEmpty), expectedObj.toJson == expectedStr)
@@ -395,7 +395,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySeq(Seq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptySeq] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptySeq].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -406,7 +406,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyChunk(Chunk.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyChunk] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyChunk].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -417,7 +417,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyIndexedSeq(IndexedSeq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyIndexedSeq] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -431,7 +431,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyLinearSeq(immutable.LinearSeq.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyLinearSeq] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -445,7 +445,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyListSet(immutable.ListSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyListSet] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyListSet].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -456,7 +456,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyTreeSet(immutable.TreeSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyTreeSet] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyTreeSet].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -467,7 +467,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyList(List.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyList] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyList].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -478,7 +478,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyVector(Vector.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyVector] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyVector].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -489,7 +489,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySet(Set.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptySet] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptySet].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -500,7 +500,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyHashSet(immutable.HashSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyHashSet] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyHashSet].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -511,7 +511,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySortedSet(immutable.SortedSet.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptySortedSet] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -525,7 +525,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyMap(Map.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyMap] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyMap].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -536,7 +536,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyHashMap(immutable.HashMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyHashMap] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyHashMap].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)
@@ -547,7 +547,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyMutableMap(mutable.Map.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyMutableMap] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -561,7 +561,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptySortedMap(collection.SortedMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptySortedMap] = DeriveJsonCodec.gen
 
           assertTrue(
@@ -575,7 +575,7 @@ object ConfigurableDeriveCodecSpec extends ZIOSpecDefault {
           val expectedObj = EmptyListMap(immutable.ListMap.empty)
 
           implicit val config: JsonCodecConfiguration =
-            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(whenDecoding = false))
+            JsonCodecConfiguration(explicitEmptyCollections = ExplicitEmptyCollections(decoding = false))
           implicit val codec: JsonCodec[EmptyListMap] = DeriveJsonCodec.gen
 
           assertTrue("""{}""".fromJson[EmptyListMap].toOption.contains(expectedObj), expectedObj.toJson == expectedStr)

--- a/zio-json/shared/src/test/scala/zio/json/internal/FieldEncoderHelperSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/internal/FieldEncoderHelperSpec.scala
@@ -1,0 +1,106 @@
+package zio.json
+package internal
+
+import zio.test._
+
+object FieldEncoderSpec extends ZIOSpecDefault {
+  val spec = suite("FieldEncoder.encodeOrSkip")(
+    suite("OptionEncoder")(
+      test("should skip encoding None when withExplicitNulls is false") {
+        val helper = new FieldEncoder(
+          1,
+          "test",
+          JsonEncoder.option(JsonEncoder.int),
+          withExplicitNulls = false,
+          withExplicitEmptyCollections = false
+        )
+        var called = false
+        helper.encodeOrSkip(None)(() => called = true)
+        assertTrue(!called)
+      },
+      test("should encode None when withExplicitNulls is true") {
+        val helper = new FieldEncoder(
+          1,
+          "test",
+          JsonEncoder.option(JsonEncoder.int),
+          withExplicitNulls = true,
+          withExplicitEmptyCollections = false
+        )
+        var called = false
+        helper.encodeOrSkip(None)(() => called = true)
+        assertTrue(called)
+      }
+    ),
+    suite("CollectionEncoder")(
+      suite("for a List")(
+        test("should encode empty collections when withExplicitEmptyCollections is true") {
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            implicitly[JsonEncoder[List[Int]]],
+            withExplicitNulls = false,
+            withExplicitEmptyCollections = true
+          )
+          var called = false
+          helper.encodeOrSkip(Nil)(() => called = true)
+          assertTrue(called)
+        },
+        test("should not encode empty collections when withExplicitEmptyCollections is false") {
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            implicitly[JsonEncoder[List[Int]]],
+            withExplicitNulls = false,
+            withExplicitEmptyCollections = false
+          )
+          var called = false
+          helper.encodeOrSkip(Nil)(() => called = true)
+          assertTrue(!called)
+        }
+      ),
+      suite("for a case class")(
+        test("should encode case classes with empty collections when withExplicitEmptyCollections is true") {
+          case class Test(list: List[Int], option: Option[Int])
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            DeriveJsonEncoder.gen[Test],
+            withExplicitNulls = false,
+            withExplicitEmptyCollections = true
+          )
+          var called = false
+          helper.encodeOrSkip(Test(Nil, None))(() => called = true)
+          assertTrue(called)
+        },
+        test("should not encode case classes with empty collections when withExplicitEmptyCollections is false") {
+          case class Test(list: List[Int], option: Option[Int])
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            DeriveJsonEncoder.gen[Test],
+            withExplicitNulls = false,
+            withExplicitEmptyCollections = false
+          )
+          var called = false
+          helper.encodeOrSkip(Test(Nil, None))(() => called = true)
+          assertTrue(!called)
+        },
+        test(
+          "should also not encode case classes with empty options when withExplicitEmptyCollections is false, even when withExplicitNulls is true"
+        ) {
+          case class Test(list: List[Int], option: Option[Int])
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            DeriveJsonEncoder.gen[Test],
+            withExplicitNulls = true,
+            withExplicitEmptyCollections = false
+          )
+          var called = false
+          helper.encodeOrSkip(Test(Nil, None))(() => called = true)
+          assertTrue(!called)
+        }
+      )
+    )
+  )
+}

--- a/zio-json/shared/src/test/scala/zio/json/internal/FieldEncoderHelperSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/internal/FieldEncoderHelperSpec.scala
@@ -1,38 +1,141 @@
 package zio.json
 package internal
 
+import zio.json.ast.Json
+import zio.Chunk
 import zio.test._
 
 object FieldEncoderSpec extends ZIOSpecDefault {
-  val spec = suite("FieldEncoder.encodeOrSkip")(
-    suite("OptionEncoder")(
-      test("should skip encoding None when withExplicitNulls is false") {
-        val helper = new FieldEncoder(
-          1,
-          "test",
-          JsonEncoder.option(JsonEncoder.int),
-          withExplicitNulls = false,
-          withExplicitEmptyCollections = false
+  val spec = suite("FieldEncoder")(
+    suite("encodeOrSkip")(
+      suite("OptionEncoder")(
+        test("should skip encoding None when withExplicitNulls is false") {
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            JsonEncoder.option(JsonEncoder.int),
+            withExplicitNulls = false,
+            withExplicitEmptyCollections = false
+          )
+          var called = false
+          helper.encodeOrSkip(None)(() => called = true)
+          assertTrue(!called)
+        },
+        test("should encode None when withExplicitNulls is true") {
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            JsonEncoder.option(JsonEncoder.int),
+            withExplicitNulls = true,
+            withExplicitEmptyCollections = false
+          )
+          var called = false
+          helper.encodeOrSkip(None)(() => called = true)
+          assertTrue(called)
+        }
+      ),
+      suite("CollectionEncoder")(
+        suite("for a List")(
+          test("should encode empty collections when withExplicitEmptyCollections is true") {
+            val helper = new FieldEncoder(
+              1,
+              "test",
+              implicitly[JsonEncoder[List[Int]]],
+              withExplicitNulls = false,
+              withExplicitEmptyCollections = true
+            )
+            var called = false
+            helper.encodeOrSkip(Nil)(() => called = true)
+            assertTrue(called)
+          },
+          test("should not encode empty collections when withExplicitEmptyCollections is false") {
+            val helper = new FieldEncoder(
+              1,
+              "test",
+              implicitly[JsonEncoder[List[Int]]],
+              withExplicitNulls = false,
+              withExplicitEmptyCollections = false
+            )
+            var called = false
+            helper.encodeOrSkip(Nil)(() => called = true)
+            assertTrue(!called)
+          }
+        ),
+        suite("for a case class")(
+          test("should encode case classes with empty collections when withExplicitEmptyCollections is true") {
+            case class Test(list: List[Int], option: Option[Int])
+            val helper = new FieldEncoder(
+              1,
+              "test",
+              DeriveJsonEncoder.gen[Test],
+              withExplicitNulls = false,
+              withExplicitEmptyCollections = true
+            )
+            var called = false
+            helper.encodeOrSkip(Test(Nil, None))(() => called = true)
+            assertTrue(called)
+          },
+          test("should not encode case classes with empty collections when withExplicitEmptyCollections is false") {
+            case class Test(list: List[Int], option: Option[Int])
+            val helper = new FieldEncoder(
+              1,
+              "test",
+              DeriveJsonEncoder.gen[Test],
+              withExplicitNulls = false,
+              withExplicitEmptyCollections = false
+            )
+            var called = false
+            helper.encodeOrSkip(Test(Nil, None))(() => called = true)
+            assertTrue(!called)
+          },
+          test(
+            "should also not encode case classes with empty options when withExplicitEmptyCollections is false, even when withExplicitNulls is true"
+          ) {
+            case class Test(list: List[Int], option: Option[Int])
+            val helper = new FieldEncoder(
+              1,
+              "test",
+              DeriveJsonEncoder.gen[Test],
+              withExplicitNulls = true,
+              withExplicitEmptyCollections = false
+            )
+            var called = false
+            helper.encodeOrSkip(Test(Nil, None))(() => called = true)
+            assertTrue(!called)
+          }
         )
-        var called = false
-        helper.encodeOrSkip(None)(() => called = true)
-        assertTrue(!called)
-      },
-      test("should encode None when withExplicitNulls is true") {
-        val helper = new FieldEncoder(
-          1,
-          "test",
-          JsonEncoder.option(JsonEncoder.int),
-          withExplicitNulls = true,
-          withExplicitEmptyCollections = false
-        )
-        var called = false
-        helper.encodeOrSkip(None)(() => called = true)
-        assertTrue(called)
-      }
+      )
     ),
-    suite("CollectionEncoder")(
-      suite("for a List")(
+    suite("encodeOrDefault")(
+      suite("OptionEncoder")(
+        test("should use the default encoding None when withExplicitNulls is false") {
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            JsonEncoder.option(JsonEncoder.int),
+            withExplicitNulls = false,
+            withExplicitEmptyCollections = false
+          )
+          val expected = Chunk(("a", Json.Bool.True))
+          assertTrue(
+            helper.encodeOrDefault(None)(() => Left(""), Right(expected)) == Right(expected)
+          )
+        },
+        test("should encode None when withExplicitNulls is true") {
+          val helper = new FieldEncoder(
+            1,
+            "test",
+            JsonEncoder.option(JsonEncoder.int),
+            withExplicitNulls = true,
+            withExplicitEmptyCollections = false
+          )
+          val expected = Chunk(("a", Json.Bool.True))
+          assertTrue(
+            helper.encodeOrDefault(None)(() => Right(expected), Left("")) == Right(expected)
+          )
+        }
+      ),
+      suite("CollectionEncoder")(
         test("should encode empty collections when withExplicitEmptyCollections is true") {
           val helper = new FieldEncoder(
             1,
@@ -41,9 +144,10 @@ object FieldEncoderSpec extends ZIOSpecDefault {
             withExplicitNulls = false,
             withExplicitEmptyCollections = true
           )
-          var called = false
-          helper.encodeOrSkip(Nil)(() => called = true)
-          assertTrue(called)
+          val expected = Chunk(("a", Json.Bool.True))
+          assertTrue(
+            helper.encodeOrDefault(Nil)(() => Right(expected), Left("")) == Right(expected)
+          )
         },
         test("should not encode empty collections when withExplicitEmptyCollections is false") {
           val helper = new FieldEncoder(
@@ -53,9 +157,10 @@ object FieldEncoderSpec extends ZIOSpecDefault {
             withExplicitNulls = false,
             withExplicitEmptyCollections = false
           )
-          var called = false
-          helper.encodeOrSkip(Nil)(() => called = true)
-          assertTrue(!called)
+          val expected = Chunk(("a", Json.Bool.True))
+          assertTrue(
+            helper.encodeOrDefault(Nil)(() => Left(""), Right(expected)) == Right(expected)
+          )
         }
       ),
       suite("for a case class")(
@@ -68,9 +173,13 @@ object FieldEncoderSpec extends ZIOSpecDefault {
             withExplicitNulls = false,
             withExplicitEmptyCollections = true
           )
-          var called = false
-          helper.encodeOrSkip(Test(Nil, None))(() => called = true)
-          assertTrue(called)
+          val expected = Chunk(("a", Json.Bool.True))
+          assertTrue(
+            helper.encodeOrDefault(Test(Nil, None))(
+              () => Right(expected),
+              Left("")
+            ) == Right(expected)
+          )
         },
         test("should not encode case classes with empty collections when withExplicitEmptyCollections is false") {
           case class Test(list: List[Int], option: Option[Int])
@@ -81,9 +190,10 @@ object FieldEncoderSpec extends ZIOSpecDefault {
             withExplicitNulls = false,
             withExplicitEmptyCollections = false
           )
-          var called = false
-          helper.encodeOrSkip(Test(Nil, None))(() => called = true)
-          assertTrue(!called)
+          val expected = Chunk(("a", Json.Bool.True))
+          assertTrue(
+            helper.encodeOrDefault(Test(Nil, None))(() => Left(""), Right(expected)) == Right(expected)
+          )
         },
         test(
           "should also not encode case classes with empty options when withExplicitEmptyCollections is false, even when withExplicitNulls is true"
@@ -96,9 +206,13 @@ object FieldEncoderSpec extends ZIOSpecDefault {
             withExplicitNulls = true,
             withExplicitEmptyCollections = false
           )
-          var called = false
-          helper.encodeOrSkip(Test(Nil, None))(() => called = true)
-          assertTrue(!called)
+          val expected = Chunk(("a", Json.Bool.True))
+          assertTrue(
+            helper.encodeOrDefault(Test(Nil, None))(
+              () => Left(""),
+              Right(expected)
+            ) == Right(expected)
+          )
         }
       )
     )


### PR DESCRIPTION
A retry of the `explicitEmptyCollections` feature. The defaults should be exactly as the current release (decoding missing collections will fail). 

To tap in on the feature use annotation `@jsonExplicitEmptyCollections(false)` on fields or case classes or use the `JsonCodecConfiguration.explicitEmptyCollections = false` config. 
After this, all collections and case classes which have empty values will be omitted from the json output and decoding will fill in the missing values with empty collections. 

To implement this while keeping performance I introduced three new decoder traits (scope private[json]), to allow to build an efficient decoder. (`CollectionJsonDecoder`, `OptionJsonDecoder`, `MappedJsonDecoder`).