### PR TITLE
More efficient decoding of booleans

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -41,38 +41,38 @@ object Lexer {
   // FIXME: remove trace paramenter in the next major version
   // True if we got anything besides a }, False for }
   @inline def firstField(trace: List[JsonError], in: RetractReader): Boolean =
-    in.nextNonWhitespace() != '}' && {
+    if (in.nextNonWhitespace() != '}') {
       in.retract()
       true
-    }
+    } else false
 
   // True if we got a comma, and False for }
-  @inline def nextField(trace: List[JsonError], in: OneCharReader): Boolean =
-    (in.nextNonWhitespace(): @switch) match {
-      case ',' => true
-      case '}' => false
-      case c   => error("',' or '}'", c, trace)
-    }
+  @inline def nextField(trace: List[JsonError], in: OneCharReader): Boolean = {
+    val c = in.nextNonWhitespace()
+    if (c == ',') true
+    else if (c == '}') false
+    else error("',' or '}'", c, trace)
+  }
 
   // True if we got anything besides a ], False for ]
   @inline def firstArrayElement(in: RetractReader): Boolean =
-    in.nextNonWhitespace() != ']' && {
+    if (in.nextNonWhitespace() != ']') {
       in.retract()
       true
-    }
+    } else false
 
-  @inline def nextArrayElement(trace: List[JsonError], in: OneCharReader): Boolean =
-    (in.nextNonWhitespace(): @switch) match {
-      case ',' => true
-      case ']' => false
-      case c   => error("',' or ']'", c, trace)
-    }
+  @inline def nextArrayElement(trace: List[JsonError], in: OneCharReader): Boolean = {
+    val c = in.nextNonWhitespace()
+    if (c == ',') true
+    else if (c == ']') false
+    else error("',' or ']'", c, trace)
+  }
 
   @inline def field(trace: List[JsonError], in: OneCharReader, matrix: StringMatrix): Int = {
     val f = enumeration(trace, in, matrix)
     val c = in.nextNonWhitespace()
-    if (c != ':') error("':'", c, trace)
-    f
+    if (c == ':') return f
+    error("':'", c, trace)
   }
 
   def enumeration(trace: List[JsonError], in: OneCharReader, matrix: StringMatrix): Int = {
@@ -89,8 +89,7 @@ object Lexer {
       bs = matrix.update(bs, i, c)
       i += 1
     }
-    bs = matrix.exact(bs, i)
-    matrix.first(bs)
+    matrix.first(matrix.exact(bs, i))
   }
 
   @noinline def skipValue(trace: List[JsonError], in: RetractReader): Unit =
@@ -208,15 +207,14 @@ object Lexer {
   def uuid(trace: List[JsonError], in: OneCharReader): UUID = {
     var c = in.nextNonWhitespace()
     if (c != '"') error("'\"'", c, trace)
-    var cs = charArrays.get
+    val cs = charArrays.get
     var i  = 0
     while ({
       c = in.readChar()
       c != '"'
     }) {
       if (c == '\\') c = nextEscaped(trace, in)
-      if (c > 0xff) uuidError(trace)
-      if (i == cs.length) cs = java.util.Arrays.copyOf(cs, i << 1)
+      if (i == 36 || c > 0xff) uuidError(trace)
       cs(i) = c
       i += 1
     }
@@ -240,20 +238,20 @@ object Lexer {
             ds(cs(6).toInt) << 4 |
             ds(cs(7).toInt))
       val msb2 =
-        ds(cs(9).toInt) << 12 |
+        (ds(cs(9).toInt) << 12 |
           ds(cs(10).toInt) << 8 |
           ds(cs(11).toInt) << 4 |
-          ds(cs(12).toInt)
+          ds(cs(12).toInt)).toLong
       val msb3 =
-        ds(cs(14).toInt) << 12 |
+        (ds(cs(14).toInt) << 12 |
           ds(cs(15).toInt) << 8 |
           ds(cs(16).toInt) << 4 |
-          ds(cs(17).toInt)
+          ds(cs(17).toInt)).toLong
       val lsb1 =
-        ds(cs(19).toInt) << 12 |
+        (ds(cs(19).toInt) << 12 |
           ds(cs(20).toInt) << 8 |
           ds(cs(21).toInt) << 4 |
-          ds(cs(22).toInt)
+          ds(cs(22).toInt)).toLong
       val lsb2 =
         (ds(cs(24).toInt) << 16 |
           ds(cs(25).toInt) << 12 |
@@ -268,7 +266,7 @@ object Lexer {
             ds(cs(34).toInt) << 4 |
             ds(cs(35).toInt))
       if ((msb1 | msb2 | msb3 | lsb1 | lsb2) >= 0L) {
-        return new UUID(msb1 << 32 | msb2.toLong << 16 | msb3, lsb1.toLong << 48 | lsb2)
+        return new UUID(msb1 << 32 | msb2 << 16 | msb3, lsb1 << 48 | lsb2)
       }
     } else if (i <= 36) {
       return uuidExtended(trace, cs, i)
@@ -325,7 +323,7 @@ object Lexer {
   @noinline private[this] def uuidError(trace: List[JsonError]): Nothing = error("expected UUID string", trace)
 
   private[this] val charArrays = new ThreadLocal[Array[Char]] {
-    override def initialValue(): Array[Char] = new Array[Char](1024)
+    override def initialValue(): Array[Char] = new Array[Char](1024) // should be longer than 256
   }
 
   private[this] val hexDigits: Array[Byte] = {
@@ -397,21 +395,12 @@ object Lexer {
     accum.toChar
   }
 
-  def boolean(trace: List[JsonError], in: OneCharReader): Boolean =
-    (in.nextNonWhitespace(): @switch) match {
-      case 't' =>
-        if (in.readChar() != 'r' || in.readChar() != 'u' || in.readChar() != 'e') {
-          error("expected 'true'", trace)
-        }
-        true
-      case 'f' =>
-        if (in.readChar() != 'a' || in.readChar() != 'l' || in.readChar() != 's' || in.readChar() != 'e') {
-          error("expected 'false'", trace)
-        }
-        false
-      case c =>
-        error("'true' or 'false'", c, trace)
-    }
+  def boolean(trace: List[JsonError], in: OneCharReader): Boolean = {
+    val c = in.nextNonWhitespace()
+    if (c == 't' && in.readChar() == 'r' && in.readChar() == 'u' && in.readChar() == 'e') true
+    else if (c == 'f' && in.readChar() == 'a' && in.readChar() == 'l' && in.readChar() == 's' && in.readChar() == 'e') false
+    else error("expected a Boolean", c, trace)
+  }
 
   def byte(trace: List[JsonError], in: RetractReader): Byte =
     try {

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -398,7 +398,8 @@ object Lexer {
   def boolean(trace: List[JsonError], in: OneCharReader): Boolean = {
     val c = in.nextNonWhitespace()
     if (c == 't' && in.readChar() == 'r' && in.readChar() == 'u' && in.readChar() == 'e') true
-    else if (c == 'f' && in.readChar() == 'a' && in.readChar() == 'l' && in.readChar() == 's' && in.readChar() == 'e') false
+    else if (c == 'f' && in.readChar() == 'a' && in.readChar() == 'l' && in.readChar() == 's' && in.readChar() == 'e')
+      false
     else error("expected a Boolean", c, trace)
   }
 

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -167,14 +167,14 @@ object Lexer {
             case 'n'              => '\n'
             case 'r'              => '\r'
             case 't'              => '\t'
-            case 'u'              => Lexer.nextHex4(trace, in)
-            case c                => Lexer.error(c, trace)
+            case 'u'              => nextHex4(trace, in)
+            case c                => error(c, trace)
           }).toInt
         } else if (c == '\\') {
           escaped = true
           read()
         } else if (c == '"') -1 // this is the EOS for the caller
-        else if (c < ' ') Lexer.error("invalid control in string", trace)
+        else if (c < ' ') error("invalid control in string", trace)
         else c.toInt
       }
 
@@ -384,18 +384,15 @@ object Lexer {
       case c    => error(c, trace)
     }
 
-  def nextHex4(trace: List[JsonError], in: OneCharReader): Char = {
+  private[this] def nextHex4(trace: List[JsonError], in: OneCharReader): Char = {
     var i, accum = 0
     while (i < 4) {
-      val c = in.readChar()
-      accum <<= 4
-      accum += {
-        if ('0' <= c && c <= '9') c - '0'
-        else if ('A' <= c && c <= 'F') c - 'A' + 10
-        else if ('a' <= c && c <= 'f') c - 'a' + 10
-        else error("invalid charcode in string", trace)
-      }
+      val c = in.readChar() | 0x20
+      accum = (accum << 4) + c
       i += 1
+      if ('0' <= c && c <= '9') accum -= 48
+      else if ('a' <= c && c <= 'f') accum -= 87
+      else error("invalid charcode in string", trace)
     }
     accum.toChar
   }


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                                   (size)   Mode  Cnt        Score       Error  Units
ArrayBufferOfBooleansReading.zioSchemaJson     128  thrpt    5  1048786.538 ±  6630.269  ops/s
ArrayOfBooleansReading.zioJson                 128  thrpt    5  1884086.300 ± 10715.550  ops/s
ArrayOfBooleansReading.zioSchemaJson           128  thrpt    5  1226574.624 ± 17789.201  ops/s
ArraySeqOfBooleansReading.zioJson              128  thrpt    5  1687694.071 ± 39218.973  ops/s
ArraySeqOfBooleansReading.zioSchemaJson        128  thrpt    5  1131214.620 ± 12011.729  ops/s
ListOfBooleansReading.zioJson                  128  thrpt    5  1183228.227 ± 15484.292  ops/s
ListOfBooleansReading.zioSchemaJson            128  thrpt    5   801988.755 ±  8861.996  ops/s
VectorOfBooleansReading.zioJson                128  thrpt    5  1445047.569 ± 33342.106  ops/s
VectorOfBooleansReading.zioSchemaJson          128  thrpt    5   828646.802 ±  8922.681  ops/s
```

#### After
```txt
Benchmark                                   (size)   Mode  Cnt        Score        Error  Units
ArrayBufferOfBooleansReading.zioSchemaJson     128  thrpt    5  1097902.384 ±  10064.691  ops/s
ArrayOfBooleansReading.zioJson                 128  thrpt    5  1892103.362 ±  23129.647  ops/s
ArrayOfBooleansReading.zioSchemaJson           128  thrpt    5  1229650.481 ±  15709.329  ops/s
ArraySeqOfBooleansReading.zioJson              128  thrpt    5  1812104.561 ± 134985.997  ops/s
ArraySeqOfBooleansReading.zioSchemaJson        128  thrpt    5  1200243.600 ±  39887.079  ops/s
ListOfBooleansReading.zioJson                  128  thrpt    5  1199166.956 ±  76466.575  ops/s
ListOfBooleansReading.zioSchemaJson            128  thrpt    5   829455.128 ±  22945.978  ops/s
VectorOfBooleansReading.zioJson                128  thrpt    5  1480336.259 ±  20425.230  ops/s
VectorOfBooleansReading.zioSchemaJson          128  thrpt    5   863184.010 ±  31147.887  ops/s
```