### PR TITLE
More efficient encoding of lists

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -359,7 +359,54 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
 
   implicit def treeSet[A: JsonEncoder]: JsonEncoder[immutable.TreeSet[A]] = iterable[A, immutable.TreeSet]
 
-  implicit def list[A: JsonEncoder]: JsonEncoder[List[A]] = iterable[A, List]
+  implicit def list[A](implicit A: JsonEncoder[A]): JsonEncoder[List[A]] =
+    new JsonEncoder[List[A]] {
+      override def isEmpty(as: List[A]): Boolean = as eq Nil
+
+      def unsafeEncode(as: List[A], indent: Option[Int], out: Write): Unit =
+        if (as eq Nil) out.write("[]")
+        else {
+          out.write('[')
+          if (indent.isDefined) unsafeEncodePadded(as, indent, out)
+          else unsafeEncodeCompact(as, indent, out)
+          out.write(']')
+        }
+
+      private[this] def unsafeEncodeCompact(as: List[A], indent: Option[Int], out: Write): Unit = {
+        var as_   = as
+        var first = true
+        while (as_ ne Nil) {
+          if (first) first = false
+          else out.write(',')
+          A.unsafeEncode(as_.head, indent, out)
+          as_ = as_.tail
+        }
+      }
+
+      private[this] def unsafeEncodePadded(as: List[A], indent: Option[Int], out: Write): Unit = {
+        val indent_ = bump(indent)
+        pad(indent_, out)
+        var as_   = as
+        var first = true
+        while (as_ ne Nil) {
+          if (first) first = false
+          else {
+            out.write(',')
+            pad(indent_, out)
+          }
+          A.unsafeEncode(as_.head, indent_, out)
+          as_ = as_.tail
+        }
+        pad(indent, out)
+      }
+
+      override final def toJsonAST(as: List[A]): Either[String, Json] =
+        as.map(A.toJsonAST)
+          .foldLeft[Either[String, Chunk[Json]]](Right(Chunk.empty)) { (s, i) =>
+            s.flatMap(chunk => i.map(item => chunk :+ item))
+          }
+          .map(Json.Arr(_))
+    }
 
   implicit def vector[A: JsonEncoder]: JsonEncoder[Vector[A]] = iterable[A, Vector]
 


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                      (size)   Mode  Cnt         Score         Error  Units
ListOfBooleansWriting.zioJson       1  thrpt    5  42626498.232 ± 1191762.765  ops/s
ListOfBooleansWriting.zioJson       3  thrpt    5  30622270.257 ±  565535.698  ops/s
ListOfBooleansWriting.zioJson      10  thrpt    5  11410538.676 ±   52518.404  ops/s
ListOfBooleansWriting.zioJson      33  thrpt    5   3954503.595 ±   10465.811  ops/s
ListOfBooleansWriting.zioJson     100  thrpt    5   1141918.106 ±   78351.131  ops/s
ListOfBooleansWriting.zioJson     333  thrpt    5    356808.175 ±    8228.529  ops/s
ListOfBooleansWriting.zioJson    1000  thrpt    5    105240.520 ±     537.849  ops/s
```

#### After
```txt
Benchmark                      (size)   Mode  Cnt         Score        Error  Units
ListOfBooleansWriting.zioJson       1  thrpt    5  42893766.949 ± 830789.797  ops/s
ListOfBooleansWriting.zioJson       3  thrpt    5  31424740.861 ± 205664.394  ops/s
ListOfBooleansWriting.zioJson      10  thrpt    5  14039622.426 ± 292832.648  ops/s
ListOfBooleansWriting.zioJson      33  thrpt    5   4321492.200 ±  74325.392  ops/s
ListOfBooleansWriting.zioJson     100  thrpt    5   1406430.432 ±  51164.812  ops/s
ListOfBooleansWriting.zioJson     333  thrpt    5    407791.373 ±   6986.114  ops/s
ListOfBooleansWriting.zioJson    1000  thrpt    5    123098.798 ±   5591.825  ops/s
```