### PR TITLE
More efficient decoding of `BigDecimal` values + other inlinings

### DIFF
--- a/zio-json/js/src/main/scala/zio/json/internal/UnsafeNumbers.scala
+++ b/zio-json/js/src/main/scala/zio/json/internal/UnsafeNumbers.scala
@@ -160,21 +160,28 @@ object UnsafeNumbers {
       else in.nextNonWhitespace().toInt
     val negate = current == '-'
     if (negate) current = in.readChar().toInt
-    var bigM10: java.math.BigInteger = null
-    var m10                          = -1L
+    var loM10                       = 0L
+    var loDigits                    = 0
+    var hiM10: java.math.BigDecimal = null
     if ('0' <= current && current <= '9') {
-      m10 = (current - '0').toLong
+      loM10 = (current - '0').toLong
+      loDigits += 1
       while ({
         current = in.read()
         '0' <= current && current <= '9'
       }) {
-        if (m10 < 922337203685477580L) {
-          if (m10 <= 0) m10 = (current - '0').toLong
-          else m10 = (m10 << 3) + (m10 << 1) + (current - '0')
-        } else {
-          if (bigM10 eq null) bigM10 = java.math.BigInteger.valueOf(m10)
-          bigM10 = bigM10.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
-          if (bigM10.bitLength >= max_bits) throw UnsafeNumber
+        loM10 = (loM10 << 3) + (loM10 << 1) + (current - '0')
+        loDigits += 1
+        if (loM10 >= 100000000000000000L) {
+          if (negate) loM10 = -loM10
+          val bd = java.math.BigDecimal.valueOf(loM10)
+          if (hiM10 eq null) hiM10 = bd
+          else {
+            hiM10 = hiM10.scaleByPowerOfTen(loDigits).add(bd)
+            if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+          }
+          loM10 = 0
+          loDigits = 0
         }
       }
     }
@@ -184,18 +191,23 @@ object UnsafeNumbers {
         current = in.read()
         '0' <= current && current <= '9'
       }) {
+        loM10 = (loM10 << 3) + (loM10 << 1) + (current - '0')
+        loDigits += 1
         e10 -= 1
-        if (m10 < 922337203685477580L) {
-          if (m10 <= 0) m10 = (current - '0').toLong
-          else m10 = (m10 << 3) + (m10 << 1) + (current - '0')
-        } else {
-          if (bigM10 eq null) bigM10 = java.math.BigInteger.valueOf(m10)
-          bigM10 = bigM10.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
-          if (bigM10.bitLength >= max_bits) throw UnsafeNumber
+        if (loM10 >= 100000000000000000L) {
+          if (negate) loM10 = -loM10
+          val bd = java.math.BigDecimal.valueOf(loM10)
+          if (hiM10 eq null) hiM10 = bd
+          else {
+            hiM10 = hiM10.scaleByPowerOfTen(loDigits).add(bd)
+            if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+          }
+          loM10 = 0
+          loDigits = 0
         }
       }
     }
-    if (m10 < 0) throw UnsafeNumber
+    if ((hiM10 eq null) && loDigits == 0) throw UnsafeNumber
     if ((current | 0x20) == 'e') {
       current = in.readChar().toInt
       val negateExp = current == '-'
@@ -218,12 +230,17 @@ object UnsafeNumbers {
       else throw UnsafeNumber
     }
     if (consume && current != -1) throw UnsafeNumber
-    if (bigM10 eq null) {
-      if (negate) m10 = -m10
-      return java.math.BigDecimal.valueOf(m10, -e10)
+    if (hiM10 eq null) {
+      if (negate) loM10 = -loM10
+      return java.math.BigDecimal.valueOf(loM10, -e10)
     }
-    if (negate) bigM10 = bigM10.negate
-    new java.math.BigDecimal(bigM10, -e10)
+    hiM10 = hiM10.scaleByPowerOfTen(loDigits + e10)
+    if (loDigits != 0) {
+      if (negate) loM10 = -loM10
+      hiM10 = hiM10.add(java.math.BigDecimal.valueOf(loM10, -e10))
+    }
+    if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+    hiM10
   }
 
   def float(num: String, max_bits: Int): Float =

--- a/zio-json/jvm/src/main/scala/zio/json/internal/UnsafeNumbers.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/internal/UnsafeNumbers.scala
@@ -160,21 +160,28 @@ object UnsafeNumbers {
       else in.nextNonWhitespace().toInt
     val negate = current == '-'
     if (negate) current = in.readChar().toInt
-    var bigM10: java.math.BigInteger = null
-    var m10                          = -1L
+    var loM10                       = 0L
+    var loDigits                    = 0
+    var hiM10: java.math.BigDecimal = null
     if ('0' <= current && current <= '9') {
-      m10 = (current - '0').toLong
+      loM10 = (current - '0').toLong
+      loDigits += 1
       while ({
         current = in.read()
         '0' <= current && current <= '9'
       }) {
-        if (m10 < 922337203685477580L) {
-          if (m10 <= 0) m10 = (current - '0').toLong
-          else m10 = m10 * 10 + (current - '0')
-        } else {
-          if (bigM10 eq null) bigM10 = java.math.BigInteger.valueOf(m10)
-          bigM10 = bigM10.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
-          if (bigM10.bitLength >= max_bits) throw UnsafeNumber
+        loM10 = loM10 * 10 + (current - '0')
+        loDigits += 1
+        if (loM10 >= 100000000000000000L) {
+          if (negate) loM10 = -loM10
+          val bd = java.math.BigDecimal.valueOf(loM10)
+          if (hiM10 eq null) hiM10 = bd
+          else {
+            hiM10 = hiM10.scaleByPowerOfTen(loDigits).add(bd)
+            if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+          }
+          loM10 = 0
+          loDigits = 0
         }
       }
     }
@@ -184,18 +191,23 @@ object UnsafeNumbers {
         current = in.read()
         '0' <= current && current <= '9'
       }) {
+        loM10 = loM10 * 10 + (current - '0')
+        loDigits += 1
         e10 -= 1
-        if (m10 < 922337203685477580L) {
-          if (m10 <= 0) m10 = (current - '0').toLong
-          else m10 = m10 * 10 + (current - '0')
-        } else {
-          if (bigM10 eq null) bigM10 = java.math.BigInteger.valueOf(m10)
-          bigM10 = bigM10.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
-          if (bigM10.bitLength >= max_bits) throw UnsafeNumber
+        if (loM10 >= 100000000000000000L) {
+          if (negate) loM10 = -loM10
+          val bd = java.math.BigDecimal.valueOf(loM10)
+          if (hiM10 eq null) hiM10 = bd
+          else {
+            hiM10 = hiM10.scaleByPowerOfTen(loDigits).add(bd)
+            if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+          }
+          loM10 = 0
+          loDigits = 0
         }
       }
     }
-    if (m10 < 0) throw UnsafeNumber
+    if ((hiM10 eq null) && loDigits == 0) throw UnsafeNumber
     if ((current | 0x20) == 'e') {
       current = in.readChar().toInt
       val negateExp = current == '-'
@@ -218,12 +230,17 @@ object UnsafeNumbers {
       else throw UnsafeNumber
     }
     if (consume && current != -1) throw UnsafeNumber
-    if (bigM10 eq null) {
-      if (negate) m10 = -m10
-      return java.math.BigDecimal.valueOf(m10, -e10)
+    if (hiM10 eq null) {
+      if (negate) loM10 = -loM10
+      return java.math.BigDecimal.valueOf(loM10, -e10)
     }
-    if (negate) bigM10 = bigM10.negate
-    new java.math.BigDecimal(bigM10, -e10)
+    hiM10 = hiM10.scaleByPowerOfTen(loDigits + e10)
+    if (loDigits != 0) {
+      if (negate) loM10 = -loM10
+      hiM10 = hiM10.add(java.math.BigDecimal.valueOf(loM10, -e10))
+    }
+    if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+    hiM10
   }
 
   def float(num: String, max_bits: Int): Float =

--- a/zio-json/native/src/main/scala/zio/json/internal/UnsafeNumbers.scala
+++ b/zio-json/native/src/main/scala/zio/json/internal/UnsafeNumbers.scala
@@ -160,21 +160,28 @@ object UnsafeNumbers {
       else in.nextNonWhitespace().toInt
     val negate = current == '-'
     if (negate) current = in.readChar().toInt
-    var bigM10: java.math.BigInteger = null
-    var m10                          = -1L
+    var loM10                       = 0L
+    var loDigits                    = 0
+    var hiM10: java.math.BigDecimal = null
     if ('0' <= current && current <= '9') {
-      m10 = (current - '0').toLong
+      loM10 = (current - '0').toLong
+      loDigits += 1
       while ({
         current = in.read()
         '0' <= current && current <= '9'
       }) {
-        if (m10 < 922337203685477580L) {
-          if (m10 <= 0) m10 = (current - '0').toLong
-          else m10 = m10 * 10 + (current - '0')
-        } else {
-          if (bigM10 eq null) bigM10 = java.math.BigInteger.valueOf(m10)
-          bigM10 = bigM10.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
-          if (bigM10.bitLength >= max_bits) throw UnsafeNumber
+        loM10 = loM10 * 10 + (current - '0')
+        loDigits += 1
+        if (loM10 >= 100000000000000000L) {
+          if (negate) loM10 = -loM10
+          val bd = java.math.BigDecimal.valueOf(loM10)
+          if (hiM10 eq null) hiM10 = bd
+          else {
+            hiM10 = hiM10.scaleByPowerOfTen(loDigits).add(bd)
+            if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+          }
+          loM10 = 0
+          loDigits = 0
         }
       }
     }
@@ -184,18 +191,23 @@ object UnsafeNumbers {
         current = in.read()
         '0' <= current && current <= '9'
       }) {
+        loM10 = loM10 * 10 + (current - '0')
+        loDigits += 1
         e10 -= 1
-        if (m10 < 922337203685477580L) {
-          if (m10 <= 0) m10 = (current - '0').toLong
-          else m10 = m10 * 10 + (current - '0')
-        } else {
-          if (bigM10 eq null) bigM10 = java.math.BigInteger.valueOf(m10)
-          bigM10 = bigM10.multiply(java.math.BigInteger.TEN).add(bigIntegers(current - '0'))
-          if (bigM10.bitLength >= max_bits) throw UnsafeNumber
+        if (loM10 >= 100000000000000000L) {
+          if (negate) loM10 = -loM10
+          val bd = java.math.BigDecimal.valueOf(loM10)
+          if (hiM10 eq null) hiM10 = bd
+          else {
+            hiM10 = hiM10.scaleByPowerOfTen(loDigits).add(bd)
+            if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+          }
+          loM10 = 0
+          loDigits = 0
         }
       }
     }
-    if (m10 < 0) throw UnsafeNumber
+    if ((hiM10 eq null) && loDigits == 0) throw UnsafeNumber
     if ((current | 0x20) == 'e') {
       current = in.readChar().toInt
       val negateExp = current == '-'
@@ -218,12 +230,17 @@ object UnsafeNumbers {
       else throw UnsafeNumber
     }
     if (consume && current != -1) throw UnsafeNumber
-    if (bigM10 eq null) {
-      if (negate) m10 = -m10
-      return java.math.BigDecimal.valueOf(m10, -e10)
+    if (hiM10 eq null) {
+      if (negate) loM10 = -loM10
+      return java.math.BigDecimal.valueOf(loM10, -e10)
     }
-    if (negate) bigM10 = bigM10.negate
-    new java.math.BigDecimal(bigM10, -e10)
+    hiM10 = hiM10.scaleByPowerOfTen(loDigits + e10)
+    if (loDigits != 0) {
+      if (negate) loM10 = -loM10
+      hiM10 = hiM10.add(java.math.BigDecimal.valueOf(loM10, -e10))
+    }
+    if (hiM10.unscaledValue.bitLength >= max_bits) throw UnsafeNumber
+    hiM10
   }
 
   def float(num: String, max_bits: Int): Float =

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -22,7 +22,6 @@ import zio.json.uuid.UUIDParser
 import zio.{ Chunk, NonEmptyChunk }
 
 import java.util.UUID
-import scala.annotation._
 import scala.collection.immutable.{ LinearSeq, ListSet, TreeSet }
 import scala.collection.{ immutable, mutable }
 import scala.util.control.NoStackTrace
@@ -71,10 +70,10 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
   final def bothWith[B, C](that: => JsonDecoder[B])(f: (A, B) => C): JsonDecoder[C] =
     new JsonDecoder[C] {
       override def unsafeDecode(trace: List[JsonError], in: RetractReader): C = {
-        val in2 = new WithRecordingReader(in, 64)
-        val a   = self.unsafeDecode(trace, in2)
-        in2.rewind()
-        val b = that.unsafeDecode(trace, in2)
+        val rr = RecordingReader(in)
+        val a  = self.unsafeDecode(trace, rr)
+        rr.rewind()
+        val b = that.unsafeDecode(trace, rr)
         f(a, b)
       }
     }
@@ -116,24 +115,19 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
     new JsonDecoder[A1] {
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): A1 = {
-        val in2 = new zio.json.internal.WithRecordingReader(in, 64)
-
-        try self.unsafeDecode(trace, in2)
+        val rr = RecordingReader(in)
+        try self.unsafeDecode(trace, rr)
         catch {
-          case JsonDecoder.UnsafeJson(_) =>
-            in2.rewind()
-            that.unsafeDecode(trace, in2)
-
-          case _: UnexpectedEnd =>
-            in2.rewind()
-            that.unsafeDecode(trace, in2)
+          case _: JsonDecoder.UnsafeJson | _: UnexpectedEnd =>
+            rr.rewind()
+            that.unsafeDecode(trace, rr)
         }
       }
 
       override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): A1 =
         try self.unsafeFromJsonAST(trace, json)
         catch {
-          case JsonDecoder.UnsafeJson(_) | _: UnexpectedEnd => that.unsafeFromJsonAST(trace, json)
+          case _: JsonDecoder.UnsafeJson | _: UnexpectedEnd => that.unsafeFromJsonAST(trace, json)
         }
 
       override def unsafeDecodeMissing(trace: List[JsonError]): A1 =
@@ -141,7 +135,6 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
         catch {
           case _: Throwable => that.unsafeDecodeMissing(trace)
         }
-
     }
 
   /**
@@ -149,7 +142,7 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
    * codec fails, the specified codec will be tried instead.
    */
   final def orElseEither[B](that: => JsonDecoder[B]): JsonDecoder[Either[A, B]] =
-    self.map(Left(_)).orElse(that.map(Right(_)))
+    self.map(new Left(_)).orElse(that.map(new Right(_)))
 
   /**
    * Returns a new codec whose decoded values will be mapped by the specified function.
@@ -166,7 +159,6 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
 
       override def unsafeDecodeMissing(trace: List[JsonError]): B =
         f(self.unsafeDecodeMissing(trace))
-
     }
 
   /**
@@ -193,7 +185,6 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
           case Right(b)  => b
           case Left(err) => Lexer.error(err, trace)
         }
-
     }
 
   /**
@@ -243,7 +234,6 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
       case _: UnexpectedEnd              => Left("Unexpected end of input")
       case _: StackOverflowError         => Left("Unexpected structure")
     }
-
 }
 
 object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with JsonDecoderVersionSpecific {
@@ -329,7 +319,8 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
   implicit val float: JsonDecoder[Float]                     = number(Lexer.float, _.floatValue())
   implicit val double: JsonDecoder[Double]                   = number(Lexer.double, _.doubleValue())
   implicit val bigDecimal: JsonDecoder[java.math.BigDecimal] = number(Lexer.bigDecimal, identity)
-  implicit val scalaBigDecimal: JsonDecoder[BigDecimal]      = bigDecimal.map(x => x)
+  implicit val scalaBigDecimal: JsonDecoder[BigDecimal] =
+    number(Lexer.bigDecimal, x => new BigDecimal(x, BigDecimal.defaultMathContext))
 
   // numbers decode from numbers or strings for maximum compatibility
   private[this] def number[A](
@@ -339,14 +330,14 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     new JsonDecoder[A] {
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
-        (in.nextNonWhitespace(): @switch) match {
-          case '"' =>
-            val i = f(trace, in)
-            Lexer.charOnly(trace, in, '"')
-            i
-          case _ =>
-            in.retract()
-            f(trace, in)
+        if (in.nextNonWhitespace() == '"') {
+          val a = f(trace, in)
+          val c = in.readChar()
+          if (c != '"') Lexer.error("'\"'", c, trace)
+          a
+        } else {
+          in.retract()
+          f(trace, in)
         }
 
       override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): A =
@@ -354,13 +345,10 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
           case Json.Num(value) =>
             try fromBigDecimal(value)
             catch {
-              case exception: ArithmeticException => Lexer.error(exception.getMessage, trace)
+              case ex: ArithmeticException => Lexer.error(ex.getMessage, trace)
             }
-          case Json.Str(value) =>
-            val reader = new FastStringReader(value)
-            try f(List.empty, reader)
-            finally reader.close()
-          case _ => Lexer.error("Not a number or a string", trace)
+          case Json.Str(value) => f(trace, new FastStringReader(value))
+          case _               => Lexer.error("expected number", trace)
         }
     }
 
@@ -427,8 +415,8 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
           }) ()
         if (left == null && right == null) Lexer.error("missing fields", trace)
         if (left != null && right != null) Lexer.error("ambiguous either, zip present", trace)
-        if (left != null) Left(left.asInstanceOf[A])
-        else Right(right.asInstanceOf[B])
+        if (left != null) new Left(left.asInstanceOf[A])
+        else new Right(right.asInstanceOf[B])
       }
     }
 
@@ -437,14 +425,13 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     in: RetractReader,
     builder: mutable.Builder[A, T[A]]
   )(implicit A: JsonDecoder[A]): T[A] = {
-    Lexer.char(trace, in, '[')
+    val c = in.nextNonWhitespace()
+    if (c != '[') Lexer.error("'['", c, trace)
     var i: Int = 0
     if (Lexer.firstArrayElement(in)) while ({
-      {
-        val trace_ = JsonError.ArrayAccess(i) :: trace
-        builder += A.unsafeDecode(trace_, in)
-        i += 1
-      }; Lexer.nextArrayElement(trace, in)
+      builder += A.unsafeDecode(JsonError.ArrayAccess(i) :: trace, in)
+      i += 1
+      Lexer.nextArrayElement(trace, in)
     }) ()
     builder.result()
   }
@@ -454,16 +441,16 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     in: RetractReader,
     builder: mutable.Builder[(K, V), T[K, V]]
   )(implicit K: JsonFieldDecoder[K], V: JsonDecoder[V]): T[K, V] = {
-    Lexer.char(trace, in, '{')
+    val c = in.nextNonWhitespace()
+    if (c != '{') Lexer.error("'{'", c, trace)
     if (Lexer.firstField(trace, in))
       while ({
-        {
-          val field  = Lexer.string(trace, in).toString
-          val trace_ = JsonError.ObjectAccess(field) :: trace
-          Lexer.char(trace_, in, ':')
-          val value = V.unsafeDecode(trace_, in)
-          builder += ((K.unsafeDecodeField(trace_, field), value))
-        }; Lexer.nextField(trace, in)
+        val field  = Lexer.string(trace, in).toString
+        val trace_ = JsonError.ObjectAccess(field) :: trace
+        Lexer.char(trace_, in, ':')
+        val value = V.unsafeDecode(trace_, in)
+        builder += ((K.unsafeDecodeField(trace_, field), value))
+        Lexer.nextField(trace, in)
       }) ()
     builder.result()
   }
@@ -506,8 +493,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
   implicit def seq[A: JsonDecoder]: JsonDecoder[Seq[A]] =
     new CollectionJsonDecoder[Seq[A]] {
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): Seq[A] =
-        Seq.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): Seq[A] = Seq.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Seq[A] =
         builder(trace, in, immutable.Seq.newBuilder[A])
@@ -549,8 +535,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def linearSeq[A: JsonDecoder]: JsonDecoder[immutable.LinearSeq[A]] =
     new CollectionJsonDecoder[immutable.LinearSeq[A]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.LinearSeq[A] =
-        immutable.LinearSeq.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.LinearSeq[A] = immutable.LinearSeq.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): LinearSeq[A] =
         builder(trace, in, immutable.LinearSeq.newBuilder[A])
@@ -558,8 +543,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def listSet[A: JsonDecoder]: JsonDecoder[immutable.ListSet[A]] =
     new CollectionJsonDecoder[immutable.ListSet[A]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.ListSet[A] =
-        immutable.ListSet.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.ListSet[A] = immutable.ListSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): ListSet[A] =
         builder(trace, in, immutable.ListSet.newBuilder[A])
@@ -567,8 +551,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def treeSet[A: JsonDecoder: Ordering]: JsonDecoder[immutable.TreeSet[A]] =
     new CollectionJsonDecoder[immutable.TreeSet[A]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.TreeSet[A] =
-        immutable.TreeSet.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.TreeSet[A] = immutable.TreeSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): TreeSet[A] =
         builder(trace, in, immutable.TreeSet.newBuilder[A])
@@ -600,8 +583,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def hashSet[A: JsonDecoder]: JsonDecoder[immutable.HashSet[A]] =
     new CollectionJsonDecoder[immutable.HashSet[A]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.HashSet[A] =
-        immutable.HashSet.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.HashSet[A] = immutable.HashSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.HashSet[A] =
         builder(trace, in, immutable.HashSet.newBuilder[A])
@@ -617,8 +599,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def hashMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[immutable.HashMap[K, V]] =
     new CollectionJsonDecoder[immutable.HashMap[K, V]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.HashMap[K, V] =
-        immutable.HashMap.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.HashMap[K, V] = immutable.HashMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.HashMap[K, V] =
         keyValueBuilder(trace, in, immutable.HashMap.newBuilder[K, V])
@@ -626,8 +607,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def mutableMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[mutable.Map[K, V]] =
     new CollectionJsonDecoder[mutable.Map[K, V]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): mutable.Map[K, V] =
-        mutable.Map.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): mutable.Map[K, V] = mutable.Map.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): mutable.Map[K, V] =
         keyValueBuilder(trace, in, mutable.Map.newBuilder[K, V])
@@ -635,8 +615,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def sortedSet[A: Ordering: JsonDecoder]: JsonDecoder[immutable.SortedSet[A]] =
     new CollectionJsonDecoder[immutable.SortedSet[A]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.SortedSet[A] =
-        immutable.SortedSet.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.SortedSet[A] = immutable.SortedSet.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.SortedSet[A] =
         builder(trace, in, immutable.SortedSet.newBuilder[A])
@@ -644,8 +623,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def sortedMap[K: JsonFieldDecoder: Ordering, V: JsonDecoder]: JsonDecoder[collection.SortedMap[K, V]] =
     new CollectionJsonDecoder[collection.SortedMap[K, V]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): collection.SortedMap[K, V] =
-        collection.SortedMap.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): collection.SortedMap[K, V] = collection.SortedMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): collection.SortedMap[K, V] =
         keyValueBuilder(trace, in, collection.SortedMap.newBuilder[K, V])
@@ -653,8 +631,7 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
 
   implicit def listMap[K: JsonFieldDecoder, V: JsonDecoder]: JsonDecoder[immutable.ListMap[K, V]] =
     new CollectionJsonDecoder[immutable.ListMap[K, V]] {
-      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.ListMap[K, V] =
-        immutable.ListMap.empty
+      override def unsafeDecodeMissing(trace: List[JsonError]): immutable.ListMap[K, V] = immutable.ListMap.empty
 
       def unsafeDecode(trace: List[JsonError], in: RetractReader): immutable.ListMap[K, V] =
         keyValueBuilder(trace, in, immutable.ListMap.newBuilder[K, V])
@@ -698,7 +675,6 @@ private[json] trait DecoderLowPriority2 extends DecoderLowPriority3 {
           zio.ChunkBuilder.make[(K, A)]()
         )
     }
-
 }
 
 private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
@@ -734,8 +710,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       }
 
     // Commonized handling for decoding from string to java.time Class
-    @inline
-    private[this] def parseJavaTime(trace: List[JsonError], s: String): A =
+    @inline private[this] def parseJavaTime(trace: List[JsonError], s: String): A =
       try f(s)
       catch {
         case ex: DateTimeException =>
@@ -747,12 +722,12 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
 
   // Commonized handling for decoding from string to java.time Class
   private[json] def parseJavaTime[A](f: String => A, s: String): Either[String, A] =
-    try Right(f(s))
+    try new Right(f(s))
     catch {
       case ex: DateTimeException =>
-        Left(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}")
+        new Left(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}")
       case _: IllegalArgumentException =>
-        Left(s"${strip(s)} is not a valid ISO-8601 format")
+        new Left(s"${strip(s)} is not a valid ISO-8601 format")
     }
 
   implicit val uuid: JsonDecoder[UUID] = new JsonDecoder[UUID] {
@@ -765,8 +740,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
         case _               => Lexer.error("expected string", trace)
       }
 
-    @inline
-    private[this] def parseUUID(trace: List[JsonError], s: String): UUID =
+    @inline private[this] def parseUUID(trace: List[JsonError], s: String): UUID =
       try UUIDParser.unsafeParse(s)
       catch {
         case _: IllegalArgumentException => Lexer.error(s"Invalid UUID: ${strip(s)}", trace)
@@ -783,20 +757,18 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
         case _               => Lexer.error("expected string", trace)
       }
 
-    @inline
-    private[this] def parseCurrency(trace: List[JsonError], s: String): java.util.Currency =
+    @inline private[this] def parseCurrency(trace: List[JsonError], s: String): java.util.Currency =
       try java.util.Currency.getInstance(s)
       catch {
         case _: IllegalArgumentException => Lexer.error(s"Invalid Currency: ${strip(s)}", trace)
       }
   }
 
-  private[json] def strip(s: String, len: Int = 50): String =
+  @noinline private[json] def strip(s: String, len: Int = 50): String =
     if (s.length <= len) s
     else s.substring(0, len) + "..."
 }
 
 private[json] trait DecoderLowPriority4 extends DecoderLowPriorityVersionSpecific {
-  @inline
-  implicit def fromCodec[A](implicit codec: JsonCodec[A]): JsonDecoder[A] = codec.decoder
+  @inline implicit def fromCodec[A](implicit codec: JsonCodec[A]): JsonDecoder[A] = codec.decoder
 }

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -28,16 +28,13 @@ object Lexer {
 
   val NumberMaxBits: Int = 256
 
-  @noinline
-  def error(msg: String, trace: List[JsonError]): Nothing =
+  @noinline def error(msg: String, trace: List[JsonError]): Nothing =
     throw UnsafeJson(JsonError.Message(msg) :: trace)
 
-  @noinline
-  private[json] def error(expected: String, got: Char, trace: List[JsonError]): Nothing =
+  @noinline private[json] def error(expected: String, got: Char, trace: List[JsonError]): Nothing =
     error(s"expected $expected got '$got'", trace)
 
-  @noinline
-  private[json] def error(c: Char, trace: List[JsonError]): Nothing =
+  @noinline private[json] def error(c: Char, trace: List[JsonError]): Nothing =
     error(s"invalid '\\$c' in string", trace)
 
   // True if we got a string (implies a retraction), False for }
@@ -60,11 +57,9 @@ object Lexer {
 
   // True if we got anything besides a ], False for ]
   def firstArrayElement(in: RetractReader): Boolean =
-    (in.nextNonWhitespace(): @switch) match {
-      case ']' => false
-      case _ =>
-        in.retract()
-        true
+    in.nextNonWhitespace() != ']' && {
+      in.retract()
+      true
     }
 
   def nextArrayElement(trace: List[JsonError], in: OneCharReader): Boolean =
@@ -74,13 +69,10 @@ object Lexer {
       case c   => error("',' or ']'", c, trace)
     }
 
-  // avoids allocating lots of strings (they are often the bulk of incoming
-  // messages) by only checking for what we expect to see (Jon Pretty's idea).
-  //
-  // returns the index of the matched field, or -1
   def field(trace: List[JsonError], in: OneCharReader, matrix: StringMatrix): Int = {
     val f = enumeration(trace, in, matrix)
-    char(trace, in, ':')
+    val c = in.nextNonWhitespace()
+    if (c != ':') error("':'", c, trace)
     f
   }
 
@@ -135,23 +127,20 @@ object Lexer {
   def skipString(trace: List[JsonError], in: OneCharReader): Unit =
     skipString(in, evenBackSlashes = true)
 
-  @tailrec
-  private def skipFixedChars(in: OneCharReader, n: Int): Unit =
+  @tailrec private def skipFixedChars(in: OneCharReader, n: Int): Unit =
     if (n > 0) {
       in.readChar()
       skipFixedChars(in, n - 1)
     }
 
-  @tailrec
-  private def skipString(in: OneCharReader, evenBackSlashes: Boolean): Unit = {
+  @tailrec private def skipString(in: OneCharReader, evenBackSlashes: Boolean): Unit = {
     val ch = in.readChar()
     if (evenBackSlashes) {
       if (ch != '"') skipString(in, ch != '\\')
     } else skipString(in, evenBackSlashes = true)
   }
 
-  @tailrec
-  private def skipObject(in: OneCharReader, level: Int): Unit = {
+  @tailrec private def skipObject(in: OneCharReader, level: Int): Unit = {
     val ch = in.readChar()
     if (ch == '"') {
       skipString(in, evenBackSlashes = true)
@@ -161,8 +150,7 @@ object Lexer {
     else if (level != 0) skipObject(in, level - 1)
   }
 
-  @tailrec
-  private def skipArray(in: OneCharReader, level: Int): Unit = {
+  @tailrec private def skipArray(in: OneCharReader, level: Int): Unit = {
     val b = in.readChar()
     if (b == '"') {
       skipString(in, evenBackSlashes = true)
@@ -180,8 +168,7 @@ object Lexer {
 
       private[this] var escaped = false
 
-      @tailrec
-      override def read(): Int = {
+      @tailrec override def read(): Int = {
         val c = in.readChar()
         if (escaped) {
           escaped = false
@@ -266,8 +253,7 @@ object Lexer {
   }
 
   // consumes 4 hex characters after current
-  @noinline
-  def nextHex4(trace: List[JsonError], in: OneCharReader): Char = {
+  @noinline def nextHex4(trace: List[JsonError], in: OneCharReader): Char = {
     var i, accum = 0
     while (i < 4) {
       val c = in.readChar()
@@ -389,9 +375,8 @@ object Lexer {
   // non-positional for performance
   @inline private[this] def isNumber(c: Char): Boolean =
     (c: @switch) match {
-      case '+' | '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '.' | 'e' | 'E' =>
-        true
-      case _ => false
+      case '+' | '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '.' | 'e' | 'E' => true
+      case _                                                                                       => false
     }
 
   def readChars(


### PR DESCRIPTION
TBD: make similar improvements for parsing of floats and doubles

Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                          (size)   Mode  Cnt        Score       Error  Units
ArrayOfBigDecimalsReading.zioJson     128  thrpt    5    63247.638 ±   891.067  ops/s
```

#### After
```txt
Benchmark                          (size)   Mode  Cnt        Score       Error  Units
ArrayOfBigDecimalsReading.zioJson     128  thrpt    5   139494.914 ±  4433.385  ops/s
```