### PR TITLE
More efficient default encoding to strings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,8 +227,9 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       exclude[Problem]("zio.json.package.*")
     ),
     libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time"      % scalaJavaTimeVersion,
-      "io.github.cquiroz" %%% "scala-java-time-tzdb" % scalaJavaTimeVersion % "test"
+      ("org.scala-js"     %%% "scalajs-weakreferences" % "1.0.0").cross(CrossVersion.for3Use2_13),
+      "io.github.cquiroz" %%% "scala-java-time"        % scalaJavaTimeVersion,
+      "io.github.cquiroz" %%% "scala-java-time-tzdb"   % scalaJavaTimeVersion % "test"
     )
   )
   .nativeSettings(nativeSettings)

--- a/zio-json/js/src/main/scala/zio/json/internal/FastStringWrite.scala
+++ b/zio-json/js/src/main/scala/zio/json/internal/FastStringWrite.scala
@@ -6,10 +6,6 @@ final class FastStringWrite(initial: Int) extends Write {
 
   @inline def reset(): Unit = chars = ""
 
-  @inline private[internal] def length: Int = chars.length
-
-  @inline private[internal] def getChars: Array[Char] = chars.toCharArray
-
   @inline def write(s: String): Unit = chars += s
 
   @inline def write(c: Char): Unit = chars += c
@@ -81,4 +77,6 @@ final class FastStringWrite(initial: Int) extends Write {
   }
 
   @inline def buffer: CharSequence = chars
+
+  @inline override def toString: String = chars
 }

