### PR TITLE
More efficient decoding of chars

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -309,11 +309,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
   }
 
   implicit val char: JsonDecoder[Char] = new JsonDecoder[Char] {
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): Char = {
-      val s = Lexer.string(trace, in)
-      if (s.length == 1) s.charAt(0)
-      else Lexer.error("expected single character string", trace)
-    }
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): Char = Lexer.char(trace, in)
 
     override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): Char =
       json match {

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -250,6 +250,30 @@ object Lexer {
     sb.buffer
   }
 
+  def char(trace: List[JsonError], in: OneCharReader): Char = {
+    var c = in.nextNonWhitespace()
+    if (c != '"') error("'\"'", c, trace)
+    c = in.readChar()
+    if (c == '"') error("expected single character string", trace)
+    else if (c == '\\') {
+      (in.readChar(): @switch) match {
+        case '"'  => c = '"'
+        case '\\' => c = '\\'
+        case '/'  => c = '/'
+        case 'b'  => c = '\b'
+        case 'f'  => c = '\f'
+        case 'n'  => c = '\n'
+        case 'r'  => c = '\r'
+        case 't'  => c = '\t'
+        case 'u'  => c = nextHex4(trace, in)
+        case _    => error(c, trace)
+      }
+    } else if (c < ' ') error("invalid control in string", trace)
+    val c1 = in.readChar()
+    if (c1 != '"') error("expected single character string", trace)
+    c
+  }
+
   // consumes 4 hex characters after current
   @noinline
   def nextHex4(trace: List[JsonError], in: OneCharReader): Char = {


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                    (size)   Mode  Cnt        Score        Error  Units
ArrayOfCharsReading.zioJson     128  thrpt    5   701886.408 ±  10380.529  ops/s
```

#### After
```txt
Benchmark                    (size)   Mode  Cnt        Score       Error  Units
ArrayOfCharsReading.zioJson     128  thrpt    5  1869367.626 ± 13808.736  ops/s
```