### PR TITLE
More efficient encoding of floats and doubles without an exponent

### DIFF
--- a/zio-json/js/src/main/scala/zio/json/internal/SafeNumbers.scala
+++ b/zio-json/js/src/main/scala/zio/json/internal/SafeNumbers.scala
@@ -190,14 +190,19 @@ object SafeNumbers {
           }) out.write('0')
           writeMantissa(stripTrailingZeros(dv), out)
         } else {
-          exp += 1
-          if (exp < len) {
-            val w = writes.get
-            writeMantissa(stripTrailingZeros(dv), w)
-            val cs = w.getChars
-            out.write(cs, 0, exp)
+          var pow10i = len - exp - 1
+          if (pow10i > 0) {
+            val pow10 = pow10longs(pow10i)
+            val q     = dv / pow10
+            val r     = dv - q * pow10
+            writeMantissa(q, out)
             out.write('.')
-            out.write(cs, exp, w.length)
+            pow10i -= digitCount(r)
+            while (pow10i > 0) {
+              out.write('0')
+              pow10i -= 1
+            }
+            writeMantissa(stripTrailingZeros(r), out)
           } else {
             writeMantissa(dv.toInt, out)
             out.write('.', '0')
@@ -286,14 +291,19 @@ object SafeNumbers {
           }) out.write('0')
           writeMantissa(stripTrailingZeros(dv), out)
         } else {
-          exp += 1
-          if (exp < len) {
-            val w = writes.get
-            writeMantissa(stripTrailingZeros(dv), w)
-            val cs = w.getChars
-            out.write(cs, 0, exp)
+          var pow10i = len - exp - 1
+          if (pow10i > 0) {
+            val pow10 = pow10ints(pow10i)
+            val q     = dv / pow10
+            val r     = dv - q * pow10
+            writeMantissa(q, out)
             out.write('.')
-            out.write(cs, exp, w.length)
+            pow10i -= digitCount(r)
+            while (pow10i > 0) {
+              out.write('0')
+              pow10i -= 1
+            }
+            writeMantissa(stripTrailingZeros(r), out)
           } else {
             writeMantissa(dv, out)
             out.write('.', '0')
@@ -394,7 +404,7 @@ object SafeNumbers {
     q0
   }
 
-  @inline private[this] def stripTrailingZeros(x: Int): Int = {
+  private[this] def stripTrailingZeros(x: Int): Int = {
     var q0, q1 = x
     while ({
       q0 = q1
@@ -415,7 +425,7 @@ object SafeNumbers {
       }
     }
     var q = q0.toInt
-    if (q0 == q) write(q, out)
+    if (q0 == q) writeMantissa(q, out)
     else {
       var last: Char = 0
       if (q0 >= 1000000000000000000L) {
@@ -436,10 +446,10 @@ object SafeNumbers {
       }
       val q1 = ((q0 >>> 8) * 2.56e-6).toLong // divide a medium positive long by 100000000
       q = q1.toInt
-      if (q1 == q) write(q, out)
+      if (q1 == q) writeMantissa(q, out)
       else {
         q = ((q1 >>> 8) * 1441151881L >>> 49).toInt // divide a small positive long by 100000000
-        write(q, out)
+        writeMantissa(q, out)
         write8Digits((q1 - q * 100000000L).toInt, out)
       }
       write8Digits((q0 - q1 * 100000000L).toInt, out)
@@ -592,6 +602,14 @@ object SafeNumbers {
 
   @inline private[json] def write2Digits(x: Int, out: Write): Unit =
     out.write(digits(x))
+
+  private[this] final val pow10ints: Array[Int] =
+    Array(1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000)
+
+  private[this] final val pow10longs: Array[Long] =
+    Array(1L, 10L, 100L, 1000L, 10000L, 100000L, 1000000L, 10000000L, 100000000L, 1000000000L, 10000000000L,
+      100000000000L, 1000000000000L, 10000000000000L, 100000000000000L, 1000000000000000L, 10000000000000000L,
+      100000000000000000L)
 
   private[this] final val digits: Array[Short] = Array(
     12336, 12592, 12848, 13104, 13360, 13616, 13872, 14128, 14384, 14640, 12337, 12593, 12849, 13105, 13361, 13617,

--- a/zio-json/jvm-native/src/main/scala/zio/json/internal/SafeNumbers.scala
+++ b/zio-json/jvm-native/src/main/scala/zio/json/internal/SafeNumbers.scala
@@ -181,14 +181,19 @@ object SafeNumbers {
           }) out.write('0')
           writeMantissa(stripTrailingZeros(dv), out)
         } else {
-          exp += 1
-          if (exp < len) {
-            val w = writes.get
-            writeMantissa(stripTrailingZeros(dv), w)
-            val cs = w.getChars
-            out.write(cs, 0, exp)
+          var pow10i = len - exp - 1
+          if (pow10i > 0) {
+            val pow10 = pow10longs(pow10i)
+            val q     = dv / pow10
+            val r     = dv - q * pow10
+            writeMantissa(q, out)
             out.write('.')
-            out.write(cs, exp, w.length)
+            pow10i -= digitCount(r)
+            while (pow10i > 0) {
+              out.write('0')
+              pow10i -= 1
+            }
+            writeMantissa(stripTrailingZeros(r), out)
           } else {
             writeMantissa(dv.toInt, out)
             out.write('.', '0')
@@ -277,14 +282,19 @@ object SafeNumbers {
           }) out.write('0')
           writeMantissa(stripTrailingZeros(dv), out)
         } else {
-          exp += 1
-          if (exp < len) {
-            val w = writes.get
-            writeMantissa(stripTrailingZeros(dv), w)
-            val cs = w.getChars
-            out.write(cs, 0, exp)
+          var pow10i = len - exp - 1
+          if (pow10i > 0) {
+            val pow10 = pow10ints(pow10i)
+            val q     = dv / pow10
+            val r     = dv - q * pow10
+            writeMantissa(q, out)
             out.write('.')
-            out.write(cs, exp, w.length)
+            pow10i -= digitCount(r.toLong)
+            while (pow10i > 0) {
+              out.write('0')
+              pow10i -= 1
+            }
+            writeMantissa(stripTrailingZeros(r), out)
           } else {
             writeMantissa(dv, out)
             out.write('.', '0')
@@ -382,14 +392,14 @@ object SafeNumbers {
       }
     }
     val m1 = 100000000L
-    if (q0 < m1) write(q0.toInt, out)
+    if (q0 < m1) writeMantissa(q0.toInt, out)
     else {
       val m2 = 6189700196426901375L
       val q1 = Math.multiplyHigh(q0, m2) >>> 25 // divide a positive long by 100000000
-      if (q1 < m1) write(q1.toInt, out)
+      if (q1 < m1) writeMantissa(q1.toInt, out)
       else {
         val q2 = Math.multiplyHigh(q1, m2) >>> 25 // divide a small positive long by 100000000
-        write(q2.toInt, out)
+        writeMantissa(q2.toInt, out)
         write8Digits((q1 - q2 * m1).toInt, out)
       }
       write8Digits((q0 - q1 * m1).toInt, out)
@@ -541,6 +551,14 @@ object SafeNumbers {
 
   @inline private[json] def write2Digits(x: Int, out: Write): Unit =
     out.write(digits(x))
+
+  private[this] final val pow10ints: Array[Int] =
+    Array(1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000)
+
+  private[this] final val pow10longs: Array[Long] =
+    Array(1L, 10L, 100L, 1000L, 10000L, 100000L, 1000000L, 10000000L, 100000000L, 1000000000L, 10000000000L,
+      100000000000L, 1000000000000L, 10000000000000L, 100000000000000L, 1000000000000000L, 10000000000000000L,
+      100000000000000000L)
 
   private[this] final val digits: Array[Short] = Array(
     12336, 12592, 12848, 13104, 13360, 13616, 13872, 14128, 14384, 14640, 12337, 12593, 12849, 13105, 13361, 13617,


### PR DESCRIPTION
Tested with Scala 3 and GraalVM JDK-25ea on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                            (size)   Mode  Cnt        Score        Error  Units
ArrayOfDoublesWriting.zioJson           128  thrpt    5   213042.974 ±   1967.557  ops/s
ArrayOfDoublesWriting.zioSchemaJson     128  thrpt    5   210949.814 ±   2905.848  ops/s
ArrayOfFloatsWriting.zioJson            128  thrpt    5   285297.646 ±   7687.284  ops/s
ArrayOfFloatsWriting.zioSchemaJson      128  thrpt    5   314495.765 ±   5640.222  ops/s
GeoJSONWriting.zioJson                  N/A  thrpt    5    16847.105 ±   1045.649  ops/s
GeoJSONWriting.zioSchemaJson            N/A  thrpt    5    26026.200 ±    349.518  ops/s
```

#### After
```txt
Benchmark                            (size)   Mode  Cnt        Score        Error  Units
ArrayOfDoublesWriting.zioJson           128  thrpt    5   216015.004 ±   5348.566  ops/s
ArrayOfDoublesWriting.zioSchemaJson     128  thrpt    5   220146.565 ±   1437.523  ops/s
ArrayOfFloatsWriting.zioJson            128  thrpt    5   337490.570 ±  22496.827  ops/s
ArrayOfFloatsWriting.zioSchemaJson      128  thrpt    5   331373.715 ±   3244.506  ops/s
GeoJSONWriting.zioJson                  N/A  thrpt    5    14534.595 ±   2277.668  ops/s
GeoJSONWriting.zioSchemaJson            N/A  thrpt    5    32090.535 ±    682.181  ops/s
```