### PR TITLE
More efficient decoding of UUIDs

### DIFF
--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonFieldDecoder.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonFieldDecoder.scala
@@ -69,11 +69,11 @@ object JsonFieldDecoder extends LowPriorityJsonFieldDecoder {
     def unsafeDecodeField(trace: List[JsonError], in: String): java.util.UUID =
       try UUIDParser.unsafeParse(in)
       catch {
-        case _: IllegalArgumentException => Lexer.error(s"Invalid UUID: ${strip(in)}", trace)
+        case _: IllegalArgumentException => Lexer.error("expected UUID string", trace)
       }
   }
 
-  // use this instead of `string.mapOrFail` in supertypes (to prevent class initialization error at runtime)
+  // FIXME: remove from the next major version
   private[json] def mapStringOrFail[A](f: String => Either[String, A]): JsonFieldDecoder[A] =
     new JsonFieldDecoder[A] {
       def unsafeDecodeField(trace: List[JsonError], in: String): A =

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonFieldDecoder.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonFieldDecoder.scala
@@ -69,11 +69,11 @@ object JsonFieldDecoder extends LowPriorityJsonFieldDecoder {
     def unsafeDecodeField(trace: List[JsonError], in: String): java.util.UUID =
       try UUIDParser.unsafeParse(in)
       catch {
-        case _: IllegalArgumentException => Lexer.error(s"Invalid UUID: ${strip(in)}", trace)
+        case _: IllegalArgumentException => Lexer.error("expected UUID string", trace)
       }
   }
 
-  // use this instead of `string.mapOrFail` in supertypes (to prevent class initialization error at runtime)
+  // FIXME: remove from the next major version
   private[json] def mapStringOrFail[A](f: String => Either[String, A]): JsonFieldDecoder[A] =
     new JsonFieldDecoder[A] {
       def unsafeDecodeField(trace: List[JsonError], in: String): A =

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -910,19 +910,16 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
     }
 
   implicit val uuid: JsonDecoder[UUID] = new JsonDecoder[UUID] {
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): UUID =
-      parseUUID(trace, Lexer.string(trace, in).toString)
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): UUID = Lexer.uuid(trace, in)
 
     override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): UUID =
       json match {
-        case s: Json.Str => parseUUID(trace, s.value)
-        case _           => Lexer.error("expected string", trace)
-      }
-
-    @inline private[this] def parseUUID(trace: List[JsonError], s: String): UUID =
-      try UUIDParser.unsafeParse(s)
-      catch {
-        case _: IllegalArgumentException => Lexer.error(s"Invalid UUID: ${strip(s)}", trace)
+        case s: Json.Str =>
+          try UUIDParser.unsafeParse(s.value)
+          catch {
+            case _: IllegalArgumentException => Lexer.error("expected UUID string", trace)
+          }
+        case _ => Lexer.error("expected UUID string", trace)
       }
   }
 

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -17,6 +17,7 @@ package zio.json.internal
 
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 
+import java.util.UUID
 import scala.annotation._
 
 // tries to stick to the spec, but maybe a bit loose in places (e.g. numbers)
@@ -206,8 +207,155 @@ object Lexer {
     new String(cs, 0, i)
   }
 