--- a/zio-json/js/src/main/scala/zio/json/internal/SafeNumbers.scala
+++ b/zio-json/js/src/main/scala/zio/json/internal/SafeNumbers.scala
@@ -81,31 +81,31 @@ object SafeNumbers {
   def toString(x: java.math.BigDecimal): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def toString(x: java.math.BigInteger): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def toString(x: Double): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def toString(x: Float): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def toString(x: UUID): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: java.math.BigDecimal, out: Write): Unit = {

--- a/zio-json/jvm-native/src/main/scala/zio/json/internal/FastStringWrite.scala
+++ b/zio-json/jvm-native/src/main/scala/zio/json/internal/FastStringWrite.scala
@@ -10,10 +10,6 @@ final class FastStringWrite(initial: Int) extends Write {
 
   @inline def reset(): Unit = count = 0
 
-  @inline private[internal] def length: Int = count
-
-  @inline private[internal] def getChars: Array[Char] = chars
-
   def write(s: String): Unit = {
     val l  = s.length
     var cs = chars
@@ -168,4 +164,6 @@ final class FastStringWrite(initial: Int) extends Write {
   }
 
   def buffer: CharSequence = CharBuffer.wrap(chars, 0, count)
+
+  override def toString: String = new String(chars, 0, count)
 }

--- a/zio-json/jvm-native/src/main/scala/zio/json/internal/SafeNumbers.scala
+++ b/zio-json/jvm-native/src/main/scala/zio/json/internal/SafeNumbers.scala
@@ -81,31 +81,31 @@ object SafeNumbers {
   def toString(x: java.math.BigDecimal): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def toString(x: java.math.BigInteger): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def toString(x: Double): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def toString(x: Float): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def toString(x: UUID): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: java.math.BigDecimal, out: Write): Unit = {

--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -19,7 +19,6 @@ import zio.json.ast.Json
 import zio.json.internal.{ FastStringWrite, SafeNumbers, Write }
 import zio.json.javatime.serializers
 import zio.{ Chunk, NonEmptyChunk }
-
 import java.util.UUID
 import scala.annotation._
 import scala.collection.{ immutable, mutable }
@@ -67,9 +66,12 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
    * Encodes the specified value into a JSON string, with the specified indentation level.
    */
   final def encodeJson(a: A, indent: Option[Int] = None): CharSequence = {
-    val writer = new FastStringWrite(64)
-    unsafeEncode(a, indent, writer)
-    writer.buffer
+    val writePool = JsonEncoder.writePools.get
+    try {
+      val write = writePool.acquire()
+      unsafeEncode(a, indent, write)
+      write.toString
+    } finally writePool.release()
   }
 
   /**
@@ -111,6 +113,35 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
 }
 
 object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with JsonEncoderVersionSpecific {
+  private class FastStringWritePool {
+    private[this] var weakRef: java.lang.ref.WeakReference[Array[FastStringWrite]] =
+      new java.lang.ref.WeakReference(Array(new FastStringWrite(64)))
+    private[this] var level: Int = 0
+
+    def acquire(): FastStringWrite = {
+      var writes = weakRef.get
+      if (writes eq null) { // the reference was collected by GC
+        level = 0
+        writes = new Array(0)
+      }
+      if (level == writes.length) { // exceding the deepest level of recusion
+        writes = java.util.Arrays.copyOf(writes, level + 1)
+        writes(level) = new FastStringWrite(64)
+        weakRef = new java.lang.ref.WeakReference(writes)
+      }
+      val write = writes(level)
+      level += 1 // increase the level of recusrion
+      write.reset()
+      write
+    }
+
+    def release(): Unit = level -= 1 // decrease the level of recusrion
+  }
+
+  private val writePools = new ThreadLocal[FastStringWritePool] {
+    override def initialValue(): FastStringWritePool = new FastStringWritePool
+  }
+
   @inline def apply[A](implicit a: JsonEncoder[A]): JsonEncoder[A] = a
 
   implicit val string: JsonEncoder[String] = new JsonEncoder[String] {

--- a/zio-json/shared/src/main/scala/zio/json/javatime/serializers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/serializers.scala
@@ -23,7 +23,7 @@ private[json] object serializers {
   def toString(x: Duration): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: Duration, out: Write): Unit = {
@@ -61,7 +61,7 @@ private[json] object serializers {
   def toString(x: Instant): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: Instant, out: Write): Unit = {
@@ -124,7 +124,7 @@ private[json] object serializers {
   def toString(x: LocalDate): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: LocalDate, out: Write): Unit = {
@@ -138,7 +138,7 @@ private[json] object serializers {
   def toString(x: LocalDateTime): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: LocalDateTime, out: Write): Unit = {
@@ -150,7 +150,7 @@ private[json] object serializers {
   def toString(x: LocalTime): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: LocalTime, out: Write): Unit = {
@@ -166,7 +166,7 @@ private[json] object serializers {
   def toString(x: MonthDay): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: MonthDay, out: Write): Unit = {
@@ -179,7 +179,7 @@ private[json] object serializers {
   def toString(x: OffsetDateTime): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: OffsetDateTime, out: Write): Unit = {
@@ -192,7 +192,7 @@ private[json] object serializers {
   def toString(x: OffsetTime): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: OffsetTime, out: Write): Unit = {
@@ -203,7 +203,7 @@ private[json] object serializers {
   def toString(x: Period): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: Period, out: Write): Unit = {
@@ -231,7 +231,7 @@ private[json] object serializers {
   def toString(x: Year): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   @inline def write(x: Year, out: Write): Unit = writeYear(x.getValue, out)
@@ -239,7 +239,7 @@ private[json] object serializers {
   def toString(x: YearMonth): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: YearMonth, out: Write): Unit = {
@@ -251,7 +251,7 @@ private[json] object serializers {
   def toString(x: ZonedDateTime): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: ZonedDateTime, out: Write): Unit = {
@@ -274,7 +274,7 @@ private[json] object serializers {
   def toString(x: ZoneOffset): String = {
     val out = writes.get
     write(x, out)
-    out.buffer.toString
+    out.toString
   }
 
   def write(x: ZoneOffset, out: Write): Unit = {


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                                  (size)   Mode  Cnt         Score         Error  Units
ADTWriting.zioJson                            N/A  thrpt    5   2446477.121 ±    3828.169  ops/s
AnyValsWriting.zioJson                        N/A  thrpt    5   4285913.815 ±   78292.399  ops/s
ArrayBufferOfBooleansWriting.zioJson          128  thrpt    5   1048903.155 ±   32001.706  ops/s
ArrayOfBigDecimalsWriting.zioJson             128  thrpt    5     86577.324 ±    3435.528  ops/s
ArrayOfBigIntsWriting.zioJson                 128  thrpt    5     96500.939 ±    1358.784  ops/s
ArrayOfBooleansWriting.zioJson                128  thrpt    5    954080.727 ±   34228.978  ops/s
ArrayOfBytesWriting.zioJson                   128  thrpt    5   1334865.579 ±   15756.476  ops/s
ArrayOfCharsWriting.zioJson                   128  thrpt    5   1202856.554 ±   34615.643  ops/s
ArrayOfDoublesWriting.zioJson                 128  thrpt    5    188174.779 ±    1474.490  ops/s
ArrayOfDurationsWriting.zioJson               128  thrpt    5    171971.039 ±    3536.193  ops/s
ArrayOfEnumADTsWriting.zioJson                128  thrpt    5    553561.970 ±    9631.389  ops/s
ArrayOfEnumsWriting.zioJson                   128  thrpt    5    671131.338 ±   12585.420  ops/s
ArrayOfFloatsWriting.zioJson                  128  thrpt    5    266833.716 ±    8676.455  ops/s
ArrayOfInstantsWriting.zioJson                128  thrpt    5    164825.490 ±    1095.352  ops/s
ArrayOfIntsWriting.zioJson                    128  thrpt    5    717845.231 ±    9501.502  ops/s
ArrayOfLocalDateTimesWriting.zioJson          128  thrpt    5    232596.453 ±    2859.296  ops/s
ArrayOfLocalDatesWriting.zioJson              128  thrpt    5    378415.567 ±    2655.644  ops/s
ArrayOfLocalTimesWriting.zioJson              128  thrpt    5    321630.004 ±    3527.985  ops/s
ArrayOfLongsWriting.zioJson                   128  thrpt    5    394422.779 ±    7256.495  ops/s
ArrayOfMonthDaysWriting.zioJson               128  thrpt    5    660578.112 ±   24556.711  ops/s
ArrayOfOffsetDateTimesWriting.zioJson         128  thrpt    5    159983.513 ±    1550.934  ops/s
ArrayOfOffsetTimesWriting.zioJson             128  thrpt    5    249814.823 ±    6870.869  ops/s
ArrayOfPeriodsWriting.zioJson                 128  thrpt    5    205605.870 ±    7026.158  ops/s
ArrayOfShortsWriting.zioJson                  128  thrpt    5    910325.023 ±   25976.309  ops/s
ArrayOfUUIDsWriting.zioJson                   128  thrpt    5    171786.704 ±    2487.755  ops/s
ArrayOfYearMonthsWriting.zioJson              128  thrpt    5    565643.079 ±   18377.583  ops/s
ArrayOfYearsWriting.zioJson                   128  thrpt    5    938795.881 ±   14207.508  ops/s
ArrayOfZoneIdsWriting.zioJson                 128  thrpt    5    560009.700 ±    7515.634  ops/s
ArrayOfZoneOffsetsWriting.zioJson             128  thrpt    5    621881.443 ±    9857.014  ops/s
ArrayOfZonedDateTimesWriting.zioJson          128  thrpt    5    137084.167 ±    1834.363  ops/s
ArraySeqOfBooleansWriting.zioJson             128  thrpt    5    979283.444 ±   19265.165  ops/s
Base64Writing.zioJson                         128  thrpt    5   6570745.371 ±   65448.657  ops/s
BigDecimalWriting.zioJson                     128  thrpt    5   1094923.105 ±   20745.723  ops/s
BigIntWriting.zioJson                         128  thrpt    5   1102699.927 ±   15835.377  ops/s
GeoJSONWriting.zioJson                        N/A  thrpt    5     15777.406 ±     240.390  ops/s
GitHubActionsAPIWriting.zioJson               N/A  thrpt    5    604002.506 ±    7590.858  ops/s
GoogleMapsAPIWriting.zioJson                  N/A  thrpt    5     35982.755 ±     346.175  ops/s
IntWriting.zioJson                            N/A  thrpt    5  37856674.221 ± 1067274.716  ops/s
ListOfBooleansWriting.zioJson                 128  thrpt    5   1185395.642 ±   32794.682  ops/s
MapOfIntsToBooleansWriting.zioJson            128  thrpt    5    257214.860 ±    7204.003  ops/s
MutableMapOfIntsToBooleansWriting.zioJson     128  thrpt    5    246645.651 ±    6746.935  ops/s
MutableSetOfIntsWriting.zioJson               128  thrpt    5    537335.499 ±    8506.192  ops/s
NestedStructsWriting.zioJson                  128  thrpt    5    419511.531 ±    3701.376  ops/s
PrimitivesWriting.zioJson                     N/A  thrpt    5   6242401.376 ±  190914.026  ops/s
SetOfIntsWriting.zioJson                      128  thrpt    5    563397.372 ±   18761.546  ops/s
StringOfAsciiCharsWriting.zioJson             128  thrpt    5   8235744.007 ±  178053.061  ops/s
StringOfNonAsciiCharsWriting.zioJson          128  thrpt    5   3203330.710 ±   49931.776  ops/s
VectorOfBooleansWriting.zioJson               128  thrpt    5   1178248.051 ±   20358.365  ops/s
```

#### After
```txt
Benchmark                                  (size)   Mode  Cnt         Score         Error  Units
ADTWriting.zioJson                            N/A  thrpt    5   2491707.239 ±   44895.386  ops/s
AnyValsWriting.zioJson                        N/A  thrpt    5   4311092.014 ±  100336.209  ops/s
ArrayBufferOfBooleansWriting.zioJson          128  thrpt    5    996157.885 ±    6463.267  ops/s
ArrayOfBigDecimalsWriting.zioJson             128  thrpt    5     97507.215 ±    5617.251  ops/s
ArrayOfBigIntsWriting.zioJson                 128  thrpt    5    107400.220 ±    9246.735  ops/s
ArrayOfBooleansWriting.zioJson                128  thrpt    5   1234944.795 ±   54006.461  ops/s
ArrayOfBytesWriting.zioJson                   128  thrpt    5   1277836.743 ±   20299.217  ops/s
ArrayOfCharsWriting.zioJson                   128  thrpt    5   1128524.776 ±   29576.307  ops/s
ArrayOfDoublesWriting.zioJson                 128  thrpt    5    242208.039 ±   10367.750  ops/s
ArrayOfDurationsWriting.zioJson               128  thrpt    5    216276.979 ±    2569.403  ops/s
ArrayOfEnumADTsWriting.zioJson                128  thrpt    5    781166.582 ±   17842.093  ops/s
ArrayOfEnumsWriting.zioJson                   128  thrpt    5    782548.099 ±    8104.795  ops/s
ArrayOfFloatsWriting.zioJson                  128  thrpt    5    292755.364 ±    5647.454  ops/s
ArrayOfInstantsWriting.zioJson                128  thrpt    5    221307.781 ±    5681.666  ops/s
ArrayOfIntsWriting.zioJson                    128  thrpt    5    680636.325 ±    8380.584  ops/s
ArrayOfLocalDateTimesWriting.zioJson          128  thrpt    5    209568.218 ±    1054.299  ops/s
ArrayOfLocalDatesWriting.zioJson              128  thrpt    5    441581.956 ±    4408.013  ops/s
ArrayOfLocalTimesWriting.zioJson              128  thrpt    5    320613.110 ±     880.005  ops/s
ArrayOfLongsWriting.zioJson                   128  thrpt    5    498552.082 ±    8344.910  ops/s
ArrayOfMonthDaysWriting.zioJson               128  thrpt    5    537401.955 ±    4020.940  ops/s
ArrayOfOffsetDateTimesWriting.zioJson         128  thrpt    5    258975.996 ±    1513.878  ops/s
ArrayOfOffsetTimesWriting.zioJson             128  thrpt    5    225722.085 ±    6814.133  ops/s
ArrayOfPeriodsWriting.zioJson                 128  thrpt    5    245310.530 ±    3633.747  ops/s
ArrayOfShortsWriting.zioJson                  128  thrpt    5    895010.540 ±    4207.154  ops/s
ArrayOfUUIDsWriting.zioJson                   128  thrpt    5    220832.419 ±     806.009  ops/s
ArrayOfYearMonthsWriting.zioJson              128  thrpt    5    503854.941 ±    2277.717  ops/s
ArrayOfYearsWriting.zioJson                   128  thrpt    5    820728.520 ±    5668.814  ops/s
ArrayOfZoneIdsWriting.zioJson                 128  thrpt    5    576730.719 ±   19851.234  ops/s
ArrayOfZoneOffsetsWriting.zioJson             128  thrpt    5    571654.905 ±    3420.433  ops/s
ArrayOfZonedDateTimesWriting.zioJson          128  thrpt    5    133038.612 ±     687.499  ops/s
ArraySeqOfBooleansWriting.zioJson             128  thrpt    5   1471592.783 ±   43680.998  ops/s
Base64Writing.zioJson                         128  thrpt    5  12972785.339 ±  358726.596  ops/s
BigDecimalWriting.zioJson                     128  thrpt    5   1100075.426 ±   16711.260  ops/s
BigIntWriting.zioJson                         128  thrpt    5   1117156.257 ±   28000.544  ops/s
GeoJSONWriting.zioJson                        N/A  thrpt    5     16979.473 ±     378.278  ops/s
GitHubActionsAPIWriting.zioJson               N/A  thrpt    5    855308.376 ±   11061.669  ops/s
GoogleMapsAPIWriting.zioJson                  N/A  thrpt    5     42801.236 ±     276.868  ops/s
IntWriting.zioJson                            N/A  thrpt    5  45233221.961 ± 1805425.617  ops/s
ListOfBooleansWriting.zioJson                 128  thrpt    5   1019140.834 ±   10075.400  ops/s
MapOfIntsToBooleansWriting.zioJson            128  thrpt    5    303441.399 ±    7537.146  ops/s
MutableMapOfIntsToBooleansWriting.zioJson     128  thrpt    5    310776.329 ±    2659.552  ops/s
MutableSetOfIntsWriting.zioJson               128  thrpt    5    676033.780 ±   24389.161  ops/s
NestedStructsWriting.zioJson                  128  thrpt    5    244730.670 ±    2176.845  ops/s
PrimitivesWriting.zioJson                     N/A  thrpt    5   5834958.116 ±  451931.165  ops/s
SetOfIntsWriting.zioJson                      128  thrpt    5    718218.891 ±    5242.705  ops/s
StringOfAsciiCharsWriting.zioJson             128  thrpt    5  11733973.120 ±   47722.106  ops/s
StringOfNonAsciiCharsWriting.zioJson          128  thrpt    5   3670975.627 ±   16357.948  ops/s
VectorOfBooleansWriting.zioJson               128  thrpt    5   1145200.410 ±    4321.598  ops/s
```