### PR TITLE
More efficient pretty printing

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -324,8 +324,13 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
     if (indent ne None) {
       out.write('\n')
       var i = indent.get
+      val ws = 8224: Short
+      while (i > 4) {
+        out.write(ws, ws, ws, ws)
+        i -= 4
+      }
       while (i > 0) {
-        out.write(' ', ' ')
+        out.write(ws)
         i -= 1
       }
     }

--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -323,7 +323,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
   def pad(indent: Option[Int], out: Write): Unit =
     if (indent ne None) {
       out.write('\n')
-      var i = indent.get
+      var i  = indent.get
       val ws = 8224: Short
       while (i > 4) {
         out.write(ws, ws, ws, ws)

--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -103,9 +103,9 @@ private[zio] final class FastStringReader(s: CharSequence) extends RetractReader
 
   override def read(): Int = {
     if (i < s.length) {
-      val c = s.charAt(i)
+      val c = s.charAt(i).toInt
       i += 1
-      return c.toInt
+      return c
     }
     -1
   }


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                                   Mode  Cnt      Score     Error  Units
GoogleMapsAPIPrettyPrinting.zioJson        thrpt    5  24977.085 ± 252.679  ops/s
GoogleMapsAPIPrettyPrinting.zioSchemaJson  thrpt    5  26320.560 ± 226.108  ops/s
```

#### After
```txt
Benchmark                                   Mode  Cnt      Score     Error  Units
GoogleMapsAPIPrettyPrinting.zioJson        thrpt    5  27151.581 ± 176.025  ops/s
GoogleMapsAPIPrettyPrinting.zioSchemaJson  thrpt    5  27362.712 ± 538.031  ops/s
```