### PR TITLE
More efficient decoding of string values

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -203,7 +203,8 @@ object Lexer {
   def string(trace: List[JsonError], in: OneCharReader): CharSequence = {
     var c = in.nextNonWhitespace()
     if (c != '"') error("'\"'", c, trace)
-    val sb = new FastStringBuilder(64)
+    var cs = new Array[Char](64)
+    var i = 0
     while ({
       c = in.readChar()
       c != '"'
@@ -222,9 +223,11 @@ object Lexer {
           case _    => error(c, trace)
         }
       } else if (c < ' ') error("invalid control in string", trace)
-      sb.append(c)
+      if (i == cs.length) cs = java.util.Arrays.copyOf(cs, i << 1)
+      cs(i) = c
+      i += 1
     }
-    sb.buffer
+    new String(cs, 0, i)
   }
 
   def char(trace: List[JsonError], in: OneCharReader): Char = {

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -204,7 +204,7 @@ object Lexer {
     var c = in.nextNonWhitespace()
     if (c != '"') error("'\"'", c, trace)
     var cs = new Array[Char](64)
-    var i = 0
+    var i  = 0
     while ({
       c = in.readChar()
       c != '"'

--- a/zio-json/shared/src/main/scala/zio/json/internal/writers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/writers.scala
@@ -43,7 +43,7 @@ final class FastStringWrite(initial: Int) extends Write {
   def buffer: CharSequence = sb
 }
 
-// like StringBuilder but doesn't have any encoding or range checks
+// FIXME: remove in the next major version
 private[zio] final class FastStringBuilder(initial: Int) {
   private[this] var chars: Array[Char] = new Array[Char](initial)
   private[this] var i: Int             = 0


### PR DESCRIPTION
Tested with Scala 3 and JDK 21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                             (size)   Mode  Cnt        Score       Error  Units
StringOfAsciiCharsReading.zioJson        128  thrpt    5  2564276.761 ± 12171.566  ops/s
StringOfEscapedCharsReading.zioJson      128  thrpt    5   772746.093 ± 56346.729  ops/s
StringOfNonAsciiCharsReading.zioJson     128  thrpt    5  1534866.952 ± 14050.482  ops/s
```

#### After
```txt
Benchmark                             (size)   Mode  Cnt        Score       Error  Units
StringOfAsciiCharsReading.zioJson        128  thrpt    5  3804646.804 ±  7068.611  ops/s
StringOfEscapedCharsReading.zioJson      128  thrpt    5   794500.421 ± 24975.739  ops/s
StringOfNonAsciiCharsReading.zioJson     128  thrpt    5  1842774.078 ± 10740.569  ops/s
```
