### PR TITLE
More efficient decoding of case classes for Scala 3

### DIFF
--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -8,6 +8,7 @@ import zio.json.internal.{ FieldEncoder, Lexer, RetractReader, StringMatrix, Wri
 
 import scala.annotation._
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 /**
  * If used on a case class field, determines the name of the JSON field. Defaults to the case class field name.

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -12,6 +12,7 @@ import zio.json.ast.Json
 import zio.json.internal.{ FieldEncoder, Lexer, RetractReader, StringMatrix, Write }
 
 import scala.annotation._
+import scala.collection.Factory
 import scala.collection.mutable
 import scala.language.experimental.macros
 
@@ -516,6 +517,9 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
   private final class ArraySeq(p: Array[Any]) extends IndexedSeq[Any] {
     def apply(i: Int): Any = p(i)
     def length: Int        = p.length
+    override def to[A](factory: Factory[Any, A]): A =
+      if (factory.isInstanceOf[Factory[Any, Array[Any]]]) p.asInstanceOf[A]
+      else super.to(factory)
   }
 }
 
@@ -540,6 +544,9 @@ object DeriveJsonDecoder extends JsonDecoderDerivation(JsonCodecConfiguration.de
   private final class ArraySeq(p: Array[Any]) extends IndexedSeq[Any] {
     def apply(i: Int): Any = p(i)
     def length: Int        = p.length
+    override def to[A](factory: Factory[Any, A]): A =
+      if (factory.isInstanceOf[Factory[Any, Array[Any]]]) p.asInstanceOf[A]
+      else super.to(factory)
   }
 }
 


### PR DESCRIPTION
Tested with Scala 3 and JDK 21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                        (size)   Mode  Cnt        Score       Error  Units
ADTReading.zioJson                  N/A  thrpt    5  1691106.729 ± 23451.647  ops/s
AnyValsReading.zioJson              N/A  thrpt    5  3528456.325 ± 41147.322  ops/s
ExtractFieldsReading.zioJson        128  thrpt    5   137661.759 ±   938.162  ops/s
GeoJSONReading.zioJson              N/A  thrpt    5    11349.613 ±    94.790  ops/s
GitHubActionsAPIReading.zioJson     N/A  thrpt    5   315013.535 ±  8754.854  ops/s
GoogleMapsAPIReading.zioJson        N/A  thrpt    5    19387.118 ±   682.092  ops/s
NestedStructsReading.zioJson        128  thrpt    5   208924.503 ±  2951.986  ops/s
OpenRTBReading.zioJson              N/A  thrpt    5   135867.805 ±  3377.469  ops/s
PrimitivesReading.zioJson           N/A  thrpt    5  3875838.485 ± 47690.202  ops/s
TwitterAPIReading.zioJson           N/A  thrpt    5    16653.397 ±   870.447  ops/s
```

#### After
```txt
Benchmark                        (size)   Mode  Cnt        Score       Error  Units
ADTReading.zioJson                  N/A  thrpt    5  1892482.299 ±  3112.288  ops/s
AnyValsReading.zioJson              N/A  thrpt    5  3921001.708 ± 11951.810  ops/s
ExtractFieldsReading.zioJson        128  thrpt    5   143759.851 ±   710.118  ops/s
GeoJSONReading.zioJson              N/A  thrpt    5    11475.226 ±   452.265  ops/s
GitHubActionsAPIReading.zioJson     N/A  thrpt    5   323624.965 ±  6710.459  ops/s
GoogleMapsAPIReading.zioJson        N/A  thrpt    5    21989.391 ±   574.145  ops/s
NestedStructsReading.zioJson        128  thrpt    5   281407.248 ±  1855.487  ops/s
OpenRTBReading.zioJson              N/A  thrpt    5   147230.243 ±  2369.924  ops/s
PrimitivesReading.zioJson           N/A  thrpt    5  4195266.444 ± 52439.347  ops/s
TwitterAPIReading.zioJson           N/A  thrpt    5    17703.260 ±   334.242  ops/s
```
