### PR TITLE
More efficient parsing of floats and doubles

### DIFF
--- a/zio-json/js/src/main/scala/zio/json/internal/SafeNumbers.scala
+++ b/zio-json/js/src/main/scala/zio/json/internal/SafeNumbers.scala
@@ -42,41 +42,41 @@ object SafeNumbers {
 
   def byte(num: String): ByteOption =
     try ByteSome(UnsafeNumbers.byte(num))
-    catch { case UnsafeNumber => ByteNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => ByteNone }
 
   def short(num: String): ShortOption =
     try ShortSome(UnsafeNumbers.short(num))
-    catch { case UnsafeNumber => ShortNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => ShortNone }
 
   def int(num: String): IntOption =
     try IntSome(UnsafeNumbers.int(num))
-    catch { case UnsafeNumber => IntNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => IntNone }
 
   def long(num: String): LongOption =
     try LongSome(UnsafeNumbers.long(num))
-    catch { case UnsafeNumber => LongNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => LongNone }
 
   def bigInteger(
     num: String,
     max_bits: Int = 128
   ): Option[java.math.BigInteger] =
     try Some(UnsafeNumbers.bigInteger(num, max_bits))
-    catch { case UnsafeNumber => None }
+    catch { case _: UnexpectedEnd | UnsafeNumber => None }
 
   def float(num: String, max_bits: Int = 128): FloatOption =
     try FloatSome(UnsafeNumbers.float(num, max_bits))
-    catch { case UnsafeNumber => FloatNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => FloatNone }
 
   def double(num: String, max_bits: Int = 128): DoubleOption =
     try DoubleSome(UnsafeNumbers.double(num, max_bits))
-    catch { case UnsafeNumber => DoubleNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => DoubleNone }
 
   def bigDecimal(
     num: String,
     max_bits: Int = 128
   ): Option[java.math.BigDecimal] =
     try Some(UnsafeNumbers.bigDecimal(num, max_bits))
-    catch { case UnsafeNumber => None }
+    catch { case _: UnexpectedEnd | UnsafeNumber => None }
 
   // Based on the amazing work of Raffaello Giulietti
   // "The Schubfach way to render doubles": https://drive.google.com/file/d/1luHhyQF9zKlM8yJ1nebU0OgVYhfC6CBN/view

--- a/zio-json/jvm/src/main/scala/zio/json/internal/SafeNumbers.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/internal/SafeNumbers.scala
@@ -42,41 +42,41 @@ object SafeNumbers {
 
   def byte(num: String): ByteOption =
     try ByteSome(UnsafeNumbers.byte(num))
-    catch { case UnsafeNumber => ByteNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => ByteNone }
 
   def short(num: String): ShortOption =
     try ShortSome(UnsafeNumbers.short(num))
-    catch { case UnsafeNumber => ShortNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => ShortNone }
 
   def int(num: String): IntOption =
     try IntSome(UnsafeNumbers.int(num))
-    catch { case UnsafeNumber => IntNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => IntNone }
 
   def long(num: String): LongOption =
     try LongSome(UnsafeNumbers.long(num))
-    catch { case UnsafeNumber => LongNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => LongNone }
 
   def bigInteger(
     num: String,
     max_bits: Int = 128
   ): Option[java.math.BigInteger] =
     try Some(UnsafeNumbers.bigInteger(num, max_bits))
-    catch { case UnsafeNumber => None }
+    catch { case _: UnexpectedEnd | UnsafeNumber => None }
 
   def float(num: String, max_bits: Int = 128): FloatOption =
     try FloatSome(UnsafeNumbers.float(num, max_bits))
-    catch { case UnsafeNumber => FloatNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => FloatNone }
 
   def double(num: String, max_bits: Int = 128): DoubleOption =
     try DoubleSome(UnsafeNumbers.double(num, max_bits))
-    catch { case UnsafeNumber => DoubleNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => DoubleNone }
 
   def bigDecimal(
     num: String,
     max_bits: Int = 128
   ): Option[java.math.BigDecimal] =
     try Some(UnsafeNumbers.bigDecimal(num, max_bits))
-    catch { case UnsafeNumber => None }
+    catch { case _: UnexpectedEnd | UnsafeNumber => None }
 
   // Based on the amazing work of Raffaello Giulietti
   // "The Schubfach way to render doubles": https://drive.google.com/file/d/1luHhyQF9zKlM8yJ1nebU0OgVYhfC6CBN/view

--- a/zio-json/native/src/main/scala/zio/json/internal/SafeNumbers.scala
+++ b/zio-json/native/src/main/scala/zio/json/internal/SafeNumbers.scala
@@ -42,41 +42,41 @@ object SafeNumbers {
 
   def byte(num: String): ByteOption =
     try ByteSome(UnsafeNumbers.byte(num))
-    catch { case UnsafeNumber => ByteNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => ByteNone }
 
   def short(num: String): ShortOption =
     try ShortSome(UnsafeNumbers.short(num))
-    catch { case UnsafeNumber => ShortNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => ShortNone }
 
   def int(num: String): IntOption =
     try IntSome(UnsafeNumbers.int(num))
-    catch { case UnsafeNumber => IntNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => IntNone }
 
   def long(num: String): LongOption =
     try LongSome(UnsafeNumbers.long(num))
-    catch { case UnsafeNumber => LongNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => LongNone }
 
   def bigInteger(
     num: String,
     max_bits: Int = 128
   ): Option[java.math.BigInteger] =
     try Some(UnsafeNumbers.bigInteger(num, max_bits))
-    catch { case UnsafeNumber => None }
+    catch { case _: UnexpectedEnd | UnsafeNumber => None }
 
   def float(num: String, max_bits: Int = 128): FloatOption =
     try FloatSome(UnsafeNumbers.float(num, max_bits))
-    catch { case UnsafeNumber => FloatNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => FloatNone }
 
   def double(num: String, max_bits: Int = 128): DoubleOption =
     try DoubleSome(UnsafeNumbers.double(num, max_bits))
-    catch { case UnsafeNumber => DoubleNone }
+    catch { case _: UnexpectedEnd | UnsafeNumber => DoubleNone }
 
   def bigDecimal(
     num: String,
     max_bits: Int = 128
   ): Option[java.math.BigDecimal] =
     try Some(UnsafeNumbers.bigDecimal(num, max_bits))
-    catch { case UnsafeNumber => None }
+    catch { case _: UnexpectedEnd | UnsafeNumber => None }
 
   // Based on the amazing work of Raffaello Giulietti
   // "The Schubfach way to render doubles": https://drive.google.com/file/d/1luHhyQF9zKlM8yJ1nebU0OgVYhfC6CBN/view

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -285,9 +285,7 @@ object Lexer {
     }
   }
 
-  def byte(trace: List[JsonError], in: RetractReader): Byte = {
-    in.nextNonWhitespace()
-    in.retract()
+  def byte(trace: List[JsonError], in: RetractReader): Byte =
     try {
       val i = UnsafeNumbers.byte_(in, false)
       in.retract()
@@ -295,11 +293,8 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error("expected a Byte", trace)
     }
-  }
 
-  def short(trace: List[JsonError], in: RetractReader): Short = {
-    in.nextNonWhitespace()
-    in.retract()
+  def short(trace: List[JsonError], in: RetractReader): Short =
     try {
       val i = UnsafeNumbers.short_(in, false)
       in.retract()
@@ -307,11 +302,8 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error("expected a Short", trace)
     }
-  }
 
-  def int(trace: List[JsonError], in: RetractReader): Int = {
-    in.nextNonWhitespace()
-    in.retract()
+  def int(trace: List[JsonError], in: RetractReader): Int =
     try {
       val i = UnsafeNumbers.int_(in, false)
       in.retract()
@@ -319,11 +311,8 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error("expected an Int", trace)
     }
-  }
 
-  def long(trace: List[JsonError], in: RetractReader): Long = {
-    in.nextNonWhitespace()
-    in.retract()
+  def long(trace: List[JsonError], in: RetractReader): Long =
     try {
       val i = UnsafeNumbers.long_(in, false)
       in.retract()
@@ -331,14 +320,11 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error("expected a Long", trace)
     }
-  }
 
   def bigInteger(
     trace: List[JsonError],
     in: RetractReader
-  ): java.math.BigInteger = {
-    in.nextNonWhitespace()
-    in.retract()
+  ): java.math.BigInteger =
     try {
       val i = UnsafeNumbers.bigInteger_(in, false, NumberMaxBits)
       in.retract()
@@ -346,11 +332,8 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error(s"expected a $NumberMaxBits bit BigInteger", trace)
     }
-  }
 
-  def float(trace: List[JsonError], in: RetractReader): Float = {
-    in.nextNonWhitespace()
-    in.retract()
+  def float(trace: List[JsonError], in: RetractReader): Float =
     try {
       val i = UnsafeNumbers.float_(in, false, NumberMaxBits)
       in.retract()
@@ -358,11 +341,8 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error("expected a Float", trace)
     }
-  }
 
-  def double(trace: List[JsonError], in: RetractReader): Double = {
-    in.nextNonWhitespace()
-    in.retract()
+  def double(trace: List[JsonError], in: RetractReader): Double =
     try {
       val i = UnsafeNumbers.double_(in, false, NumberMaxBits)
       in.retract()
@@ -370,14 +350,11 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error("expected a Double", trace)
     }
-  }
 
   def bigDecimal(
     trace: List[JsonError],
     in: RetractReader
-  ): java.math.BigDecimal = {
-    in.nextNonWhitespace()
-    in.retract()
+  ): java.math.BigDecimal =
     try {
       val i = UnsafeNumbers.bigDecimal_(in, false, NumberMaxBits)
       in.retract()
@@ -385,7 +362,6 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error(s"expected a $NumberMaxBits BigDecimal", trace)
     }
-  }
 
   // optional whitespace and then an expected character
   @inline def char(trace: List[JsonError], in: OneCharReader, c: Char): Unit = {

--- a/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
@@ -15,7 +15,6 @@
  */
 package zio.json.internal
 
-import java.io._
 import scala.util.control.NoStackTrace
 
 // specialised Options to avoid boxing. Prefer .isEmpty guarded access to .value
@@ -25,10 +24,12 @@ sealed abstract class ByteOption {
   def isEmpty: Boolean
   def value: Byte
 }
+
 case object ByteNone extends ByteOption {
   def isEmpty     = true
   def value: Byte = throw new java.util.NoSuchElementException
 }
+
 case class ByteSome(value: Byte) extends ByteOption {
   def isEmpty = false
 }
@@ -37,10 +38,12 @@ sealed abstract class ShortOption {
   def isEmpty: Boolean
   def value: Short
 }
+
 case object ShortNone extends ShortOption {
   def isEmpty      = true
   def value: Short = throw new java.util.NoSuchElementException
 }
+
 case class ShortSome(value: Short) extends ShortOption {
   def isEmpty = false
 }
@@ -49,10 +52,12 @@ sealed abstract class IntOption {
   def isEmpty: Boolean
   def value: Int
 }
+
 case object IntNone extends IntOption {
   def isEmpty    = true
   def value: Int = throw new java.util.NoSuchElementException
 }
+
 case class IntSome(value: Int) extends IntOption {
   def isEmpty = false
 }
@@ -61,10 +66,12 @@ sealed abstract class LongOption {
   def isEmpty: Boolean
   def value: Long
 }
+
 case object LongNone extends LongOption {
   def isEmpty     = true
   def value: Long = throw new java.util.NoSuchElementException
 }
+
 case class LongSome(value: Long) extends LongOption {
   def isEmpty = false
 }
@@ -73,10 +80,12 @@ sealed abstract class FloatOption {
   def isEmpty: Boolean
   def value: Float
 }
+
 case object FloatNone extends FloatOption {
   def isEmpty      = true
   def value: Float = throw new java.util.NoSuchElementException
 }
+
 case class FloatSome(value: Float) extends FloatOption {
   def isEmpty = false
 }
@@ -85,10 +94,12 @@ sealed abstract class DoubleOption {
   def isEmpty: Boolean
   def value: Double
 }
+
 case object DoubleNone extends DoubleOption {
   def isEmpty       = true
   def value: Double = throw new java.util.NoSuchElementException
 }
+
 case class DoubleSome(value: Double) extends DoubleOption {
   def isEmpty = false
 }
@@ -113,42 +124,56 @@ object UnsafeNumbers {
 
   def byte(num: String): Byte =
     byte_(new FastStringReader(num), true)
-  def byte_(in: Reader, consume: Boolean): Byte =
-    int__(in, -128, 127, consume).toByte
+
+  def byte_(in: OneCharReader, consume: Boolean): Byte = {
+    val n = int__(in, consume)
+    if (n < -128 || n > 127) throw UnsafeNumber
+    n.toByte
+  }
 
   def short(num: String): Short =
     short_(new FastStringReader(num), true)
-  def short_(in: Reader, consume: Boolean): Short =
-    int__(in, -32768, 32767, consume).toShort
+
+  def short_(in: OneCharReader, consume: Boolean): Short = {
+    val n = int__(in, consume)
+    if (n < -32768 || n > 32767) throw UnsafeNumber
+    n.toShort
+  }
 
   def int(num: String): Int =
     int_(new FastStringReader(num), true)
-  def int_(in: Reader, consume: Boolean): Int =
-    int__(in, -2147483648, 2147483647, consume).toInt
+
+  def int_(in: OneCharReader, consume: Boolean): Int =
+    int__(in, consume)
 
   def long(num: String): Long =
     long_(new FastStringReader(num), true)
-  def long_(in: Reader, consume: Boolean): Long =
-    long__(in, Long.MinValue, Long.MaxValue, consume)
+
+  def long_(in: OneCharReader, consume: Boolean): Long =
+    long__(in, consume)
 
   def bigInteger(num: String, max_bits: Int): java.math.BigInteger =
     bigInteger_(new FastStringReader(num), true, max_bits)
+
   def bigInteger_(
-    in: Reader,
+    in: OneCharReader,
     consume: Boolean,
     max_bits: Int
   ): java.math.BigInteger = {
-    var current: Int = in.read()
-    val negative     = current == '-'
-    if (negative) current = in.read()
-    if (current == -1) throw UnsafeNumber
+    var current =
+      if (consume) in.readChar()
+      else in.nextNonWhitespace()
+    val negative = current == '-'
+    if (negative) current = in.readChar()
     bigDecimal__(in, consume, negative, current, true, max_bits).unscaledValue
   }
 
-  def int__(in: Reader, lower: Int, upper: Int, consume: Boolean): Int = {
-    var current  = in.read()
+  @inline def int__(in: OneCharReader, consume: Boolean): Int = {
+    var current =
+      if (consume) in.readChar().toInt
+      else in.nextNonWhitespace().toInt
     val negative = current == '-'
-    if (negative) current = in.read()
+    if (negative) current = in.readChar().toInt
     if (current < '0' || current > '9') throw UnsafeNumber
     var accum = '0' - current
     while ({
@@ -163,19 +188,17 @@ object UnsafeNumbers {
       ) throw UnsafeNumber
     }
     if (consume && current != -1) throw UnsafeNumber
-    if (negative) {
-      if (accum < lower) throw UnsafeNumber
-    } else if (accum != -2147483648) {
-      accum = -accum
-      if (upper < accum) throw UnsafeNumber
-    } else throw UnsafeNumber
-    accum
+    if (negative) accum
+    else if (accum != -2147483648) -accum
+    else throw UnsafeNumber
   }
 
-  def long__(in: Reader, lower: Long, upper: Long, consume: Boolean): Long = {
-    var current  = in.read()
+  @inline def long__(in: OneCharReader, consume: Boolean): Long = {
+    var current =
+      if (consume) in.readChar().toInt
+      else in.nextNonWhitespace().toInt
     val negative = current == '-'
-    if (negative) current = in.read()
+    if (negative) current = in.readChar().toInt
     if (current < '0' || current > '9') throw UnsafeNumber
     var accum = ('0' - current).toLong
     while ({
@@ -190,44 +213,34 @@ object UnsafeNumbers {
       ) throw UnsafeNumber
     }
     if (consume && current != -1) throw UnsafeNumber
-    if (negative) {
-      if (accum < lower) throw UnsafeNumber
-    } else if (accum != -9223372036854775808L) {
-      accum = -accum
-      if (upper < accum) throw UnsafeNumber
-    } else throw UnsafeNumber
-    accum
+    if (negative) accum
+    else if (accum != -9223372036854775808L) -accum
+    else throw UnsafeNumber
   }
 
   def float(num: String, max_bits: Int): Float =
     float_(new FastStringReader(num), true, max_bits)
 
-  def float_(in: Reader, consume: Boolean, max_bits: Int): Float = {
-    var current  = in.read()
-    var negative = false
-
+  def float_(in: OneCharReader, consume: Boolean, max_bits: Int): Float = {
+    var current =
+      if (consume) in.readChar()
+      else in.nextNonWhitespace()
     if (current == 'N') {
       readAll(in, "aN", consume)
       return Float.NaN
     }
-
-    negative = current == '-'
-    if (negative) current = in.read()
-
+    val negative = current == '-'
+    if (negative) current = in.readChar()
     if (current == 'I' || current == '+') {
       if (current == '+') {
-        current = in.read()
+        current = in.readChar()
         if (current != 'I') throw UnsafeNumber
       }
       readAll(in, "nfinity", consume)
       if (negative) return Float.NegativeInfinity
       else return Float.PositiveInfinity
     }
-
-    if (current == -1) throw UnsafeNumber
-
     val res = bigDecimal__(in, consume, negative = negative, initial = current, int_only = false, max_bits = max_bits)
-
     if (negative && res.unscaledValue == java.math.BigInteger.ZERO) -0.0f
     else res.floatValue
   }
@@ -235,30 +248,25 @@ object UnsafeNumbers {
   def double(num: String, max_bits: Int): Double =
     double_(new FastStringReader(num), true, max_bits)
 
-  def double_(in: Reader, consume: Boolean, max_bits: Int): Double = {
-    var current  = in.read()
-    var negative = false
-
+  def double_(in: OneCharReader, consume: Boolean, max_bits: Int): Double = {
+    var current =
+      if (consume) in.readChar()
+      else in.nextNonWhitespace()
     if (current == 'N') {
       readAll(in, "aN", consume)
       return Double.NaN
     }
-
-    negative = current == '-'
-    if (negative) current = in.read()
-
+    val negative = current == '-'
+    if (negative) current = in.readChar()
     if (current == 'I' || current == '+') {
       if (current == '+') {
-        current = in.read()
+        current = in.readChar()
         if (current != 'I') throw UnsafeNumber
       }
       readAll(in, "nfinity", consume)
       if (negative) return Double.NegativeInfinity
       else return Double.PositiveInfinity
     }
-
-    if (current == -1) throw UnsafeNumber
-
     // we could avoid going via BigDecimal if we wanted to do something like
     // https://github.com/plokhotnyuk/jsoniter-scala/blob/56ff2a60e28aa27bd4788caf3b1557a558c00fa1/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala#L1395-L1425
     // based on
@@ -275,41 +283,42 @@ object UnsafeNumbers {
     else res.doubleValue
   }
 
-  private[this] def readAll(in: Reader, s: String, consume: Boolean): Unit = {
-    val len        = s.length
-    var i, current = 0
+  private[this] def readAll(in: OneCharReader, s: String, consume: Boolean): Unit = {
+    val len = s.length
+    var i   = 0
     while (i < len) {
-      current = in.read()
-      if (current != s(i)) throw UnsafeNumber
+      if (in.readChar() != s.charAt(i)) throw UnsafeNumber
       i += 1
     }
-    current = in.read() // to be consistent read the terminator
+    val current = in.read() // to be consistent read the terminator
     if (consume && current != -1) throw UnsafeNumber
   }
 
   def bigDecimal(num: String, max_bits: Int): java.math.BigDecimal =
     bigDecimal_(new FastStringReader(num), true, max_bits)
+
   def bigDecimal_(
-    in: Reader,
+    in: OneCharReader,
     consume: Boolean,
     max_bits: Int
   ): java.math.BigDecimal = {
-    var current: Int = in.read()
-    val negative     = current == '-'
-    if (negative) current = in.read()
-    if (current == -1) throw UnsafeNumber
+    var current =
+      if (consume) in.readChar()
+      else in.nextNonWhitespace()
+    val negative = current == '-'
+    if (negative) current = in.readChar()
     bigDecimal__(in, consume, negative, current, false, max_bits)
   }
 
   def bigDecimal__(
-    in: Reader,
+    in: OneCharReader,
     consume: Boolean,
     negative: Boolean,
-    initial: Int,
+    initial: Char,
     int_only: Boolean,
     max_bits: Int
   ): java.math.BigDecimal = {
-    var current: Int = initial
+    var current: Int = initial.toInt
     // record the significand as Long until it overflows, then swap to BigInteger
     var sig: Long                   = -1   // -1 means it hasn't been seen yet
     var sig_ : java.math.BigInteger = null // non-null wins over sig
@@ -324,58 +333,42 @@ object UnsafeNumbers {
         return java.math.BigDecimal.ZERO
     }
 
-    def push_sig(): Unit = {
-      val c = current - '0'
-      // would be nice if there was a fused instruction...
-      if (sig_ != null) {
-        sig_ = sig_
-          .multiply(java.math.BigInteger.TEN)
-          .add(bigIntegers(c))
-        // arbitrary limit on BigInteger size to avoid OOM attacks
-        if (sig_.bitLength >= max_bits)
-          throw UnsafeNumber
-      } else if (sig >= 922337203685477580L)
-        sig_ = java.math.BigInteger
-          .valueOf(sig)
-          .multiply(java.math.BigInteger.TEN)
-          .add(bigIntegers(c))
-      else if (sig < 0) sig = c.toLong
-      else sig = sig * 10 + c
-    }
-
-    def significand() =
-      if (sig <= 0) java.math.BigDecimal.ZERO
-      else {
-        val res =
-          if (sig_ != null)
-            new java.math.BigDecimal(sig_)
-          else
-            new java.math.BigDecimal(sig)
-        if (negative) res.negate else res
-      }
-
     while ('0' <= current && current <= '9') {
-      push_sig()
+      val digit = current - '0'
+      if (sig_ != null) {
+        sig_ = sig_.multiply(java.math.BigInteger.TEN).add(bigIntegers(digit))
+        if (sig_.bitLength >= max_bits) throw UnsafeNumber
+      } else if (sig >= 922337203685477580L)
+        sig_ = java.math.BigInteger.valueOf(sig).multiply(java.math.BigInteger.TEN).add(bigIntegers(digit))
+      else if (sig < 0) sig = digit.toLong
+      else sig = (sig << 3) + (sig << 1) + digit
       current = in.read()
       if (current == -1)
-        return significand()
+        return significand(sig, sig_, negative, 0)
     }
 
     if (int_only) {
-      if (consume && current != -1)
-        throw UnsafeNumber
-      return significand()
+      if (consume && current != -1) throw UnsafeNumber
+      return significand(sig, sig_, negative, 0)
     }
 
     if (current == '.') {
       if (sig < 0) sig = 0 // e.g. ".1" is shorthand for "0.1"
       current = in.read()
       if (current == -1)
-        return significand()
+        return significand(sig, sig_, negative, 0)
       while ('0' <= current && current <= '9') {
         dot += 1
-        if (sig > 0 || current != '0')
-          push_sig()
+        if (sig > 0 || current != '0') {
+          val digit = current - '0'
+          if (sig_ != null) {
+            sig_ = sig_.multiply(java.math.BigInteger.TEN).add(bigIntegers(digit))
+            if (sig_.bitLength >= max_bits) throw UnsafeNumber
+          } else if (sig >= 922337203685477580L)
+            sig_ = java.math.BigInteger.valueOf(sig).multiply(java.math.BigInteger.TEN).add(bigIntegers(digit))
+          else if (sig < 0) sig = digit.toLong
+          else sig = (sig << 3) + (sig << 1) + digit
+        }
         // overflowed...
         if (dot < 0) throw UnsafeNumber
         current = in.read()
@@ -386,37 +379,45 @@ object UnsafeNumbers {
 
     if (current == 'E' || current == 'e') {
       current = in.read()
-      val negative = current == '-'
-      if (negative || current == '+') current = in.read()
+      val negativeExp = current == '-'
+      if (negativeExp || current == '+') current = in.read()
       if (current < '0' || current > '9') throw UnsafeNumber
-      var accum = '0' - current
+      exp = '0' - current
       while ({
         current = in.read()
         '0' <= current && current <= '9'
       }) {
         if (
-          accum < -214748364 || {
-            accum = accum * 10 + ('0' - current)
-            accum > 0
+          exp < -214748364 || {
+            exp = exp * 10 + ('0' - current)
+            exp > 0
           }
         ) throw UnsafeNumber
       }
       if (consume && current != -1) throw UnsafeNumber
-      if (negative) {
-        exp = accum
-      } else if (accum != -2147483648) {
-        exp = -accum
-      } else throw UnsafeNumber
-    } else if (consume && current != -1)
-      throw UnsafeNumber
+      if (negativeExp) {
+      } else if (exp != -2147483648) exp = -exp
+      else throw UnsafeNumber
+    } else if (consume && current != -1) throw UnsafeNumber
 
-    val scale = if (dot < 1) exp else exp - dot
-    val res   = significand()
-    if (scale != 0)
-      res.scaleByPowerOfTen(scale)
-    else
-      res
+    significand(sig, sig_, negative, {
+      if (dot < 1) -exp
+      else dot - exp
+    })
   }
+
+  private[this] def significand(sig: Long, sig_ : java.math.BigInteger, negative: Boolean, scale: Int): java.math.BigDecimal =
+    if (sig <= 0) java.math.BigDecimal.ZERO
+    else if (sig_ != null) {
+      new java.math.BigDecimal({
+        if (negative) sig_.negate
+        else sig_
+      }, scale)
+    } else java.math.BigDecimal.valueOf({
+      if (negative) -sig
+      else sig
+    }, scale)
+
   // note that bigDecimal does not have a negative zero
   private[this] val bigIntegers: Array[java.math.BigInteger] =
     (0L to 9L).map(java.math.BigInteger.valueOf).toArray

--- a/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
@@ -126,7 +126,7 @@ object UnsafeNumbers {
     byte_(new FastStringReader(num), true)
 
   def byte_(in: OneCharReader, consume: Boolean): Byte = {
-    val n = int__(in, consume)
+    val n = int_(in, consume)
     if (n < -128 || n > 127) throw UnsafeNumber
     n.toByte
   }
@@ -135,7 +135,7 @@ object UnsafeNumbers {
     short_(new FastStringReader(num), true)
 
   def short_(in: OneCharReader, consume: Boolean): Short = {
-    val n = int__(in, consume)
+    val n = int_(in, consume)
     if (n < -32768 || n > 32767) throw UnsafeNumber
     n.toShort
   }
@@ -143,14 +143,8 @@ object UnsafeNumbers {
   def int(num: String): Int =
     int_(new FastStringReader(num), true)
 
-  def int_(in: OneCharReader, consume: Boolean): Int =
-    int__(in, consume)
-
   def long(num: String): Long =
     long_(new FastStringReader(num), true)
-
-  def long_(in: OneCharReader, consume: Boolean): Long =
-    long__(in, consume)
 
   def bigInteger(num: String, max_bits: Int): java.math.BigInteger =
     bigInteger_(new FastStringReader(num), true, max_bits)
@@ -168,7 +162,7 @@ object UnsafeNumbers {
     bigDecimal__(in, consume, negative, current, true, max_bits).unscaledValue
   }
 
-  @inline def int__(in: OneCharReader, consume: Boolean): Int = {
+  def int_(in: OneCharReader, consume: Boolean): Int = {
     var current =
       if (consume) in.readChar().toInt
       else in.nextNonWhitespace().toInt
@@ -193,7 +187,7 @@ object UnsafeNumbers {
     else throw UnsafeNumber
   }
 
-  @inline def long__(in: OneCharReader, consume: Boolean): Long = {
+  def long_(in: OneCharReader, consume: Boolean): Long = {
     var current =
       if (consume) in.readChar().toInt
       else in.nextNonWhitespace().toInt
@@ -395,28 +389,41 @@ object UnsafeNumbers {
         ) throw UnsafeNumber
       }
       if (consume && current != -1) throw UnsafeNumber
-      if (negativeExp) {
-      } else if (exp != -2147483648) exp = -exp
+      if (negativeExp) {}
+      else if (exp != -2147483648) exp = -exp
       else throw UnsafeNumber
     } else if (consume && current != -1) throw UnsafeNumber
 
-    significand(sig, sig_, negative, {
+    significand(
+      sig,
+      sig_,
+      negative,
       if (dot < 1) -exp
       else dot - exp
-    })
+    )
   }
 
-  private[this] def significand(sig: Long, sig_ : java.math.BigInteger, negative: Boolean, scale: Int): java.math.BigDecimal =
+  @inline private[this] def significand(
+    sig: Long,
+    sig_ : java.math.BigInteger,
+    negative: Boolean,
+    scale: Int
+  ): java.math.BigDecimal =
     if (sig <= 0) java.math.BigDecimal.ZERO
     else if (sig_ != null) {
-      new java.math.BigDecimal({
-        if (negative) sig_.negate
-        else sig_
-      }, scale)
-    } else java.math.BigDecimal.valueOf({
-      if (negative) -sig
-      else sig
-    }, scale)
+      new java.math.BigDecimal(
+        {
+          if (negative) sig_.negate
+          else sig_
+        },
+        scale
+      )
+    } else
+      java.math.BigDecimal.valueOf(
+        if (negative) -sig
+        else sig,
+        scale
+      )
 
   // note that bigDecimal does not have a negative zero
   private[this] val bigIntegers: Array[java.math.BigInteger] =

--- a/zio-json/shared/src/test/scala/zio/json/internal/SafeNumbersSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/internal/SafeNumbersSpec.scala
@@ -41,11 +41,7 @@ object SafeNumbersSpec extends ZIOSpecDefault {
         )
 
         check(Gen.fromIterable(invalidBigDecimalEdgeCases)) { s =>
-          assert(SafeNumbers.bigDecimal(s).map(_.toString))(
-            isSome(
-              equalTo((new java.math.BigDecimal(s)).toString)
-            )
-          )
+          assert(SafeNumbers.bigDecimal(s).get.compareTo(new java.math.BigDecimal(s)))(equalTo(0))
         }
       },
       test("invalid BigDecimal text") {
@@ -65,7 +61,7 @@ object SafeNumbersSpec extends ZIOSpecDefault {
         check(Gen.fromIterable(inputs)) { s =>
           assert(SafeNumbers.bigInteger(s))(
             isSome(
-              equalTo((new java.math.BigInteger(s)))
+              equalTo(new java.math.BigInteger(s))
             )
           )
         }
@@ -202,6 +198,19 @@ object SafeNumbersSpec extends ZIOSpecDefault {
         test("valid") {
           check(Gen.int)(d => assert(SafeNumbers.int(d.toString))(equalTo(IntSome(d))))
         },
+        test("invalid (edge cases)") {
+          val input = List(
+            "1e3",
+            "1E-2",
+            "0.1",
+            "",
+            "1 ",
+            "-2147483649",
+            "2147483648"
+          )
+
+          check(Gen.fromIterable(input))(x => assert(SafeNumbers.int(x))(equalTo(IntNone)))
+        },
         test("invalid (out of range)") {
           check(Gen.long.filter(i => i < Int.MinValue || i > Int.MaxValue))(d =>
             assert(SafeNumbers.int(d.toString))(equalTo(IntNone))
@@ -217,10 +226,10 @@ object SafeNumbersSpec extends ZIOSpecDefault {
 
           check(Gen.fromIterable(input))(x => assert(SafeNumbers.long(x))(equalTo(LongSome(x.toLong))))
         },
-        test("in valid edge cases") {
+        test("invalid (edge cases)") {
           val input = List(
-            "0foo",
-            "01foo",
+            "1e3foo",
+            "1E-2",
             "0.1",
             "",
             "1 ",


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                          (size)   Mode  Cnt        Score       Error  Units
ArrayOfDoublesReading.zioJson         128  thrpt    5   135920.917 ±  2255.318  ops/s
ArrayOfFloatsReading.zioJson          128  thrpt    5   213677.601 ±  5056.059  ops/s
GeoJSONReading.zioJson                N/A  thrpt    5     9315.513 ±   271.037  ops/s
PrimitivesReading.zioJson             N/A  thrpt    5  3515039.119 ± 21043.374  ops/s
```

#### After
```txt
Benchmark                          (size)   Mode  Cnt        Score       Error  Units
ArrayOfDoublesReading.zioJson         128  thrpt    5   149040.245 ±  1606.733  ops/s
ArrayOfFloatsReading.zioJson          128  thrpt    5   233975.363 ± 28846.808  ops/s
GeoJSONReading.zioJson                N/A  thrpt    5    10582.132 ±   139.006  ops/s
PrimitivesReading.zioJson             N/A  thrpt    5  3618949.962 ± 74998.630  ops/s
```