### PR TITLE
Remove redundant dependencies for runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies ++= Seq(
       "dev.zio"                               %%% "zio"                     % zioVersion,
       "dev.zio"                               %%% "zio-streams"             % zioVersion,
-      "org.scala-lang.modules"                %%% "scala-collection-compat" % "2.12.0",
+      "org.scala-lang.modules"                %%% "scala-collection-compat" % "2.13.0"     % "test",
       "dev.zio"                               %%% "zio-test"                % zioVersion   % "test",
       "dev.zio"                               %%% "zio-test-sbt"            % zioVersion   % "test",
       "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core"     % "2.33.0"     % "test",
@@ -220,13 +220,14 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .jsSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time"      % scalaJavaTimeVersion,
-      "io.github.cquiroz" %%% "scala-java-time-tzdb" % scalaJavaTimeVersion
+      "io.github.cquiroz" %%% "scala-java-time-tzdb" % scalaJavaTimeVersion % "test"
     )
   )
   .nativeSettings(nativeSettings)
   .nativeSettings(
     libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion
+      "io.github.cquiroz" %%% "scala-java-time"      % scalaJavaTimeVersion,
+      "io.github.cquiroz" %%% "scala-java-time-tzdb" % scalaJavaTimeVersion % "test"
     )
   )
   .enablePlugins(BuildInfoPlugin)
@@ -262,10 +263,11 @@ lazy val zioJsonYaml = project
   .settings(buildInfoSettings("zio.json.yaml"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.yaml" % "snakeyaml"    % "2.3",
-      "dev.zio" %% "zio"          % zioVersion,
-      "dev.zio" %% "zio-test"     % zioVersion % "test",
-      "dev.zio" %% "zio-test-sbt" % zioVersion % "test"
+      "org.yaml"                % "snakeyaml"               % "2.3",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.13.0",
+      "dev.zio"                %% "zio"                     % zioVersion,
+      "dev.zio"                %% "zio-test"                % zioVersion % "test",
+      "dev.zio"                %% "zio-test-sbt"            % zioVersion % "test"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
   )

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,14 @@ In order to use this library, we need to add the following line in our `build.sb
 libraryDependencies += "dev.zio" %% "zio-json" % "@VERSION@"
 ```
 
+For cross-platform projects with Scala.js and Scala Native need to replace `%%` operator by `%%%`, 
+and optionally when using `java.time.ZoneId` and `java.time.ZonedDateTime` types need to add 
+the dependency on the latest version of Timezone DB:
+
+```scala
+libraryDependencies += "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.6.0"
+```
+
 ## Example
 
 Let's try a simple example of encoding and decoding JSON using ZIO JSON.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ and optionally when using `java.time.ZoneId` and `java.time.ZonedDateTime` types
 the dependency on the latest version of Timezone DB:
 
 ```scala
-libraryDependencies += "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.6.0"
+libraryDependencies += "io.github.cquiroz" %%% "scala-java-time-tzdb" % "latest.integration"
 ```
 
 ## Example


### PR DESCRIPTION
Moving `scala-java-time-tzdb` out from the runtime scope because it is huge and needed only for users of `ZoneId` and `ZonedDateTime` types:

https://repo1.maven.org/maven2/io/github/cquiroz/scala-java-time-tzdb_sjs1_3/2.6.0/

Also, `scala-collection-compat` is required only for `zio-json-yaml`.