### PR TITLE
More efficient decoding of case classes which have fields with default values

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((3, _)) =>
           Seq(
-            "com.softwaremill.magnolia1_3" %%% "magnolia" % "1.3.10"
+            "com.softwaremill.magnolia1_3" %%% "magnolia" % "1.3.11"
           )
         case _ =>
           Seq(

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -8,7 +8,6 @@ import zio.json.internal.{ FieldEncoder, Lexer, RetractReader, StringMatrix, Wri
 
 import scala.annotation._
 import scala.language.experimental.macros
-import scala.reflect.ClassTag
 
 /**
  * If used on a case class field, determines the name of the JSON field. Defaults to the case class field name.
@@ -659,8 +658,8 @@ object DeriveJsonEncoder {
 
 // backcompat for 2.12, otherwise we'd use ArraySeq.unsafeWrapArray
 private final class ArraySeq(p: Array[Any]) extends IndexedSeq[Any] {
-  def apply(i: Int): Any = p(i)
-  def length: Int        = p.length
+  @inline def apply(i: Int): Any = p(i)
+  @inline def length: Int        = p.length
 }
 
 // intercepts the first `{` of a nested writer and discards it. We also need to


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                   Mode  Cnt       Score      Error  Units
OpenRTBReading.zioJson     thrpt    5  154785.259 ± 8176.370  ops/s
TwitterAPIReading.zioJson  thrpt    5   17774.353 ±  372.782  ops/s
```

#### After
```txt
Benchmark                   Mode  Cnt       Score      Error  Units
OpenRTBReading.zioJson     thrpt    5  180153.071 ± 2194.406  ops/s
TwitterAPIReading.zioJson  thrpt    5   18021.129 ±  564.940  ops/s
```