### PR TITLE
Add both variants

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -59,6 +59,26 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
    */
   final def <*[B](that: => JsonDecoder[B]): JsonDecoder[A] = self.zipLeft(that)
 
+  final def both[B](that: => JsonDecoder[B]): JsonDecoder[(A, B)] =
+    bothWith(that)((a, b) => (a, b))
+
+  final def bothRight[B](that: => JsonDecoder[B]): JsonDecoder[B] =
+    bothWith(that)((_, b) => b)
+
+  final def bothLeft[B](that: => JsonDecoder[B]): JsonDecoder[A] =
+    bothWith(that)((a, _) => a)
+
+  final def bothWith[B, C](that: => JsonDecoder[B])(f: (A, B) => C): JsonDecoder[C] =
+    new JsonDecoder[C] {
+      override def unsafeDecode(trace: List[JsonError], in: RetractReader): C = {
+        val in2 = new WithRecordingReader(in, 64)
+        val a   = self.unsafeDecode(trace, in2)
+        in2.rewind()
+        val b = that.unsafeDecode(trace, in2)
+        f(a, b)
+      }
+    }
+
   /**
    * Attempts to decode a value of type `A` from the specified `CharSequence`, but may fail with a human-readable error
    * message if the provided text does not encode a value of this type.

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -491,6 +491,19 @@ object DecoderSpec extends ZIOSpecDefault {
               )
             )
           )
+        },
+        test("bothWith") {
+          final case class Foo(a: Int)
+          final case class Bar(b: String)
+
+          val fooDecoder: JsonDecoder[Foo]                       = DeriveJsonDecoder.gen
+          val barDecoder: JsonDecoder[Bar]                       = DeriveJsonDecoder.gen
+          implicit val fooAndBarDecoder: JsonDecoder[(Foo, Bar)] = fooDecoder.both(barDecoder)
+
+          val json = """{"a": 1, "b": "foo"}"""
+          assertTrue(
+            json.fromJson[(Foo, Bar)] == Right((Foo(1), Bar("foo")))
+          )
         }
       ),
       suite("fromJsonAST")(


### PR DESCRIPTION
A spiritual successor to #893

Adds an operator called `bothWith` as well as the derived variants of `both`, `bothLeft` and `bothRight`. I'm open to other possible namings like `and` or `combine` as well.