### PR TITLE
More efficient reading of the next character

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -95,30 +95,37 @@ final class FastCharSequence(s: Array[Char]) extends CharSequence {
 // java.io.StringReader uses a lock, which reduces perf by x2, this also allows
 // fast retraction and access to raw char arrays (which are faster than Strings)
 private[zio] final class FastStringReader(s: CharSequence) extends RetractReader with PlaybackReader {
-  private[this] var i: Int   = 0
-  private[this] val len: Int = s.length
+  private[this] var i: Int = 0
 
   def offset(): Int = i
 
   def close(): Unit = ()
 
   override def read(): Int = {
-    i += 1
-    if (i > len) -1
-    else s.charAt(i - 1).toInt // -1 is faster than assigning a temp value
-  }
-  override def readChar(): Char = {
-    i += 1
-    if (i > len) throw new UnexpectedEnd
-    s.charAt(i - 1)
-  }
-  override def nextNonWhitespace(): Char = {
-    while ({
+    if (i < s.length) {
+      val c = s.charAt(i)
       i += 1
-      if (i > len) throw new UnexpectedEnd
-      isWhitespace(s.charAt(i - 1))
-    }) ()
-    s.charAt(i - 1)
+      return c.toInt
+    }
+    -1
+  }
+
+  override def readChar(): Char = {
+    if (i < s.length) {
+      val c = s.charAt(i)
+      i += 1
+      return c
+    }
+    throw new UnexpectedEnd
+  }
+
+  override def nextNonWhitespace(): Char = {
+    while (i < s.length) {
+      val c = s.charAt(i)
+      i += 1
+      if (c != ' ' && c != '\n' && (c | 0x4) != '\r') return c
+    }
+    throw new UnexpectedEnd
   }
 
   def retract(): Unit = i -= 1


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                                    (size)   Mode  Cnt         Score         Error  Units
ExtractFieldsReading.zioJson                    128  thrpt    5    140552.200 ±    2207.225  ops/s
ExtractFieldsReading.zioSchemaJson              128  thrpt    5    139061.607 ±    5097.118  ops/s
GeoJSONReading.zioJson                          N/A  thrpt    5     11164.160 ±     147.634  ops/s
GitHubActionsAPIReading.zioJson                 N/A  thrpt    5    421158.592 ±    7436.014  ops/s
GitHubActionsAPIReading.zioSchemaJson           N/A  thrpt    5    382711.078 ±    3686.754  ops/s
GoogleMapsAPIReading.zioJson                    N/A  thrpt    5     22818.668 ±    1571.872  ops/s
GoogleMapsAPIReading.zioSchemaJson              N/A  thrpt    5     22245.189 ±     906.291  ops/s
OpenRTBReading.zioJson                          N/A  thrpt    5    204060.173 ±    4215.713  ops/s
OpenRTBReading.zioSchemaJson                    N/A  thrpt    5    166648.277 ±    1462.834  ops/s
TwitterAPIReading.zioJson                       N/A  thrpt    5     18577.748 ±    1780.057  ops/s
TwitterAPIReading.zioSchemaJson                 N/A  thrpt    5     11763.547 ±     484.364  ops/s
```

#### After
```txt
Benchmark                                    (size)   Mode  Cnt         Score        Error  Units
ExtractFieldsReading.zioJson                    128  thrpt    5    155825.330 ±    935.115  ops/s
ExtractFieldsReading.zioSchemaJson              128  thrpt    5    154666.510 ±    280.904  ops/s
GeoJSONReading.zioJson                          N/A  thrpt    5     11321.881 ±    930.318  ops/s
GitHubActionsAPIReading.zioJson                 N/A  thrpt    5    444576.769 ±   5421.532  ops/s
GitHubActionsAPIReading.zioSchemaJson           N/A  thrpt    5    433855.440 ±  13406.230  ops/s
GoogleMapsAPIReading.zioJson                    N/A  thrpt    5     26400.559 ±    713.004  ops/s
GoogleMapsAPIReading.zioSchemaJson              N/A  thrpt    5     25656.870 ±    575.364  ops/s
OpenRTBReading.zioJson                          N/A  thrpt    5    194271.373 ±  11307.506  ops/s
OpenRTBReading.zioSchemaJson                    N/A  thrpt    5    163599.973 ±   2106.434  ops/s
TwitterAPIReading.zioJson                       N/A  thrpt    5     19446.113 ±    720.093  ops/s
TwitterAPIReading.zioSchemaJson                 N/A  thrpt    5     11859.670 ±    500.501  ops/s
```