+  def uuid(trace: List[JsonError], in: OneCharReader): UUID = {
+    var c = in.nextNonWhitespace()
+    if (c != '"') error("'\"'", c, trace)
+    var cs = charArrays.get
+    var i  = 0
+    while ({
+      c = in.readChar()
+      c != '"'
+    }) {
+      if (c == '\\') c = nextEscaped(trace, in)
+      if (c > 0xff) uuidError(trace)
+      if (i == cs.length) cs = java.util.Arrays.copyOf(cs, i << 1)
+      cs(i) = c
+      i += 1
+    }
+    if (
+      i == 36 && {
+        val c1 = cs(8)
+        val c2 = cs(13)
+        val c3 = cs(18)
+        val c4 = cs(23)
+        c1 == '-' && c2 == '-' && c3 == '-' && c4 == '-'
+      }
+    ) {
+      val ds = hexDigits
+      val msb1 =
+        ds(cs(0).toInt).toLong << 28 |
+          (ds(cs(1).toInt) << 24 |
+            ds(cs(2).toInt) << 20 |
+            ds(cs(3).toInt) << 16 |
+            ds(cs(4).toInt) << 12 |
+            ds(cs(5).toInt) << 8 |
+            ds(cs(6).toInt) << 4 |
+            ds(cs(7).toInt))
+      val msb2 =
+        ds(cs(9).toInt) << 12 |
+          ds(cs(10).toInt) << 8 |
+          ds(cs(11).toInt) << 4 |
+          ds(cs(12).toInt)
+      val msb3 =
+        ds(cs(14).toInt) << 12 |
+          ds(cs(15).toInt) << 8 |
+          ds(cs(16).toInt) << 4 |
+          ds(cs(17).toInt)
+      val lsb1 =
+        ds(cs(19).toInt) << 12 |
+          ds(cs(20).toInt) << 8 |
+          ds(cs(21).toInt) << 4 |
+          ds(cs(22).toInt)
+      val lsb2 =
+        (ds(cs(24).toInt) << 16 |
+          ds(cs(25).toInt) << 12 |
+          ds(cs(26).toInt) << 8 |
+          ds(cs(27).toInt) << 4 |
+          ds(cs(28).toInt)).toLong << 28 |
+          (ds(cs(29).toInt) << 24 |
+            ds(cs(30).toInt) << 20 |
+            ds(cs(31).toInt) << 16 |
+            ds(cs(32).toInt) << 12 |
+            ds(cs(33).toInt) << 8 |
+            ds(cs(34).toInt) << 4 |
+            ds(cs(35).toInt))
+      if ((msb1 | msb2 | msb3 | lsb1 | lsb2) >= 0L) {
+        return new UUID(msb1 << 32 | msb2.toLong << 16 | msb3, lsb1.toLong << 48 | lsb2)
+      }
+    } else if (i <= 36) {
+      return uuidExtended(trace, cs, i)
+    }
+    uuidError(trace)
+  }
+
+  private[this] def uuidExtended(trace: List[JsonError], cs: Array[Char], len: Int): UUID = {
+    val dash1 = indexOfDash(cs, 1, len)
+    val dash2 = indexOfDash(cs, dash1 + 2, len)
+    val dash3 = indexOfDash(cs, dash2 + 2, len)
+    val dash4 = indexOfDash(cs, dash3 + 2, len)
+    if (dash4 >= 0) {
+      val ds       = hexDigits
+      val section1 = uuidSection(trace, ds, cs, 0, dash1, 0xffffffff00000000L)
+      val section2 = uuidSection(trace, ds, cs, dash1 + 1, dash2, 0xffffffffffff0000L)
+      val section3 = uuidSection(trace, ds, cs, dash2 + 1, dash3, 0xffffffffffff0000L)
+      val section4 = uuidSection(trace, ds, cs, dash3 + 1, dash4, 0xffffffffffff0000L)
+      val section5 = uuidSection(trace, ds, cs, dash4 + 1, len, 0xffff000000000000L)
+      return new UUID((section1 << 32) | (section2 << 16) | section3, (section4 << 48) | section5)
+    }
+    uuidError(trace)
+  }
+
+  private[this] def indexOfDash(cs: Array[Char], from: Int, to: Int): Int = {
+    var i = from
+    while (i < to) {
+      if (cs(i) == '-') return i
+      i += 1
+    }
+    -1
+  }
+
+  private[this] def uuidSection(
+    trace: List[JsonError],
+    ds: Array[Byte],
+    cs: Array[Char],
+    from: Int,
+    to: Int,
+    mask: Long
+  ): Long = {
+    if (from < to && from + 16 >= to) {
+      var result = 0L
+      var i      = from
+      while (i < to) {
+        result = (result << 4) | ds(cs(i).toInt)
+        i += 1
+      }
+      if ((result & mask) == 0L) return result
+    }
+    uuidError(trace)
+  }
+
+  @noinline private[this] def uuidError(trace: List[JsonError]): Nothing = error("expected UUID string", trace)
+
   private[this] val charArrays = new ThreadLocal[Array[Char]] {
     override def initialValue(): Array[Char] = new Array[Char](1024)
+  }
+
+  private[this] val hexDigits: Array[Byte] = {
+    val ns = new Array[Byte](256)
+    java.util.Arrays.fill(ns, -1: Byte)
+    ns('0') = 0
+    ns('1') = 1
+    ns('2') = 2
+    ns('3') = 3
+    ns('4') = 4
+    ns('5') = 5
+    ns('6') = 6
+    ns('7') = 7
+    ns('8') = 8
+    ns('9') = 9
+    ns('A') = 10
+    ns('B') = 11
+    ns('C') = 12
+    ns('D') = 13
+    ns('E') = 14
+    ns('F') = 15
+    ns('a') = 10
+    ns('b') = 11
+    ns('c') = 12
+    ns('d') = 13
+    ns('e') = 14
+    ns('f') = 15
+    ns
   }
 
   def char(trace: List[JsonError], in: OneCharReader): Char = {

--- a/zio-json/shared/src/main/scala/zio/json/uuid/UUIDParser.scala
+++ b/zio-json/shared/src/main/scala/zio/json/uuid/UUIDParser.scala
@@ -15,16 +15,13 @@
  */
 package zio.json.uuid
 
-import scala.annotation.nowarn
+import java.util.UUID
 import scala.util.control.NoStackTrace
 
-// A port of https://github.com/openjdk/jdk/commit/ebadfaeb2e1cc7b5ce5f101cd8a539bc5478cf5b with optimizations applied
 private[json] object UUIDParser {
-  // Converts characters to their numeric representation (for example 'E' or 'e' becomes 0XE)
-  private[this] val CharToNumeric: Array[Byte] = {
-    // by filling in -1's we prevent from trying to parse invalid characters
-    val ns = Array.fill[Byte](256)(-1)
-
+  private[this] val hexDigits: Array[Byte] = {
+    val ns = new Array[Byte](256)
+    java.util.Arrays.fill(ns, -1: Byte)
     ns('0') = 0
     ns('1') = 1
     ns('2') = 2
@@ -35,104 +32,92 @@ private[json] object UUIDParser {
     ns('7') = 7
     ns('8') = 8
     ns('9') = 9
-
     ns('A') = 10
     ns('B') = 11
     ns('C') = 12
     ns('D') = 13
     ns('E') = 14
     ns('F') = 15
-
     ns('a') = 10
     ns('b') = 11
     ns('c') = 12
     ns('d') = 13
     ns('e') = 14
     ns('f') = 15
-
     ns
   }
 
-  def unsafeParse(input: String): java.util.UUID =
+  def unsafeParse(input: String): java.util.UUID = {
     if (
-      input.length != 36 || {
+      input.length == 36 && {
         val ch1 = input.charAt(8)
         val ch2 = input.charAt(13)
         val ch3 = input.charAt(18)
         val ch4 = input.charAt(23)
-        ch1 != '-' || ch2 != '-' || ch3 != '-' || ch4 != '-'
+        ch1 == '-' && ch2 == '-' && ch3 == '-' && ch4 == '-'
       }
-    ) unsafeParseExtended(input)
-    else {
-      val ch2n = CharToNumeric
-      val msb1 = parseNibbles(ch2n, input, 0)
-      val msb2 = parseNibbles(ch2n, input, 4)
-      val msb3 = parseNibbles(ch2n, input, 9)
-      val msb4 = parseNibbles(ch2n, input, 14)
-      val lsb1 = parseNibbles(ch2n, input, 19)
-      val lsb2 = parseNibbles(ch2n, input, 24)
-      val lsb3 = parseNibbles(ch2n, input, 28)
-      val lsb4 = parseNibbles(ch2n, input, 32)
-      if ((msb1 | msb2 | msb3 | msb4 | lsb1 | lsb2 | lsb3 | lsb4) < 0) invalidUUIDError()
-      new java.util.UUID(msb1 << 48 | msb2 << 32 | msb3 << 16 | msb4, lsb1 << 48 | lsb2 << 32 | lsb3 << 16 | lsb4)
+    ) {
+      val ds   = hexDigits
+      val msb1 = uuidNibble(ds, input, 0)
+      val msb2 = uuidNibble(ds, input, 4)
+      val msb3 = uuidNibble(ds, input, 9)
+      val msb4 = uuidNibble(ds, input, 14)
+      val lsb1 = uuidNibble(ds, input, 19)
+      val lsb2 = uuidNibble(ds, input, 24)
+      val lsb3 = uuidNibble(ds, input, 28)
+      val lsb4 = uuidNibble(ds, input, 32)
+      if ((msb1 | msb2 | msb3 | msb4 | lsb1 | lsb2 | lsb3 | lsb4) >= 0) {
+        return new UUID(
+          msb1.toLong << 48 | msb2.toLong << 32 | msb3.toLong << 16 | msb4,
+          lsb1.toLong << 48 | lsb2.toLong << 32 | lsb3.toLong << 16 | lsb4
+        )
+      }
+    } else if (input.length <= 36) {
+      return uuidExtended(input)
     }
-
-  // A nibble is 4 bits
-  @nowarn("msg=implicit numeric widening")
-  private[this] def parseNibbles(ch2n: Array[Byte], input: String, position: Int): Long = {
-    val ch1 = input.charAt(position)
-    val ch2 = input.charAt(position + 1)
-    val ch3 = input.charAt(position + 2)
-    val ch4 = input.charAt(position + 3)
-    if ((ch1 | ch2 | ch3 | ch4) > 0xff) -1L
-    else ch2n(ch1) << 12 | ch2n(ch2) << 8 | ch2n(ch3) << 4 | ch2n(ch4)
+    uuidError()
   }
 
-  private[this] def unsafeParseExtended(input: String): java.util.UUID = {
-    val len = input.length
-    if (len > 36) invalidUUIDError()
-    val dash1 = input.indexOf('-', 0)
-    val dash2 = input.indexOf('-', dash1 + 1)
-    val dash3 = input.indexOf('-', dash2 + 1)
-    val dash4 = input.indexOf('-', dash3 + 1)
-    val dash5 = input.indexOf('-', dash4 + 1)
-
-    // For any valid input, dash1 through dash4 will be positive and dash5 will be negative,
-    // but it's enough to check dash4 and dash5:
-    // - if dash1 is -1, dash4 will be -1
-    // - if dash1 is positive but dash2 is -1, dash4 will be -1
-    // - if dash1 and dash2 is positive, dash3 will be -1, dash4 will be positive, but so will dash5
-    if (dash4 < 0 || dash5 >= 0) invalidUUIDError()
-
-    val ch2n     = CharToNumeric
-    val section1 = parseSection(ch2n, input, 0, dash1, 0xfffffff00000000L)
-    val section2 = parseSection(ch2n, input, dash1 + 1, dash2, 0xfffffffffff0000L)
-    val section3 = parseSection(ch2n, input, dash2 + 1, dash3, 0xfffffffffff0000L)
-    val section4 = parseSection(ch2n, input, dash3 + 1, dash4, 0xfffffffffff0000L)
-    val section5 = parseSection(ch2n, input, dash4 + 1, len, 0xfff000000000000L)
-    new java.util.UUID((section1 << 32) | (section2 << 16) | section3, (section4 << 48) | section5)
+  private[this] def uuidNibble(ds: Array[Byte], input: String, offset: Int): Int = {
+    val ch1 = input.charAt(offset).toInt
+    val ch2 = input.charAt(offset + 1).toInt
+    val ch3 = input.charAt(offset + 2).toInt
+    val ch4 = input.charAt(offset + 3).toInt
+    if ((ch1 | ch2 | ch3 | ch4) > 0xff) -1
+    else ds(ch1) << 12 | ds(ch2) << 8 | ds(ch3) << 4 | ds(ch4)
   }
 
-  @nowarn("msg=implicit numeric widening")
-  private[this] def parseSection(
-    ch2n: Array[Byte],
-    input: String,
-    beginIndex: Int,
-    endIndex: Int,
-    zeroMask: Long
-  ): Long = {
-    if (beginIndex >= endIndex || beginIndex + 16 < endIndex) invalidUUIDError()
-    var result = 0L
-    var i      = beginIndex
-    while (i < endIndex) {
-      result = (result << 4) | ch2n(input.charAt(i))
-      i += 1
+  private[this] def uuidExtended(input: String): UUID = {
+    val dash1 = input.indexOf('-', 1)
+    val dash2 = input.indexOf('-', dash1 + 2)
+    val dash3 = input.indexOf('-', dash2 + 2)
+    val dash4 = input.indexOf('-', dash3 + 2)
+    if (dash4 >= 0) {
+      val ds       = hexDigits
+      val section1 = uuidSection(ds, input, 0, dash1, 0xffffffff00000000L)
+      val section2 = uuidSection(ds, input, dash1 + 1, dash2, 0xffffffffffff0000L)
+      val section3 = uuidSection(ds, input, dash2 + 1, dash3, 0xffffffffffff0000L)
+      val section4 = uuidSection(ds, input, dash3 + 1, dash4, 0xffffffffffff0000L)
+      val section5 = uuidSection(ds, input, dash4 + 1, input.length, 0xffff000000000000L)
+      return new UUID((section1 << 32) | (section2 << 16) | section3, (section4 << 48) | section5)
     }
-    if ((result & zeroMask) != 0) invalidUUIDError()
-    result
+    uuidError()
   }
 
-  @noinline
-  private[this] def invalidUUIDError(): Nothing =
-    throw new IllegalArgumentException with NoStackTrace
+  private[this] def uuidSection(ds: Array[Byte], input: String, from: Int, to: Int, mask: Long): Long = {
+    if (from < to && from + 16 >= to) {
+      var result = 0L
+      var i      = from
+      while (i < to) {
+        val c = input.charAt(i).toInt
+        if (c > 0xff) uuidError()
+        result = (result << 4) | ds(c)
+        i += 1
+      }
+      if ((result & mask) == 0L) return result
+    }
+    uuidError()
+  }
+
+  @noinline private[this] def uuidError(): Nothing = throw new IllegalArgumentException with NoStackTrace
 }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -481,6 +481,8 @@ object DecoderSpec extends ZIOSpecDefault {
           val bad5 = """{"64d7c38d-2afd-XXXX-9832-4e70afe4b0f8": "value"}"""
           val bad6 = """{"64d7c38d-2afd-X-9832-4e70afe4b0f8": "value"}"""
           val bad7 = """{"0-0-0-0-00000000000000000": "value"}"""
+          val bad8 = """{"64d7c38d-2аfd-4514-9832-4e70afe4b0f8": "value"}"""
+          val bad9 = """{"0000000064D7C38D-FD-14-32-70АFE4B0f8": "value"}"""
 
           assert(ok1.fromJson[Map[UUID, String]])(
             isRight(equalTo(expectedMap("64d7c38d-2afd-4514-9832-4e70afe4b0f8")))
@@ -491,23 +493,15 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(ok3.fromJson[Map[UUID, String]])(
             isRight(equalTo(expectedMap("00000000-0000-0000-0000-000000000000")))
           ) &&
-          assert(bad1.fromJson[Map[UUID, String]])(isLeft(containsString("Invalid UUID: "))) &&
-          assert(bad2.fromJson[Map[UUID, String]])(
-            isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-9832-4e70afe4b0f80"))
-          ) &&
-          assert(bad3.fromJson[Map[UUID, String]])(
-            isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-983-4e70afe4b0f80"))
-          ) &&
-          assert(bad4.fromJson[Map[UUID, String]])(
-            isLeft(containsString("Invalid UUID: 64d7c38d-2afd--9832-4e70afe4b0f8"))
-          ) &&
-          assert(bad5.fromJson[Map[UUID, String]])(
-            isLeft(containsString("Invalid UUID: 64d7c38d-2afd-XXXX-9832-4e70afe4b0f8"))
-          ) &&
-          assert(bad6.fromJson[Map[UUID, String]])(
-            isLeft(containsString("Invalid UUID: 64d7c38d-2afd-X-9832-4e70afe4b0f8"))
-          ) &&
-          assert(bad7.fromJson[Map[UUID, String]])(isLeft(containsString("Invalid UUID: 0-0-0-0-00000000000000000")))
+          assert(bad1.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad2.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad3.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad4.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad5.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad6.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad7.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad8.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad9.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)")))
         },
         test("zio.Chunk") {
           val jsonStr  = """["5XL","2XL","XL"]"""
@@ -537,17 +531,21 @@ object DecoderSpec extends ZIOSpecDefault {
           val bad5 = """"64d7c38d-2afd-XXXX-9832-4e70afe4b0f8""""
           val bad6 = """"64d7c38d-2afd-X-9832-4e70afe4b0f8""""
           val bad7 = """"0-0-0-0-00000000000000000""""
+          val bad8 = """"64d7c38d-2аfd-4514-9832-4e70afe4b0f8""""
+          val bad9 = """"0000000064D7C38D-FD-14-32-70АFE4B0f8""""
 
           assert(ok1.fromJson[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4514-9832-4e70afe4b0f8")))) &&
           assert(ok2.fromJson[UUID])(isRight(equalTo(UUID.fromString("64D7C38D-00FD-0014-0032-0070AfE4B0f8")))) &&
           assert(ok3.fromJson[UUID])(isRight(equalTo(UUID.fromString("00000000-0000-0000-0000-000000000000")))) &&
-          assert(bad1.fromJson[UUID])(isLeft(containsString("Invalid UUID: "))) &&
-          assert(bad2.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-9832-4e70afe4b0f80"))) &&
-          assert(bad3.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-983-4e70afe4b0f80"))) &&
-          assert(bad4.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd--9832-4e70afe4b0f8"))) &&
-          assert(bad5.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-XXXX-9832-4e70afe4b0f8"))) &&
-          assert(bad6.fromJson[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-X-9832-4e70afe4b0f8"))) &&
-          assert(bad7.fromJson[UUID])(isLeft(containsString("Invalid UUID: 0-0-0-0-00000000000000000")))
+          assert(bad1.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad2.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad3.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad4.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad5.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad6.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad7.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad8.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad9.fromJson[UUID])(isLeft(containsString("(expected UUID string)")))
         },
         test("java.util.Currency") {
           assert(""""USD"""".fromJson[java.util.Currency])(isRight(equalTo(java.util.Currency.getInstance("USD")))) &&
@@ -818,17 +816,21 @@ object DecoderSpec extends ZIOSpecDefault {
           val bad5 = Json.Str("64d7c38d-2afd-XXXX-9832-4e70afe4b0f8")
           val bad6 = Json.Str("64d7c38d-2afd-X-9832-4e70afe4b0f8")
           val bad7 = Json.Str("0-0-0-0-00000000000000000")
+          val bad8 = Json.Str("64d7c38d-2аfd-4514-9832-4e70afe4b0f8")
+          val bad9 = Json.Str("0000000064D7C38D-FD-14-32-70АFE4B0f8")
 
           assert(ok1.as[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4514-9832-4e70afe4b0f8")))) &&
           assert(ok2.as[UUID])(isRight(equalTo(UUID.fromString("64D7C38D-00FD-0014-0032-0070AFE4B0f8")))) &&
           assert(ok3.as[UUID])(isRight(equalTo(UUID.fromString("00000000-0000-0000-0000-000000000000")))) &&
-          assert(bad1.as[UUID])(isLeft(containsString("Invalid UUID: "))) &&
-          assert(bad2.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-9832-4e70afe4b0f80"))) &&
-          assert(bad3.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-4514-983-4e70afe4b0f80"))) &&
-          assert(bad4.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd--9832-4e70afe4b0f8"))) &&
-          assert(bad5.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-XXXX-9832-4e70afe4b0f8"))) &&
-          assert(bad6.as[UUID])(isLeft(containsString("Invalid UUID: 64d7c38d-2afd-X-9832-4e70afe4b0f8"))) &&
-          assert(bad7.as[UUID])(isLeft(containsString("Invalid UUID: 0-0-0-0-00000000000000000")))
+          assert(bad1.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad2.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad3.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad4.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad5.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad6.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad7.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad8.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
+          assert(bad9.as[UUID])(isLeft(containsString("(expected UUID string)")))
         }
       )
     )


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                          (size)   Mode  Cnt       Score     Error  Units
ArrayOfUUIDsReading.zioJson           128  thrpt    5  108329.022 ± 648.425  ops/s
ArrayOfUUIDsReading.zioSchemaJson     128  thrpt    5  104337.883 ± 118.619  ops/s
```

#### After
```txt
Benchmark                          (size)   Mode  Cnt       Score      Error  Units
ArrayOfUUIDsReading.zioJson           128  thrpt    5  142795.994 ± 1792.819  ops/s
ArrayOfUUIDsReading.zioSchemaJson     128  thrpt    5  143245.965 ± 1447.347  ops/s
```