### PR TITLE
More efficient decoding of floats and doubles

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/numbers.scala
@@ -143,31 +143,12 @@ object UnsafeNumbers {
   def int(num: String): Int =
     int_(new FastStringReader(num), true)
 
-  def long(num: String): Long =
-    long_(new FastStringReader(num), true)
-
-  def bigInteger(num: String, max_bits: Int): java.math.BigInteger =
-    bigInteger_(new FastStringReader(num), true, max_bits)
-
-  def bigInteger_(
-    in: OneCharReader,
-    consume: Boolean,
-    max_bits: Int
-  ): java.math.BigInteger = {
-    var current =
-      if (consume) in.readChar()
-      else in.nextNonWhitespace()
-    val negative = current == '-'
-    if (negative) current = in.readChar()
-    bigDecimal__(in, consume, negative, current, true, max_bits).unscaledValue
-  }
-
   def int_(in: OneCharReader, consume: Boolean): Int = {
     var current =
       if (consume) in.readChar().toInt
       else in.nextNonWhitespace().toInt
-    val negative = current == '-'
-    if (negative) current = in.readChar().toInt
+    val negate = current == '-'
+    if (negate) current = in.readChar().toInt
     if (current < '0' || current > '9') throw UnsafeNumber
     var accum = '0' - current
     while ({
@@ -182,17 +163,20 @@ object UnsafeNumbers {
       ) throw UnsafeNumber
     }
     if (consume && current != -1) throw UnsafeNumber
-    if (negative) accum
+    if (negate) accum
     else if (accum != -2147483648) -accum
     else throw UnsafeNumber
   }
+
+  def long(num: String): Long =
+    long_(new FastStringReader(num), true)
 
   def long_(in: OneCharReader, consume: Boolean): Long = {
     var current =
       if (consume) in.readChar().toInt
       else in.nextNonWhitespace().toInt
-    val negative = current == '-'
-    if (negative) current = in.readChar().toInt
+    val negate = current == '-'
+    if (negate) current = in.readChar().toInt
     if (current < '0' || current > '9') throw UnsafeNumber
     var accum = ('0' - current).toLong
     while ({
@@ -207,9 +191,41 @@ object UnsafeNumbers {
       ) throw UnsafeNumber
     }
     if (consume && current != -1) throw UnsafeNumber
-    if (negative) accum
+    if (negate) accum
     else if (accum != -9223372036854775808L) -accum
     else throw UnsafeNumber
+  }
+
+  def bigInteger(num: String, max_bits: Int): java.math.BigInteger =
+    bigInteger_(new FastStringReader(num), true, max_bits)
+
+  def bigInteger_(in: OneCharReader, consume: Boolean, max_bits: Int): java.math.BigInteger = {
+    var current =
+      if (consume) in.readChar().toInt
+      else in.nextNonWhitespace().toInt
+    val negate = current == '-'
+    if (negate) current = in.readChar().toInt
+    if (current < '0' || current > '9') throw UnsafeNumber
+    var bigSig: java.math.BigInteger = null
+    var sig                          = (current - '0').toLong
+    while ({
+      current = in.read()
+      '0' <= current && current <= '9'
+    }) {
+      if (sig < 922337203685477580L) sig = (sig << 3) + (sig << 1) + (current - '0')
+      else {
+        if (bigSig eq null) bigSig = java.math.BigInteger.valueOf(sig)
+        bigSig = bigSig.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
+        if (bigSig.bitLength >= max_bits) throw UnsafeNumber
+      }
+    }
+    if (consume && current != -1) throw UnsafeNumber
+    if (bigSig eq null) {
+      if (negate) sig = -sig
+      return java.math.BigInteger.valueOf(sig)
+    }
+    if (negate) bigSig = bigSig.negate
+    bigSig
   }
 
   def float(num: String, max_bits: Int): Float =
@@ -217,164 +233,60 @@ object UnsafeNumbers {
 
   def float_(in: OneCharReader, consume: Boolean, max_bits: Int): Float = {
     var current =
-      if (consume) in.readChar()
-      else in.nextNonWhitespace()
+      if (consume) in.readChar().toInt
+      else in.nextNonWhitespace().toInt
     if (current == 'N') {
       readAll(in, "aN", consume)
       return Float.NaN
     }
-    val negative = current == '-'
-    if (negative) current = in.readChar()
+    val negate = current == '-'
+    if (negate) current = in.readChar().toInt
     if (current == 'I' || current == '+') {
       if (current == '+') {
-        current = in.readChar()
+        current = in.readChar().toInt
         if (current != 'I') throw UnsafeNumber
       }
       readAll(in, "nfinity", consume)
-      if (negative) return Float.NegativeInfinity
-      else return Float.PositiveInfinity
+      return if (negate) Float.NegativeInfinity else Float.PositiveInfinity
     }
-    val res = bigDecimal__(in, consume, negative = negative, initial = current, int_only = false, max_bits = max_bits)
-    if (negative && res.unscaledValue == java.math.BigInteger.ZERO) -0.0f
-    else res.floatValue
-  }
-
-  def double(num: String, max_bits: Int): Double =
-    double_(new FastStringReader(num), true, max_bits)
-
-  def double_(in: OneCharReader, consume: Boolean, max_bits: Int): Double = {
-    var current =
-      if (consume) in.readChar()
-      else in.nextNonWhitespace()
-    if (current == 'N') {
-      readAll(in, "aN", consume)
-      return Double.NaN
-    }
-    val negative = current == '-'
-    if (negative) current = in.readChar()
-    if (current == 'I' || current == '+') {
-      if (current == '+') {
-        current = in.readChar()
-        if (current != 'I') throw UnsafeNumber
-      }
-      readAll(in, "nfinity", consume)
-      if (negative) return Double.NegativeInfinity
-      else return Double.PositiveInfinity
-    }
-    // we could avoid going via BigDecimal if we wanted to do something like
-    // https://github.com/plokhotnyuk/jsoniter-scala/blob/56ff2a60e28aa27bd4788caf3b1557a558c00fa1/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonReader.scala#L1395-L1425
-    // based on
-    // https://www.reddit.com/r/rust/comments/a6j5j1/making_rust_float_parsing_fast_and_correct
-    //
-    // the fallback of .doubleValue tends to call out to parseDouble which
-    // ultimately uses strtod from the system libraries and they may loop until
-    // the answer converges
-    // https://github.com/rust-lang/rust/pull/27307/files#diff-fe6c36003393c49bf7e5c413458d6d9cR43-R84
-    val res = bigDecimal__(in, consume, negative, current, false, max_bits)
-    // BigDecimal doesn't have a negative zero, so we need to apply manually
-    if (negative && res.unscaledValue == java.math.BigInteger.ZERO) -0.0
-    // TODO implement Algorithm M or Bigcomp and avoid going via BigDecimal
-    else res.doubleValue
-  }
-
-  private[this] def readAll(in: OneCharReader, s: String, consume: Boolean): Unit = {
-    val len = s.length
-    var i   = 0
-    while (i < len) {
-      if (in.readChar() != s.charAt(i)) throw UnsafeNumber
-      i += 1
-    }
-    val current = in.read() // to be consistent read the terminator
-    if (consume && current != -1) throw UnsafeNumber
-  }
-
-  def bigDecimal(num: String, max_bits: Int): java.math.BigDecimal =
-    bigDecimal_(new FastStringReader(num), true, max_bits)
-
-  def bigDecimal_(
-    in: OneCharReader,
-    consume: Boolean,
-    max_bits: Int
-  ): java.math.BigDecimal = {
-    var current =
-      if (consume) in.readChar()
-      else in.nextNonWhitespace()
-    val negative = current == '-'
-    if (negative) current = in.readChar()
-    bigDecimal__(in, consume, negative, current, false, max_bits)
-  }
-
-  def bigDecimal__(
-    in: OneCharReader,
-    consume: Boolean,
-    negative: Boolean,
-    initial: Char,
-    int_only: Boolean,
-    max_bits: Int
-  ): java.math.BigDecimal = {
-    var current: Int = initial.toInt
-    // record the significand as Long until it overflows, then swap to BigInteger
-    var sig: Long                   = -1   // -1 means it hasn't been seen yet
-    var sig_ : java.math.BigInteger = null // non-null wins over sig
-    var dot: Int                    = 0    // counts from the right
-    var exp: Int                    = 0    // implied
-
-    // skip trailing zero on the left
-    while (current == '0') {
-      sig = 0
-      current = in.read()
-      if (current == -1)
-        return java.math.BigDecimal.ZERO
-    }
-
-    while ('0' <= current && current <= '9') {
-      val digit = current - '0'
-      if (sig_ != null) {
-        sig_ = sig_.multiply(java.math.BigInteger.TEN).add(bigIntegers(digit))
-        if (sig_.bitLength >= max_bits) throw UnsafeNumber
-      } else if (sig >= 922337203685477580L)
-        sig_ = java.math.BigInteger.valueOf(sig).multiply(java.math.BigInteger.TEN).add(bigIntegers(digit))
-      else if (sig < 0) sig = digit.toLong
-      else sig = (sig << 3) + (sig << 1) + digit
-      current = in.read()
-      if (current == -1)
-        return significand(sig, sig_, negative, 0)
-    }
-
-    if (int_only) {
-      if (consume && current != -1) throw UnsafeNumber
-      return significand(sig, sig_, negative, 0)
-    }
-
-    if (current == '.') {
-      if (sig < 0) sig = 0 // e.g. ".1" is shorthand for "0.1"
-      current = in.read()
-      if (current == -1)
-        return significand(sig, sig_, negative, 0)
-      while ('0' <= current && current <= '9') {
-        dot += 1
-        if (sig > 0 || current != '0') {
-          val digit = current - '0'
-          if (sig_ != null) {
-            sig_ = sig_.multiply(java.math.BigInteger.TEN).add(bigIntegers(digit))
-            if (sig_.bitLength >= max_bits) throw UnsafeNumber
-          } else if (sig >= 922337203685477580L)
-            sig_ = java.math.BigInteger.valueOf(sig).multiply(java.math.BigInteger.TEN).add(bigIntegers(digit))
-          else if (sig < 0) sig = digit.toLong
-          else sig = (sig << 3) + (sig << 1) + digit
-        }
-        // overflowed...
-        if (dot < 0) throw UnsafeNumber
+    var sig                          = -1L
+    var bigSig: java.math.BigInteger = null
+    if ('0' <= current && current <= '9') {
+      sig = (current - '0').toLong
+      while ({
         current = in.read()
+        '0' <= current && current <= '9'
+      }) {
+        if (sig < 922337203685477580L) sig = (sig << 3) + (sig << 1) + (current - '0')
+        else {
+          if (bigSig eq null) bigSig = java.math.BigInteger.valueOf(sig)
+          bigSig = bigSig.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
+          if (bigSig.bitLength >= max_bits) throw UnsafeNumber
+        }
       }
     }
-
-    if (sig < 0) throw UnsafeNumber // no significand
-
-    if (current == 'E' || current == 'e') {
-      current = in.read()
-      val negativeExp = current == '-'
-      if (negativeExp || current == '+') current = in.read()
+    var scale, exp = 0
+    if (current == '.') {
+      while ({
+        current = in.read()
+        '0' <= current && current <= '9'
+      }) {
+        scale += 1
+        if (sig < 922337203685477580L) {
+          if (sig < 0) sig = (current - '0').toLong
+          else sig = (sig << 3) + (sig << 1) + (current - '0')
+        } else {
+          if (bigSig eq null) bigSig = java.math.BigInteger.valueOf(sig)
+          bigSig = bigSig.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
+          if (bigSig.bitLength >= max_bits) throw UnsafeNumber
+        }
+      }
+    }
+    if (sig < 0) throw UnsafeNumber
+    if ((current | 0x20) == 'e') {
+      current = in.readChar().toInt
+      val negateExp = current == '-'
+      if (negateExp || current == '+') current = in.readChar().toInt
       if (current < '0' || current > '9') throw UnsafeNumber
       exp = '0' - current
       while ({
@@ -388,42 +300,192 @@ object UnsafeNumbers {
           }
         ) throw UnsafeNumber
       }
-      if (consume && current != -1) throw UnsafeNumber
-      if (negativeExp) {}
+      if (negateExp) {}
       else if (exp != -2147483648) exp = -exp
       else throw UnsafeNumber
-    } else if (consume && current != -1) throw UnsafeNumber
-
-    significand(
-      sig,
-      sig_,
-      negative,
-      if (dot < 1) -exp
-      else dot - exp
-    )
+    }
+    if (consume && current != -1) throw UnsafeNumber
+    if (sig == 0) {
+      return if (negate) -0.0f else 0.0f
+    } else if (bigSig eq null) {
+      if (negate) sig = -sig
+      return java.math.BigDecimal.valueOf(sig, scale - exp).floatValue()
+    }
+    if (negate) bigSig = bigSig.negate
+    new java.math.BigDecimal(bigSig, scale - exp).floatValue()
   }
 
-  @inline private[this] def significand(
-    sig: Long,
-    sig_ : java.math.BigInteger,
-    negative: Boolean,
-    scale: Int
-  ): java.math.BigDecimal =
-    if (sig <= 0) java.math.BigDecimal.ZERO
-    else if (sig_ != null) {
-      new java.math.BigDecimal(
-        {
-          if (negative) sig_.negate
-          else sig_
-        },
-        scale
-      )
-    } else
-      java.math.BigDecimal.valueOf(
-        if (negative) -sig
-        else sig,
-        scale
-      )
+  def double(num: String, max_bits: Int): Double =
+    double_(new FastStringReader(num), true, max_bits)
+
+  def double_(in: OneCharReader, consume: Boolean, max_bits: Int): Double = {
+    var current =
+      if (consume) in.readChar().toInt
+      else in.nextNonWhitespace().toInt
+    if (current == 'N') {
+      readAll(in, "aN", consume)
+      return Double.NaN
+    }
+    val negate = current == '-'
+    if (negate) current = in.readChar().toInt
+    if (current == 'I' || current == '+') {
+      if (current == '+') {
+        current = in.readChar().toInt
+        if (current != 'I') throw UnsafeNumber
+      }
+      readAll(in, "nfinity", consume)
+      return if (negate) Double.NegativeInfinity else Double.PositiveInfinity
+    }
+    var sig                          = -1L
+    var bigSig: java.math.BigInteger = null
+    if ('0' <= current && current <= '9') {
+      sig = (current - '0').toLong
+      while ({
+        current = in.read()
+        '0' <= current && current <= '9'
+      }) {
+        if (sig < 922337203685477580L) sig = (sig << 3) + (sig << 1) + (current - '0')
+        else {
+          if (bigSig eq null) bigSig = java.math.BigInteger.valueOf(sig)
+          bigSig = bigSig.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
+          if (bigSig.bitLength >= max_bits) throw UnsafeNumber
+        }
+      }
+    }
+    var scale, exp = 0
+    if (current == '.') {
+      while ({
+        current = in.read()
+        '0' <= current && current <= '9'
+      }) {
+        scale += 1
+        if (sig < 922337203685477580L) {
+          if (sig < 0) sig = (current - '0').toLong
+          else sig = (sig << 3) + (sig << 1) + (current - '0')
+        } else {
+          if (bigSig eq null) bigSig = java.math.BigInteger.valueOf(sig)
+          bigSig = bigSig.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
+          if (bigSig.bitLength >= max_bits) throw UnsafeNumber
+        }
+      }
+    }
+    if (sig < 0) throw UnsafeNumber
+    if ((current | 0x20) == 'e') {
+      current = in.readChar().toInt
+      val negateExp = current == '-'
+      if (negateExp || current == '+') current = in.readChar().toInt
+      if (current < '0' || current > '9') throw UnsafeNumber
+      exp = '0' - current
+      while ({
+        current = in.read()
+        '0' <= current && current <= '9'
+      }) {
+        if (
+          exp < -214748364 || {
+            exp = exp * 10 + ('0' - current)
+            exp > 0
+          }
+        ) throw UnsafeNumber
+      }
+      if (negateExp) {}
+      else if (exp != -2147483648) exp = -exp
+      else throw UnsafeNumber
+    }
+    if (consume && current != -1) throw UnsafeNumber
+    if (sig == 0) {
+      return if (negate) -0.0 else 0.0
+    } else if (bigSig eq null) {
+      if (negate) sig = -sig
+      return java.math.BigDecimal.valueOf(sig, scale - exp).doubleValue()
+    }
+    if (negate) bigSig = bigSig.negate
+    new java.math.BigDecimal(bigSig, scale - exp).doubleValue()
+  }
+
+  def bigDecimal(num: String, max_bits: Int): java.math.BigDecimal =
+    bigDecimal_(new FastStringReader(num), true, max_bits)
+
+  def bigDecimal_(in: OneCharReader, consume: Boolean, max_bits: Int): java.math.BigDecimal = {
+    var current =
+      if (consume) in.readChar().toInt
+      else in.nextNonWhitespace().toInt
+    val negate = current == '-'
+    if (negate) current = in.readChar().toInt
+    var bigSig: java.math.BigInteger = null
+    var sig                          = -1L
+    if ('0' <= current && current <= '9') {
+      sig = (current - '0').toLong
+      while ({
+        current = in.read()
+        '0' <= current && current <= '9'
+      }) {
+        if (sig < 922337203685477580L) sig = (sig << 3) + (sig << 1) + (current - '0')
+        else {
+          if (bigSig eq null) bigSig = java.math.BigInteger.valueOf(sig)
+          bigSig = bigSig.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
+          if (bigSig.bitLength >= max_bits) throw UnsafeNumber
+        }
+      }
+    }
+    var scale, exp = 0
+    if (current == '.') {
+      while ({
+        current = in.read()
+        '0' <= current && current <= '9'
+      }) {
+        scale += 1
+        if (sig < 922337203685477580L) {
+          if (sig < 0) sig = (current - '0').toLong
+          else sig = (sig << 3) + (sig << 1) + (current - '0')
+        } else {
+          if (bigSig eq null) bigSig = java.math.BigInteger.valueOf(sig)
+          bigSig = bigSig.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
+          if (bigSig.bitLength >= max_bits) throw UnsafeNumber
+        }
+      }
+    }
+    if (sig < 0) throw UnsafeNumber
+    if ((current | 0x20) == 'e') {
+      current = in.readChar().toInt
+      val negateExp = current == '-'
+      if (negateExp || current == '+') current = in.readChar().toInt
+      if (current < '0' || current > '9') throw UnsafeNumber
+      exp = '0' - current
+      while ({
+        current = in.read()
+        '0' <= current && current <= '9'
+      }) {
+        if (
+          exp < -214748364 || {
+            exp = exp * 10 + ('0' - current)
+            exp > 0
+          }
+        ) throw UnsafeNumber
+      }
+      if (negateExp) {}
+      else if (exp != -2147483648) exp = -exp
+      else throw UnsafeNumber
+    }
+    if (consume && current != -1) throw UnsafeNumber
+    if (bigSig eq null) {
+      if (negate) sig = -sig
+      return java.math.BigDecimal.valueOf(sig, scale - exp)
+    }
+    if (negate) bigSig = bigSig.negate
+    new java.math.BigDecimal(bigSig, scale - exp)
+  }
+
+  @noinline
+  private[this] def readAll(in: OneCharReader, s: String, consume: Boolean): Unit = {
+    val len = s.length
+    var i   = 0
+    while (i < len) {
+      if (in.readChar() != s.charAt(i)) throw UnsafeNumber
+      i += 1
+    }
+    val current = in.read() // to be consistent read the terminator
+    if (consume && current != -1) throw UnsafeNumber
+  }
 
   // note that bigDecimal does not have a negative zero
   private[this] val bigIntegers: Array[java.math.BigInteger] =


### PR DESCRIPTION
TBD: add fast and medium paths for decoding of floats and doubles and then test with JDK 11 and JDK 17

Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                          (size)   Mode  Cnt        Score       Error  Units
ArrayOfBigDecimalsReading.zioJson     128  thrpt    5    60147.258 ±  1206.244  ops/s
ArrayOfBigIntsReading.zioJson         128  thrpt    5    44040.175 ±   423.306  ops/s
ArrayOfDoublesReading.zioJson         128  thrpt    5   149040.245 ±  1606.733  ops/s
ArrayOfFloatsReading.zioJson          128  thrpt    5   233975.363 ± 28846.808  ops/s
GeoJSONReading.zioJson                N/A  thrpt    5    10582.132 ±   139.006  ops/s
PrimitivesReading.zioJson             N/A  thrpt    5  3618949.962 ± 74998.630  ops/s
```

#### After
```txt
Benchmark                          (size)   Mode  Cnt        Score       Error  Units
ArrayOfBigDecimalsReading.zioJson     128  thrpt    5    63247.638 ±   891.067  ops/s
ArrayOfBigIntsReading.zioJson         128  thrpt    5    49032.193 ±   564.246  ops/s
ArrayOfDoublesReading.zioJson         128  thrpt    5   173701.182 ±  3114.107  ops/s
ArrayOfFloatsReading.zioJson          128  thrpt    5   332838.364 ±  8347.542  ops/s
GeoJSONReading.zioJson                N/A  thrpt    5    11618.211 ±   422.198  ops/s
PrimitivesReading.zioJson             N/A  thrpt    5  3970602.729 ± 32732.282  ops/s
```