### PR TITLE
More efficient implementation of `FastStringReader`

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -95,35 +95,41 @@ final class FastCharSequence(s: Array[Char]) extends CharSequence {
 // java.io.StringReader uses a lock, which reduces perf by x2, this also allows
 // fast retraction and access to raw char arrays (which are faster than Strings)
 private[zio] final class FastStringReader(s: CharSequence) extends RetractReader with PlaybackReader {
-  private[this] var i: Int = 0
+  private[this] var i: Int   = 0
+  private[this] val len: Int = s.length
 
   def offset(): Int = i
 
   def close(): Unit = ()
 
   override def read(): Int = {
-    if (i < s.length) {
-      val c = s.charAt(i).toInt
-      i += 1
-      return c
+    val i = this.i
+    if (i < len) {
+      this.i = i + 1
+      return s.charAt(i).toInt
     }
     -1
   }
 
   override def readChar(): Char = {
-    if (i < s.length) {
-      val c = s.charAt(i)
-      i += 1
-      return c
+    val i = this.i
+    if (i < len) {
+      this.i = i + 1
+      return s.charAt(i)
     }
     throw new UnexpectedEnd
   }
 
   override def nextNonWhitespace(): Char = {
-    while (i < s.length) {
+    var i   = this.i
+    val len = this.len
+    while (i < len) {
       val c = s.charAt(i)
       i += 1
-      if (c != ' ' && c != '\n' && (c | 0x4) != '\r') return c
+      if (c != ' ' && c != '\n' && (c | 0x4) != '\r') {
+        this.i = i
+        return c
+      }
     }
     throw new UnexpectedEnd
   }


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                              (size)   Mode  Cnt         Score        Error  Units
ADTReading.zioJson                        N/A  thrpt    5   1877961.097 ±   8293.092  ops/s
AnyValsReading.zioJson                    N/A  thrpt    5   3893959.350 ±  71240.569  ops/s
ArrayOfBigDecimalsReading.zioJson         128  thrpt    5    166276.644 ±    737.975  ops/s
ArrayOfBigIntsReading.zioJson             128  thrpt    5    158020.017 ±   1793.183  ops/s
ArrayOfBooleansReading.zioJson            128  thrpt    5   1792575.398 ±  12723.527  ops/s
ArrayOfBytesReading.zioJson               128  thrpt    5   1310988.497 ±  30597.134  ops/s
ArrayOfCharsReading.zioJson               128  thrpt    5   1901238.377 ±  45669.898  ops/s
ArrayOfDoublesReading.zioJson             128  thrpt    5    296460.634 ±  12314.515  ops/s
ArrayOfDurationsReading.zioJson           128  thrpt    5    130506.992 ±   6590.064  ops/s
ArrayOfEnumADTsReading.zioJson            128  thrpt    5    364980.101 ±   6983.195  ops/s
ArrayOfEnumsReading.zioJson               128  thrpt    5    345949.613 ±   6303.683  ops/s
ArrayOfFloatsReading.zioJson              128  thrpt    5    419300.251 ±   8386.571  ops/s
ArrayOfInstantsReading.zioJson            128  thrpt    5    134806.593 ±   2759.798  ops/s
ArrayOfIntsReading.zioJson                128  thrpt    5    911616.861 ±  15688.467  ops/s
ArrayOfLocalDateTimesReading.zioJson      128  thrpt    5    137620.885 ±   1980.707  ops/s
ArrayOfLocalDatesReading.zioJson          128  thrpt    5    257179.129 ±   5399.864  ops/s
ArrayOfLocalTimesReading.zioJson          128  thrpt    5    201682.364 ±   3893.406  ops/s
ArrayOfLongsReading.zioJson               128  thrpt    5    570095.471 ±   2801.988  ops/s
ArrayOfMonthDaysReading.zioJson           128  thrpt    5    275049.205 ±   5804.522  ops/s
ArrayOfOffsetDateTimesReading.zioJson     128  thrpt    5    117294.604 ±    845.469  ops/s
ArrayOfOffsetTimesReading.zioJson         128  thrpt    5    166583.109 ±   5384.949  ops/s
ArrayOfPeriodsReading.zioJson             128  thrpt    5    140851.783 ±   3342.267  ops/s
ArrayOfShortsReading.zioJson              128  thrpt    5   1365029.920 ±  27247.584  ops/s
ArrayOfUUIDsReading.zioJson               128  thrpt    5    152727.714 ±   4693.417  ops/s
ArrayOfYearMonthsReading.zioJson          128  thrpt    5    277295.015 ±   4435.422  ops/s
ArrayOfYearsReading.zioJson               128  thrpt    5    340137.547 ±   5122.688  ops/s
ArrayOfZoneIdsReading.zioJson             128  thrpt    5    201958.425 ±   2296.899  ops/s
ArrayOfZoneOffsetsReading.zioJson         128  thrpt    5    282717.169 ±   2763.840  ops/s
ArrayOfZonedDateTimesReading.zioJson      128  thrpt    5     59115.582 ±   1659.571  ops/s
ArraySeqOfBooleansReading.zioJson         128  thrpt    5   1722564.407 ±  22352.513  ops/s
Base64Reading.zioJson                     128  thrpt    5   5226658.740 ±  40316.630  ops/s
BigDecimalReading.zioJson                 128  thrpt    5   1976875.071 ±  20480.679  ops/s
BigIntReading.zioJson                     128  thrpt    5   1720154.887 ±  31136.017  ops/s
ExtractFieldsReading.zioJson              128  thrpt    5    157186.249 ±    879.325  ops/s
GeoJSONReading.zioJson                    N/A  thrpt    5     11553.573 ±     74.153  ops/s
GitHubActionsAPIReading.zioJson           N/A  thrpt    5    437952.105 ±   5564.001  ops/s
GoogleMapsAPIReading.zioJson              N/A  thrpt    5     25496.842 ±    164.886  ops/s
IntReading.zioJson                        N/A  thrpt    5  46239892.123 ± 958469.649  ops/s
ListOfBooleansReading.zioJson             128  thrpt    5   1127547.621 ±  41563.574  ops/s
MapOfIntsToBooleansReading.zioJson        128  thrpt    5    131918.259 ±   5648.211  ops/s
MissingRequiredFieldsReading.zioJson      N/A  thrpt    5   8549731.544 ± 194343.118  ops/s
NestedStructsReading.zioJson              128  thrpt    5    265116.011 ±   6672.094  ops/s
OpenRTBReading.zioJson                    N/A  thrpt    5    189640.232 ±  10327.883  ops/s
PrimitivesReading.zioJson                 N/A  thrpt    5   4742466.440 ±  56326.510  ops/s
SetOfIntsReading.zioJson                  128  thrpt    5    247234.290 ±   6160.190  ops/s
StringOfAsciiCharsReading.zioJson         128  thrpt    5   6622554.175 ±  54586.780  ops/s
StringOfEscapedCharsReading.zioJson       128  thrpt    5    825600.380 ±  60438.037  ops/s
StringOfNonAsciiCharsReading.zioJson      128  thrpt    5   2453807.394 ±  21955.019  ops/s
TwitterAPIReading.zioJson                 N/A  thrpt    5     18751.008 ±    490.516  ops/s
VectorOfBooleansReading.zioJson           128  thrpt    5   1320318.027 ±  16140.762  ops/s
```

#### After
```txt
Benchmark                              (size)   Mode  Cnt         Score         Error  Units
ADTReading.zioJson                        N/A  thrpt    5   1932683.664 ±   32512.327  ops/s
AnyValsReading.zioJson                    N/A  thrpt    5   4328602.096 ±   29970.185  ops/s
ArrayOfBigDecimalsReading.zioJson         128  thrpt    5    153192.918 ±    2074.485  ops/s
ArrayOfBigIntsReading.zioJson             128  thrpt    5    137071.183 ±    2831.309  ops/s
ArrayOfBooleansReading.zioJson            128  thrpt    5   1722767.539 ±   77474.117  ops/s
ArrayOfBytesReading.zioJson               128  thrpt    5   1261579.350 ±   29235.978  ops/s
ArrayOfCharsReading.zioJson               128  thrpt    5   1906583.666 ±   39787.268  ops/s
ArrayOfDoublesReading.zioJson             128  thrpt    5    301670.254 ±    3201.476  ops/s
ArrayOfDurationsReading.zioJson           128  thrpt    5    127605.243 ±    1249.090  ops/s
ArrayOfEnumADTsReading.zioJson            128  thrpt    5    283100.036 ±    4901.280  ops/s
ArrayOfEnumsReading.zioJson               128  thrpt    5    286957.163 ±    5943.123  ops/s
ArrayOfFloatsReading.zioJson              128  thrpt    5    445757.895 ±    4857.488  ops/s
ArrayOfInstantsReading.zioJson            128  thrpt    5    136039.778 ±    2122.836  ops/s
ArrayOfIntsReading.zioJson                128  thrpt    5    798799.535 ±   10513.058  ops/s
ArrayOfLocalDateTimesReading.zioJson      128  thrpt    5    138537.338 ±    3454.292  ops/s
ArrayOfLocalDatesReading.zioJson          128  thrpt    5    244077.643 ±    3068.800  ops/s
ArrayOfLocalTimesReading.zioJson          128  thrpt    5    198417.333 ±    3342.819  ops/s
ArrayOfLongsReading.zioJson               128  thrpt    5    487230.675 ±    9314.170  ops/s
ArrayOfMonthDaysReading.zioJson           128  thrpt    5    276681.193 ±    5829.899  ops/s
ArrayOfOffsetDateTimesReading.zioJson     128  thrpt    5    124437.661 ±    1071.461  ops/s
ArrayOfOffsetTimesReading.zioJson         128  thrpt    5    159509.837 ±    4418.592  ops/s
ArrayOfPeriodsReading.zioJson             128  thrpt    5    136718.736 ±    1042.471  ops/s
ArrayOfShortsReading.zioJson              128  thrpt    5   1235646.887 ±   12495.953  ops/s
ArrayOfUUIDsReading.zioJson               128  thrpt    5    135045.680 ±    2966.092  ops/s
ArrayOfYearMonthsReading.zioJson          128  thrpt    5    270807.177 ±    6870.670  ops/s
ArrayOfYearsReading.zioJson               128  thrpt    5    334774.699 ±    8872.134  ops/s
ArrayOfZoneIdsReading.zioJson             128  thrpt    5    195851.822 ±    3486.586  ops/s
ArrayOfZoneOffsetsReading.zioJson         128  thrpt    5    285059.767 ±    4974.699  ops/s
ArrayOfZonedDateTimesReading.zioJson      128  thrpt    5     59823.614 ±    1383.667  ops/s
ArraySeqOfBooleansReading.zioJson         128  thrpt    5   1695514.356 ±   25269.827  ops/s
Base64Reading.zioJson                     128  thrpt    5   4862044.130 ±   89327.903  ops/s
BigDecimalReading.zioJson                 128  thrpt    5   1987068.206 ±   45335.704  ops/s
BigIntReading.zioJson                     128  thrpt    5   1862979.803 ±   20954.613  ops/s
ExtractFieldsReading.zioJson              128  thrpt    5    131764.284 ±    1770.641  ops/s
GeoJSONReading.zioJson                    N/A  thrpt    5     11367.765 ±     552.017  ops/s
GitHubActionsAPIReading.zioJson           N/A  thrpt    5    408693.953 ±    3294.936  ops/s
GoogleMapsAPIReading.zioJson              N/A  thrpt    5     25190.770 ±     534.055  ops/s
IntReading.zioJson                        N/A  thrpt    5  47036366.464 ± 1134384.787  ops/s
ListOfBooleansReading.zioJson             128  thrpt    5   1180711.805 ±   31406.265  ops/s
MapOfIntsToBooleansReading.zioJson        128  thrpt    5    135285.636 ±    2597.479  ops/s
MissingRequiredFieldsReading.zioJson      N/A  thrpt    5   8556935.243 ±   50355.570  ops/s
NestedStructsReading.zioJson              128  thrpt    5    267639.067 ±    6384.092  ops/s
OpenRTBReading.zioJson                    N/A  thrpt    5    192273.435 ±   13452.636  ops/s
PrimitivesReading.zioJson                 N/A  thrpt    5   4641241.349 ±  117108.838  ops/s
SetOfIntsReading.zioJson                  128  thrpt    5    252243.650 ±    2457.197  ops/s
StringOfAsciiCharsReading.zioJson         128  thrpt    5   6587074.234 ±   97333.667  ops/s
StringOfEscapedCharsReading.zioJson       128  thrpt    5    886907.814 ±   57766.176  ops/s
StringOfNonAsciiCharsReading.zioJson      128  thrpt    5   2396326.914 ±   25035.353  ops/s
TwitterAPIReading.zioJson                 N/A  thrpt    5     19636.487 ±    2218.300  ops/s
VectorOfBooleansReading.zioJson           128  thrpt    5   1465670.423 ±   45144.361  ops/s
```