### PR TITLE
More safe and efficient decoders for `java.time._` values

### DIFF
--- a/zio-json/shared/src/main/scala-2.x/zio/json/JsonFieldDecoder.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/JsonFieldDecoder.scala
@@ -69,7 +69,7 @@ object JsonFieldDecoder extends LowPriorityJsonFieldDecoder {
     def unsafeDecodeField(trace: List[JsonError], in: String): java.util.UUID =
       try UUIDParser.unsafeParse(in)
       catch {
-        case _: IllegalArgumentException => Lexer.error("expected UUID string", trace)
+        case _: IllegalArgumentException => Lexer.error("expected a UUID", trace)
       }
   }
 

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonFieldDecoder.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonFieldDecoder.scala
@@ -69,7 +69,7 @@ object JsonFieldDecoder extends LowPriorityJsonFieldDecoder {
     def unsafeDecodeField(trace: List[JsonError], in: String): java.util.UUID =
       try UUIDParser.unsafeParse(in)
       catch {
-        case _: IllegalArgumentException => Lexer.error("expected UUID string", trace)
+        case _: IllegalArgumentException => Lexer.error("expected a UUID", trace)
       }
   }
 

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -926,42 +926,301 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
 
   import java.time._
 
-  implicit val dayOfWeek: JsonDecoder[DayOfWeek]           = javaTimeDecoder(s => DayOfWeek.valueOf(s.toUpperCase))
-  implicit val duration: JsonDecoder[Duration]             = javaTimeDecoder(parsers.unsafeParseDuration)
-  implicit val instant: JsonDecoder[Instant]               = javaTimeDecoder(parsers.unsafeParseInstant)
-  implicit val localDate: JsonDecoder[LocalDate]           = javaTimeDecoder(parsers.unsafeParseLocalDate)
-  implicit val localDateTime: JsonDecoder[LocalDateTime]   = javaTimeDecoder(parsers.unsafeParseLocalDateTime)
-  implicit val localTime: JsonDecoder[LocalTime]           = javaTimeDecoder(parsers.unsafeParseLocalTime)
-  implicit val month: JsonDecoder[Month]                   = javaTimeDecoder(s => Month.valueOf(s.toUpperCase))
-  implicit val monthDay: JsonDecoder[MonthDay]             = javaTimeDecoder(parsers.unsafeParseMonthDay)
-  implicit val offsetDateTime: JsonDecoder[OffsetDateTime] = javaTimeDecoder(parsers.unsafeParseOffsetDateTime)
-  implicit val offsetTime: JsonDecoder[OffsetTime]         = javaTimeDecoder(parsers.unsafeParseOffsetTime)
-  implicit val period: JsonDecoder[Period]                 = javaTimeDecoder(parsers.unsafeParsePeriod)
-  implicit val year: JsonDecoder[Year]                     = javaTimeDecoder(parsers.unsafeParseYear)
-  implicit val yearMonth: JsonDecoder[YearMonth]           = javaTimeDecoder(parsers.unsafeParseYearMonth)
-  implicit val zonedDateTime: JsonDecoder[ZonedDateTime]   = javaTimeDecoder(parsers.unsafeParseZonedDateTime)
-  implicit val zoneId: JsonDecoder[ZoneId]                 = javaTimeDecoder(parsers.unsafeParseZoneId)
-  implicit val zoneOffset: JsonDecoder[ZoneOffset]         = javaTimeDecoder(parsers.unsafeParseZoneOffset)
+  implicit val dayOfWeek: JsonDecoder[DayOfWeek] = new JsonDecoder[DayOfWeek] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): DayOfWeek = Lexer.dayOfWeek(trace, in)
 
-  private[this] def javaTimeDecoder[A](f: String => A): JsonDecoder[A] = new JsonDecoder[A] {
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
-      parseJavaTime(trace, Lexer.string(trace, in).toString)
-
-    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): A =
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): DayOfWeek = {
       json match {
-        case s: Json.Str => parseJavaTime(trace, s.value)
-        case _           => Lexer.error("expected string", trace)
+        case s: Json.Str =>
+          try return DayOfWeek.valueOf(s.value.toUpperCase)
+          catch {
+            case _: IllegalArgumentException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a DayOfWeek", trace)
+    }
+  }
+  implicit val duration: JsonDecoder[Duration] = new JsonDecoder[Duration] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): Duration =
+      try parsers.unsafeParseDuration(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a Duration", trace)
       }
 
-    // Commonized handling for decoding from string to java.time Class
-    @inline private[this] def parseJavaTime(trace: List[JsonError], s: String): A =
-      try f(s)
-      catch {
-        case ex: DateTimeException =>
-          Lexer.error(s"${strip(s)} is not a valid ISO-8601 format, ${ex.getMessage}", trace)
-        case _: IllegalArgumentException =>
-          Lexer.error(s"${strip(s)} is not a valid ISO-8601 format", trace)
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Duration = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseDuration(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
       }
+      Lexer.error("expected a Duration", trace)
+    }
+  }
+  implicit val instant: JsonDecoder[Instant] = new JsonDecoder[Instant] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): Instant =
+      try parsers.unsafeParseInstant(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected an Instant", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Instant = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseInstant(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected an Instant", trace)
+    }
+  }
+  implicit val localDate: JsonDecoder[LocalDate] = new JsonDecoder[LocalDate] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): LocalDate =
+      try parsers.unsafeParseLocalDate(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a LocalDate", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): LocalDate = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseLocalDate(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a LocalDate", trace)
+    }
+  }
+  implicit val localDateTime: JsonDecoder[LocalDateTime] = new JsonDecoder[LocalDateTime] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): LocalDateTime =
+      try parsers.unsafeParseLocalDateTime(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a LocalDateTime", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): LocalDateTime = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseLocalDateTime(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a LocalDateTime", trace)
+    }
+  }
+  implicit val localTime: JsonDecoder[LocalTime] = new JsonDecoder[LocalTime] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): LocalTime =
+      try parsers.unsafeParseLocalTime(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a LocalTime", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): LocalTime = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseLocalTime(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a LocalTime", trace)
+    }
+  }
+  implicit val month: JsonDecoder[Month] = new JsonDecoder[Month] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): Month = Lexer.month(trace, in)
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Month = {
+      json match {
+        case s: Json.Str =>
+          try return Month.valueOf(s.value.toUpperCase)
+          catch {
+            case _: IllegalArgumentException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a Month", trace)
+    }
+  }
+  implicit val monthDay: JsonDecoder[MonthDay] = new JsonDecoder[MonthDay] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): MonthDay =
+      try parsers.unsafeParseMonthDay(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a MonthDay", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): MonthDay = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseMonthDay(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a MonthDay", trace)
+    }
+  }
+  implicit val offsetDateTime: JsonDecoder[OffsetDateTime] = new JsonDecoder[OffsetDateTime] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): OffsetDateTime =
+      try parsers.unsafeParseOffsetDateTime(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected an OffsetDateTime", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): OffsetDateTime = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseOffsetDateTime(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected an OffsetDateTime", trace)
+    }
+  }
+  implicit val offsetTime: JsonDecoder[OffsetTime] = new JsonDecoder[OffsetTime] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): OffsetTime =
+      try parsers.unsafeParseOffsetTime(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected an OffsetTime", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): OffsetTime = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseOffsetTime(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected an OffsetTime", trace)
+    }
+  }
+  implicit val period: JsonDecoder[Period] = new JsonDecoder[Period] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): Period =
+      try parsers.unsafeParsePeriod(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a Period", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Period = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParsePeriod(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a Period", trace)
+    }
+  }
+  implicit val year: JsonDecoder[Year] = new JsonDecoder[Year] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): Year =
+      try parsers.unsafeParseYear(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a Year", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Year = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseYear(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a Year", trace)
+    }
+  }
+  implicit val yearMonth: JsonDecoder[YearMonth] = new JsonDecoder[YearMonth] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): YearMonth =
+      try parsers.unsafeParseYearMonth(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a YearMonth", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): YearMonth = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseYearMonth(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a YearMonth", trace)
+    }
+  }
+  implicit val zonedDateTime: JsonDecoder[ZonedDateTime] = new JsonDecoder[ZonedDateTime] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): ZonedDateTime =
+      try parsers.unsafeParseZonedDateTime(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a ZonedDateTime", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): ZonedDateTime = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseZonedDateTime(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a ZonedDateTime", trace)
+    }
+  }
+  implicit val zoneId: JsonDecoder[ZoneId] = new JsonDecoder[ZoneId] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): ZoneId =
+      try parsers.unsafeParseZoneId(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a ZoneId", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): ZoneId = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseZoneId(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a ZoneId", trace)
+    }
+  }
+  implicit val zoneOffset: JsonDecoder[ZoneOffset] = new JsonDecoder[ZoneOffset] {
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): ZoneOffset =
+      try parsers.unsafeParseZoneOffset(Lexer.string(trace, in).toString)
+      catch {
+        case _: DateTimeException => Lexer.error("expected a ZoneOffset", trace)
+      }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): ZoneOffset = {
+      json match {
+        case s: Json.Str =>
+          try return parsers.unsafeParseZoneOffset(s.value)
+          catch {
+            case _: DateTimeException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a ZoneOffset", trace)
+    }
   }
 
   // FIXME: remove in the next major version
@@ -977,34 +1236,40 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
   implicit val uuid: JsonDecoder[UUID] = new JsonDecoder[UUID] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): UUID = Lexer.uuid(trace, in)
 
-    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): UUID =
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): UUID = {
       json match {
         case s: Json.Str =>
-          try UUIDParser.unsafeParse(s.value)
+          try return UUIDParser.unsafeParse(s.value)
           catch {
-            case _: IllegalArgumentException => Lexer.error("expected UUID string", trace)
+            case _: IllegalArgumentException =>
           }
-        case _ => Lexer.error("expected UUID string", trace)
+        case _ =>
       }
+      Lexer.error("expected a UUID", trace)
+    }
   }
 
   implicit val currency: JsonDecoder[java.util.Currency] = new JsonDecoder[java.util.Currency] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): java.util.Currency =
-      parseCurrency(trace, Lexer.string(trace, in).toString)
-
-    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): java.util.Currency =
-      json match {
-        case s: Json.Str => parseCurrency(trace, s.value)
-        case _           => Lexer.error("expected string", trace)
-      }
-
-    @inline private[this] def parseCurrency(trace: List[JsonError], s: String): java.util.Currency =
-      try java.util.Currency.getInstance(s)
+      try java.util.Currency.getInstance(Lexer.string(trace, in).toString)
       catch {
-        case _: IllegalArgumentException => Lexer.error(s"Invalid Currency: ${strip(s)}", trace)
+        case _: IllegalArgumentException => Lexer.error("expected a Currency", trace)
       }
+
+    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): java.util.Currency = {
+      json match {
+        case s: Json.Str =>
+          try return java.util.Currency.getInstance(s.value)
+          catch {
+            case _: IllegalArgumentException =>
+          }
+        case _ =>
+      }
+      Lexer.error("expected a Currency", trace)
+    }
   }
 
+  // FIXME: remove in the next major version
   @noinline private[json] def strip(s: String, len: Int = 50): String =
     if (s.length <= len) s
     else s.substring(0, len) + "..."

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -17,6 +17,7 @@ package zio.json.internal
 
 import zio.json.JsonDecoder.{ JsonError, UnsafeJson }
 
+import java.time.{ DayOfWeek, Month }
 import java.util.UUID
 import scala.annotation._
 
@@ -323,7 +324,7 @@ object Lexer {
     uuidError(trace)
   }
 
-  @noinline private[this] def uuidError(trace: List[JsonError]): Nothing = error("expected UUID string", trace)
+  @noinline private[this] def uuidError(trace: List[JsonError]): Nothing = error("expected a UUID", trace)
 
   private[this] val charArrays = new ThreadLocal[Array[Char]] {
     override def initialValue(): Array[Char] = new Array[Char](1024) // should be longer than 256
@@ -486,6 +487,48 @@ object Lexer {
     } catch {
       case UnsafeNumbers.UnsafeNumber => error(s"expected a BigDecimal with $NumberMaxBits-bit mantissa", trace)
     }
+
+  def dayOfWeek(trace: List[JsonError], in: OneCharReader): DayOfWeek = {
+    var c = in.nextNonWhitespace()
+    if (c == '"') {
+      var bs = dayOfWeekMatrix.initial
+      var i  = 0
+      while ({
+        c = in.readChar()
+        c != '"'
+      }) {
+        if (c == '\\') c = nextEscaped(trace, in)
+        bs = dayOfWeekMatrix.update(bs, i, (c & 0xffdf).toChar)
+        i += 1
+      }
+      val dayOfWeek = dayOfWeekMatrix.first(dayOfWeekMatrix.exact(bs, i)) + 1
+      if (dayOfWeek > 0) return DayOfWeek.of(dayOfWeek)
+    }
+    error("expected a DayOfWeek", trace)
+  }
+
+  private[this] val dayOfWeekMatrix = new StringMatrix(DayOfWeek.values.map(_.toString))
+
+  def month(trace: List[JsonError], in: OneCharReader): Month = {
+    var c = in.nextNonWhitespace()
+    if (c == '"') {
+      var bs = monthMatrix.initial
+      var i  = 0
+      while ({
+        c = in.readChar()
+        c != '"'
+      }) {
+        if (c == '\\') c = nextEscaped(trace, in)
+        bs = monthMatrix.update(bs, i, (c & 0xffdf).toChar)
+        i += 1
+      }
+      val month = monthMatrix.first(monthMatrix.exact(bs, i)) + 1
+      if (month > 0) return Month.of(month)
+    }
+    error("expected a Month", trace)
+  }
+
+  private[this] val monthMatrix = new StringMatrix(Month.values.map(_.toString))
 
   @inline def char(trace: List[JsonError], in: OneCharReader, c: Char): Unit = {
     val got = in.nextNonWhitespace()

--- a/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/javatime/parsers.scala
@@ -15,25 +15,8 @@
  */
 package zio.json.javatime
 
-import java.time.{
-  DateTimeException,
-  Duration,
-  Instant,
-  LocalDate,
-  LocalDateTime,
-  LocalTime,
-  MonthDay,
-  OffsetDateTime,
-  OffsetTime,
-  Period,
-  Year,
-  YearMonth,
-  ZoneId,
-  ZoneOffset,
-  ZonedDateTime
-}
+import java.time._
 import java.util.concurrent.ConcurrentHashMap
-import scala.annotation.switch
 import scala.util.control.NoStackTrace
 
 private[json] object parsers {
@@ -45,40 +28,38 @@ private[json] object parsers {
     var pos          = 0
     var seconds      = 0L
     var nanos, state = 0
-    if (pos >= len) durationError(pos)
+    if (pos >= len) durationError()
     var ch = input.charAt(pos)
     pos += 1
     val isNeg = ch == '-'
     if (isNeg) {
-      if (pos >= len) durationError(pos)
+      if (pos >= len) durationError()
       ch = input.charAt(pos)
       pos += 1
     }
-    if (ch != 'P') durationOrPeriodStartError(isNeg, pos - 1)
-    if (pos >= len) durationError(pos)
+    if (ch != 'P' || pos >= len) durationError()
     ch = input.charAt(pos)
     pos += 1
     while ({
       if (state == 0) {
         if (ch == 'T') {
-          if (pos >= len) durationError(pos)
+          if (pos >= len) durationError()
           ch = input.charAt(pos)
           pos += 1
           state = 1
         }
       } else if (state == 1) {
-        if (ch != 'T') charsError('T', '"', pos - 1)
-        if (pos >= len) durationError(pos)
+        if (ch != 'T' || pos >= len) durationError()
         ch = input.charAt(pos)
         pos += 1
-      } else if (state == 4 && pos >= len) durationError(pos - 1)
+      } else if (state == 4 && pos >= len) durationError()
       val isNegX = ch == '-'
       if (isNegX) {
-        if (pos >= len) durationError(pos)
+        if (pos >= len) durationError()
         ch = input.charAt(pos)
         pos += 1
       }
-      if (ch < '0' || ch > '9') durationOrPeriodDigitError(isNegX, state <= 1, pos - 1)
+      if (ch < '0' || ch > '9') durationError()
       var x: Long = ('0' - ch).toLong
       while (
         (pos < len) && {
@@ -91,31 +72,28 @@ private[json] object parsers {
             x = x * 10 + ('0' - ch)
             x > 0
           }
-        ) durationError(pos)
+        ) durationError()
         pos += 1
       }
       if (!(isNeg ^ isNegX)) {
-        if (x == -9223372036854775808L) durationError(pos)
+        if (x == -9223372036854775808L) durationError()
         x = -x
       }
       if (ch == 'D' && state <= 0) {
-        if (x < -106751991167300L || x > 106751991167300L)
-          durationError(pos) // -106751991167300L == Long.MinValue / 86400
+        if (x < -106751991167300L || x > 106751991167300L) durationError()
         seconds = x * 86400
         state = 1
       } else if (ch == 'H' && state <= 1) {
-        if (x < -2562047788015215L || x > 2562047788015215L)
-          durationError(pos) // -2562047788015215L == Long.MinValue / 3600
-        seconds = sumSeconds(x * 3600, seconds, pos)
+        if (x < -2562047788015215L || x > 2562047788015215L) durationError()
+        seconds = sumSeconds(x * 3600, seconds)
         state = 2
       } else if (ch == 'M' && state <= 2) {
-        if (x < -153722867280912930L || x > 153722867280912930L)
-          durationError(pos) // -153722867280912930L == Long.MinValue / 60
-        seconds = sumSeconds(x * 60, seconds, pos)
+        if (x < -153722867280912930L || x > 153722867280912930L) durationError()
+        seconds = sumSeconds(x * 60, seconds)
         state = 3
       } else if (ch == '.') {
         pos += 1
-        seconds = sumSeconds(x, seconds, pos)
+        seconds = sumSeconds(x, seconds)
         var nanoDigitWeight = 100000000
         while (
           (pos < len) && {
@@ -127,13 +105,13 @@ private[json] object parsers {
           nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
           pos += 1
         }
-        if (ch != 'S') nanoError(nanoDigitWeight, 'S', pos)
+        if (ch != 'S') durationError()
         if (isNeg ^ isNegX) nanos = -nanos
         state = 4
       } else if (ch == 'S') {
-        seconds = sumSeconds(x, seconds, pos)
+        seconds = sumSeconds(x, seconds)
         state = 4
-      } else durationError(state, pos)
+      } else durationError()
       pos += 1
       (pos < len) && {
         ch = input.charAt(pos)
@@ -145,126 +123,97 @@ private[json] object parsers {
   }
 
   def unsafeParseInstant(input: String): Instant = {
-    val len = input.length
-    var pos = 0
-    val year = {
-      if (pos + 4 >= len) instantError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val ch3 = input.charAt(pos + 3)
-      val ch4 = input.charAt(pos + 4)
-      if (ch0 >= '0' && ch0 <= '9') {
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 != '-') charError('-', pos + 4)
+    val len                   = input.length
+    var pos, year, month, day = 0
+    if (
+      pos + 4 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
         pos += 5
-        ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
-      } else {
-        val yearNeg = ch0 == '-' || (ch0 != '+' && charsOrDigitError('-', '+', pos))
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 < '0' || ch4 > '9') digitError(pos + 4)
-        pos += 5
-        var year       = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
-        var yearDigits = 4
-        var ch: Char   = '0'
-        while ({
-          if (pos >= len) instantError(pos)
-          ch = input.charAt(pos)
-          pos += 1
-          ch >= '0' && ch <= '9' && yearDigits < 10
-        }) {
-          year =
-            if (year > 100000000) 2147483647
-            else year * 10 + (ch - '0')
-          yearDigits += 1
+        ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9' || ch3 < '0' || ch3 > '9' || {
+          if (ch0 >= '0' && ch0 <= '9') {
+            year = ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
+            ch4 != '-'
+          } else {
+            year = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
+            val yearNeg = ch0 == '-' || (ch0 != '+' && instantError())
+            ch4 < '0' || ch4 > '9' || {
+              var yearDigits = 4
+              var ch         = '0'
+              while (
+                pos < len && {
+                  ch = input.charAt(pos)
+                  pos += 1
+                  ch >= '0' && ch <= '9' && yearDigits < 10
+                }
+              ) {
+                year =
+                  if (year > 100000000) 2147483647
+                  else year * 10 + (ch - '0')
+                yearDigits += 1
+              }
+              yearDigits == 10 && year > 1000000000 || yearNeg && {
+                year = -year
+                year == 0
+              } || ch != '-'
+            }
+          }
         }
-        if (yearDigits == 10 && year > 1000000000) yearError(pos - 2)
-        if (yearNeg) {
-          if (year == 0) yearError(pos - 2)
-          year = -year
-        }
-        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
-        year
+      } || pos + 5 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        val ch5 = input.charAt(pos + 5)
+        pos += 6
+        month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        day = ch3 * 10 + ch4 - 528   // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != '-' || ch3 < '0' || ch3 > '9' ||
+        ch4 < '0' || ch4 > '9' || ch5 != 'T' || month < 1 || month > 12 || day == 0 ||
+        (day > 28 && day > maxDayForYearMonth(year, month))
       }
-    }
-    val month = {
-      if (pos + 2 >= len) instantError(pos)
-      val ch0   = input.charAt(pos)
-      val ch1   = input.charAt(pos + 1)
-      val ch2   = input.charAt(pos + 2)
-      val month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (month < 1 || month > 12) monthError(pos + 1)
-      if (ch2 != '-') charError('-', pos + 2)
-      pos += 3
-      month
-    }
-    val day = {
-      if (pos + 2 >= len) instantError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val day = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (day == 0 || (day > 28 && day > maxDayForYearMonth(year, month))) dayError(pos + 1)
-      if (ch2 != 'T') charError('T', pos + 2)
-      pos += 3
-      day
-    }
+    ) instantError()
     val epochDay =
       epochDayForYear(year) + (dayOfYearForYearMonth(year, month) + day - 719529) // 719528 == days 0000 to 1970
-    var epochSecond = {
-      if (pos + 2 >= len) instantError(pos)
-      val ch0  = input.charAt(pos)
-      val ch1  = input.charAt(pos + 1)
-      val ch2  = input.charAt(pos + 2)
-      val hour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (hour > 23) hourError(pos + 1)
-      if (ch2 != ':') charError(':', pos + 2)
-      pos += 3
-      hour * 3600
-    }
-    epochSecond += {
-      if (pos + 1 >= len) instantError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (ch0 > '5') minuteError(pos + 1)
-      pos += 2
-      (ch0 * 10 + ch1 - 528) * 60 // 528 == '0' * 11
-    }
-    var nanoDigitWeight = -1
-    var nano            = 0
-    var ch              = (0: Char)
+    var epochSecond = 0
+    if (
+      pos + 4 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        val hour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        epochSecond = hour * 3600 + (ch3 * 10 + ch4 - 528) * 60 // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != ':' ||
+        ch3 < '0' || ch3 > '9' || ch4 < '0' || ch4 > '9' || ch3 > '5' || hour > 23
+      }
+    ) instantError()
+    var nano = 0
+    var ch   = '0'
     if (pos < len) {
       ch = input.charAt(pos)
       pos += 1
       if (ch == ':') {
-        nanoDigitWeight = -2
-        epochSecond += {
-          if (pos + 1 >= len) instantError(pos)
-          val ch0 = input.charAt(pos)
-          val ch1 = input.charAt(pos + 1)
-          if (ch0 < '0' || ch0 > '9') digitError(pos)
-          if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-          if (ch0 > '5') secondError(pos + 1)
-          pos += 2
-          ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-        }
+        if (
+          pos + 1 >= len || {
+            val ch0 = input.charAt(pos)
+            val ch1 = input.charAt(pos + 1)
+            pos += 2
+            epochSecond += ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+            ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+          }
+        ) instantError()
         if (pos < len) {
           ch = input.charAt(pos)
           pos += 1
           if (ch == '.') {
-            nanoDigitWeight = 100000000
+            var nanoDigitWeight = 100000000
             while (
               pos < len && {
                 ch = input.charAt(pos)
@@ -281,18 +230,16 @@ private[json] object parsers {
     }
     var offsetTotal = 0
     if (ch != 'Z') {
-      val offsetNeg = ch == '-' || (ch != '+' && timezoneSignError(nanoDigitWeight, pos - 1))
-      offsetTotal = {
-        if (pos + 1 >= len) instantError(pos)
-        val ch0        = input.charAt(pos)
-        val ch1        = input.charAt(pos + 1)
-        val offsetHour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-        if (ch0 < '0' || ch0 > '9') digitError(pos)
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (offsetHour > 18) timezoneOffsetHourError(pos + 1)
-        pos += 2
-        offsetHour * 3600
-      }
+      val offsetNeg = ch == '-' || (ch != '+' && instantError())
+      if (
+        pos + 1 >= len || {
+          val ch0 = input.charAt(pos)
+          val ch1 = input.charAt(pos + 1)
+          pos += 2
+          offsetTotal = (ch0 * 10 + ch1 - 528) * 3600 // 528 == '0' * 11
+          ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9'
+        }
+      ) instantError()
       if (
         pos < len && {
           ch = input.charAt(pos)
@@ -300,16 +247,15 @@ private[json] object parsers {
           ch == ':'
         }
       ) {
-        offsetTotal += {
-          if (pos + 1 >= len) instantError(pos)
-          val ch0 = input.charAt(pos)
-          val ch1 = input.charAt(pos + 1)
-          if (ch0 < '0' || ch0 > '9') digitError(pos)
-          if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-          if (ch0 > '5') timezoneOffsetMinuteError(pos + 1)
-          pos += 2
-          (ch0 * 10 + ch1 - 528) * 60 // 528 == '0' * 11
-        }
+        if (
+          pos + 1 >= len || {
+            val ch0 = input.charAt(pos)
+            val ch1 = input.charAt(pos + 1)
+            pos += 2
+            offsetTotal += (ch0 * 10 + ch1 - 528) * 60 // 528 == '0' * 11
+            ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+          }
+        ) instantError()
         if (
           pos < len && {
             ch = input.charAt(pos)
@@ -317,429 +263,348 @@ private[json] object parsers {
             ch == ':'
           }
         ) {
-          offsetTotal += {
-            if (pos + 1 >= len) instantError(pos)
-            val ch0 = input.charAt(pos)
-            val ch1 = input.charAt(pos + 1)
-            if (ch0 < '0' || ch0 > '9') digitError(pos)
-            if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-            if (ch0 > '5') timezoneOffsetSecondError(pos + 1)
-            pos += 2
-            ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-          }
+          if (
+            pos + 1 >= len || {
+              val ch0 = input.charAt(pos)
+              val ch1 = input.charAt(pos + 1)
+              pos += 2
+              offsetTotal += ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+              ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+            }
+          ) instantError()
         }
       }
-      if (offsetTotal > 64800) zoneOffsetError(pos) // 64800 == 18 * 60 * 60
+      if (offsetTotal > 64800) instantError() // 64800 == 18 * 60 * 60
       if (offsetNeg) offsetTotal = -offsetTotal
     }
-    if (pos != len) instantError(pos)
-    Instant.ofEpochSecond(
-      epochDay * 86400 + (epochSecond - offsetTotal),
-      nano.toLong
-    ) // 86400 == seconds per day
+    if (pos != len) instantError()
+    Instant.ofEpochSecond(epochDay * 86400 + (epochSecond - offsetTotal), nano.toLong)
   }
 
   def unsafeParseLocalDate(input: String): LocalDate = {
-    val len = input.length
-    var pos = 0
-    val year = {
-      if (pos + 4 >= len) localDateError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val ch3 = input.charAt(pos + 3)
-      val ch4 = input.charAt(pos + 4)
-      if (ch0 >= '0' && ch0 <= '9') {
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 != '-') charError('-', pos + 4)
+    val len                   = input.length
+    var pos, year, month, day = 0
+    if (
+      pos + 4 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
         pos += 5
-        ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
-      } else {
-        val yearNeg = ch0 == '-' || (ch0 != '+' && charsOrDigitError('-', '+', pos))
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 < '0' || ch4 > '9') digitError(pos + 4)
+        ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9' || ch3 < '0' || ch3 > '9' || {
+          if (ch0 >= '0' && ch0 <= '9') {
+            year = ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
+            ch4 != '-'
+          } else {
+            year = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
+            val yearNeg = ch0 == '-' || (ch0 != '+' && localDateError())
+            ch4 < '0' || ch4 > '9' || {
+              var yearDigits = 4
+              var ch         = '0'
+              while (
+                pos < len && {
+                  ch = input.charAt(pos)
+                  pos += 1
+                  ch >= '0' && ch <= '9' && yearDigits < 9
+                }
+              ) {
+                year = year * 10 + (ch - '0')
+                yearDigits += 1
+              }
+              yearNeg && {
+                year = -year
+                year == 0
+              } || ch != '-'
+            }
+          }
+        }
+      } || pos + 5 != len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
         pos += 5
-        var year       = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
-        var yearDigits = 4
-        var ch: Char   = '0'
-        while ({
-          if (pos >= len) localDateError(pos)
-          ch = input.charAt(pos)
-          pos += 1
-          ch >= '0' && ch <= '9' && yearDigits < 9
-        }) {
-          year = year * 10 + (ch - '0')
-          yearDigits += 1
-        }
-        if (yearNeg) {
-          if (year == 0) yearError(pos - 2)
-          year = -year
-        }
-        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
-        year
+        month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        day = ch3 * 10 + ch4 - 528   // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != '-' || ch3 < '0' || ch3 > '9' ||
+        ch4 < '0' || ch4 > '9' || month < 1 || month > 12 || day == 0 ||
+        (day > 28 && day > maxDayForYearMonth(year, month))
       }
-    }
-    val month = {
-      if (pos + 2 >= len) localDateError(pos)
-      val ch0   = input.charAt(pos)
-      val ch1   = input.charAt(pos + 1)
-      val ch2   = input.charAt(pos + 2)
-      val month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (month < 1 || month > 12) monthError(pos + 1)
-      if (ch2 != '-') charError('-', pos + 2)
-      pos += 3
-      month
-    }
-    val day = {
-      if (pos + 1 >= len) localDateError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val day = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (day == 0 || (day > 28 && day > maxDayForYearMonth(year, month))) dayError(pos + 1)
-      pos += 2
-      day
-    }
-    if (pos != len) localDateError(pos)
+    ) localDateError()
     LocalDate.of(year, month, day)
   }
 
   def unsafeParseLocalDateTime(input: String): LocalDateTime = {
-    val len = input.length
-    var pos = 0
-    val year = {
-      if (pos + 4 >= len) localDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val ch3 = input.charAt(pos + 3)
-      val ch4 = input.charAt(pos + 4)
-      if (ch0 >= '0' && ch0 <= '9') {
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 != '-') charError('-', pos + 4)
-        pos += 5
-        ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
-      } else {
-        val yearNeg = ch0 == '-' || (ch0 != '+' && charsOrDigitError('-', '+', pos))
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 < '0' || ch4 > '9') digitError(pos + 4)
-        pos += 5
-        var year       = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
-        var yearDigits = 4
-        var ch: Char   = '0'
-        while ({
-          if (pos >= len) localDateTimeError(pos)
-          ch = input.charAt(pos)
-          pos += 1
-          ch >= '0' && ch <= '9' && yearDigits < 9
-        }) {
-          year = year * 10 + (ch - '0')
-          yearDigits += 1
-        }
-        if (yearNeg) {
-          if (year == 0) yearError(pos - 2)
-          year = -year
-        }
-        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
-        year
-      }
-    }
-    val month = {
-      if (pos + 2 >= len) localDateTimeError(pos)
-      val ch0   = input.charAt(pos)
-      val ch1   = input.charAt(pos + 1)
-      val ch2   = input.charAt(pos + 2)
-      val month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (month < 1 || month > 12) monthError(pos + 1)
-      if (ch2 != '-') charError('-', pos + 2)
-      pos += 3
-      month
-    }
-    val day = {
-      if (pos + 2 >= len) localDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val day = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (day == 0 || (day > 28 && day > maxDayForYearMonth(year, month))) dayError(pos + 1)
-      if (ch2 != 'T') charError('T', pos + 2)
-      pos += 3
-      day
-    }
-    val hour = {
-      if (pos + 2 >= len) localDateTimeError(pos)
-      val ch0  = input.charAt(pos)
-      val ch1  = input.charAt(pos + 1)
-      val ch2  = input.charAt(pos + 2)
-      val hour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (hour > 23) hourError(pos + 1)
-      if (ch2 != ':') charError(':', pos + 2)
-      pos += 3
-      hour
-    }
-    val minute = {
-      if (pos + 1 >= len) localDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (ch0 > '5') minuteError(pos + 1)
-      pos += 2
-      ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-    }
-    var second, nano = 0
-    if (pos < len) {
-      if (input.charAt(pos) != ':') charError(':', pos)
-      pos += 1
-      second = {
-        if (pos + 1 >= len) localDateTimeError(pos)
+    val len                   = input.length
+    var pos, year, month, day = 0
+    if (
+      pos + 4 >= len || {
         val ch0 = input.charAt(pos)
         val ch1 = input.charAt(pos + 1)
-        if (ch0 < '0' || ch0 > '9') digitError(pos)
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch0 > '5') secondError(pos + 1)
-        pos += 2
-        ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      }
-      if (pos < len) {
-        if (input.charAt(pos) != '.') charError('.', pos)
-        pos += 1
-        var nanoDigitWeight = 100000000
-        var ch              = '0'
-        while (
-          pos < len && {
-            ch = input.charAt(pos)
-            pos += 1
-            ch >= '0' && ch <= '9' && nanoDigitWeight != 0
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9' || ch3 < '0' || ch3 > '9' || {
+          if (ch0 >= '0' && ch0 <= '9') {
+            year = ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
+            ch4 != '-'
+          } else {
+            year = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
+            val yearNeg = ch0 == '-' || (ch0 != '+' && localDateTimeError())
+            ch4 < '0' || ch4 > '9' || {
+              var yearDigits = 4
+              var ch         = '0'
+              while (
+                pos < len && {
+                  ch = input.charAt(pos)
+                  pos += 1
+                  ch >= '0' && ch <= '9' && yearDigits < 9
+                }
+              ) {
+                year = year * 10 + (ch - '0')
+                yearDigits += 1
+              }
+              yearNeg && {
+                year = -year
+                year == 0
+              } || ch != '-'
+            }
           }
-        ) {
-          nano += (ch - '0') * nanoDigitWeight
-          nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
         }
-        if (pos != len || ch < '0' || ch > '9') localDateTimeError(pos - 1)
+      } || pos + 5 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        val ch5 = input.charAt(pos + 5)
+        pos += 6
+        month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        day = ch3 * 10 + ch4 - 528   // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != '-' || ch3 < '0' || ch3 > '9' ||
+        ch4 < '0' || ch4 > '9' || ch5 != 'T' || day == 0 || month < 1 || month > 12 ||
+        (day > 28 && day > maxDayForYearMonth(year, month))
+      }
+    ) localDateTimeError()
+    var hour, minute = 0
+    if (
+      pos + 4 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        hour = ch0 * 10 + ch1 - 528   // 528 == '0' * 11
+        minute = ch3 * 10 + ch4 - 528 // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != ':' ||
+        ch3 < '0' || ch3 > '9' || ch4 < '0' || ch4 > '9' || ch3 > '5' || hour > 23
+      }
+    ) localDateTimeError()
+    var second, nano = 0
+    if (pos < len) {
+      if (
+        input.charAt(pos) != ':' || {
+          pos += 1
+          pos + 1 >= len || {
+            val ch0 = input.charAt(pos)
+            val ch1 = input.charAt(pos + 1)
+            pos += 2
+            second = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+            ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+          }
+        }
+      ) localTimeError()
+      if (pos < len) {
+        if (
+          input.charAt(pos) != '.' || {
+            pos += 1
+            var nanoDigitWeight = 100000000
+            var ch              = '0'
+            while (
+              pos < len && {
+                ch = input.charAt(pos)
+                ch >= '0' && ch <= '9' && nanoDigitWeight != 0
+              }
+            ) {
+              nano += (ch - '0') * nanoDigitWeight
+              nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
+              pos += 1
+            }
+            pos != len
+          }
+        ) localDateTimeError()
       }
     }
     LocalDateTime.of(year, month, day, hour, minute, second, nano)
   }
 
   def unsafeParseLocalTime(input: String): LocalTime = {
-    val len = input.length
-    var pos = 0
-    val hour = {
-      if (pos + 2 >= len) localTimeError(pos)
-      val ch0  = input.charAt(pos)
-      val ch1  = input.charAt(pos + 1)
-      val ch2  = input.charAt(pos + 2)
-      val hour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (hour > 23) hourError(pos + 1)
-      if (ch2 != ':') charError(':', pos + 2)
-      pos += 3
-      hour
-    }
-    val minute = {
-      if (pos + 1 >= len) localTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (ch0 > '5') minuteError(pos + 1)
-      pos += 2
-      ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-    }
-    var second, nano = 0
-    if (pos < len) {
-      if (input.charAt(pos) != ':') charError(':', pos)
-      pos += 1
-      second = {
-        if (pos + 1 >= len) localTimeError(pos)
+    val len               = input.length
+    var pos, hour, minute = 0
+    if (
+      pos + 4 >= len || {
         val ch0 = input.charAt(pos)
         val ch1 = input.charAt(pos + 1)
-        if (ch0 < '0' || ch0 > '9') digitError(pos)
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch0 > '5') secondError(pos + 1)
-        pos += 2
-        ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        hour = ch0 * 10 + ch1 - 528   // 528 == '0' * 11
+        minute = ch3 * 10 + ch4 - 528 // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != ':' ||
+        ch3 < '0' || ch3 > '9' || ch4 < '0' || ch4 > '9' || ch3 > '5' || hour > 23
       }
-      if (pos < len) {
-        if (input.charAt(pos) != '.') charError('.', pos)
-        pos += 1
-        var nanoDigitWeight = 100000000
-        var ch              = '0'
-        while (
-          pos < len && {
-            ch = input.charAt(pos)
-            pos += 1
-            ch >= '0' && ch <= '9' && nanoDigitWeight != 0
+    ) localTimeError()
+    var second, nano = 0
+    if (pos < len) {
+      if (
+        input.charAt(pos) != ':' || {
+          pos += 1
+          pos + 1 >= len || {
+            val ch0 = input.charAt(pos)
+            val ch1 = input.charAt(pos + 1)
+            pos += 2
+            second = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+            ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
           }
-        ) {
-          nano += (ch - '0') * nanoDigitWeight
-          nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
         }
-        if (pos != len || ch < '0' || ch > '9') localTimeError(pos - 1)
+      ) localTimeError()
+      if (pos < len) {
+        if (
+          input.charAt(pos) != '.' || {
+            pos += 1
+            var nanoDigitWeight = 100000000
+            var ch              = '0'
+            while (
+              pos < len && {
+                ch = input.charAt(pos)
+                ch >= '0' && ch <= '9' && nanoDigitWeight != 0
+              }
+            ) {
+              nano += (ch - '0') * nanoDigitWeight
+              nanoDigitWeight = (nanoDigitWeight * 3435973837L >> 35).toInt // divide a positive int by 10
+              pos += 1
+            }
+            pos != len
+          }
+        ) localTimeError()
       }
     }
     LocalTime.of(hour, minute, second, nano)
   }
 
   def unsafeParseMonthDay(input: String): MonthDay = {
-    if (input.length != 7) error("illegal month day", 0)
-    val ch0   = input.charAt(0)
-    val ch1   = input.charAt(1)
-    val ch2   = input.charAt(2)
-    val ch3   = input.charAt(3)
-    val ch4   = input.charAt(4)
-    val ch5   = input.charAt(5)
-    val ch6   = input.charAt(6)
-    val month = ch2 * 10 + ch3 - 528 // 528 == '0' * 11
-    val day   = ch5 * 10 + ch6 - 528 // 528 == '0' * 11
-    if (ch0 != '-') charError('-', 0)
-    if (ch1 != '-') charError('-', 1)
-    if (ch2 < '0' || ch2 > '9') digitError(2)
-    if (ch3 < '0' || ch3 > '9') digitError(3)
-    if (month < 1 || month > 12) monthError(3)
-    if (ch4 != '-') charError('-', 4)
-    if (ch5 < '0' || ch5 > '9') digitError(5)
-    if (ch6 < '0' || ch6 > '9') digitError(6)
-    if (day == 0 || (day > 28 && day > maxDayForMonth(month))) dayError(6)
+    var month, day = 0
+    if (
+      input.length != 7 || {
+        val ch0 = input.charAt(0)
+        val ch1 = input.charAt(1)
+        val ch2 = input.charAt(2)
+        val ch3 = input.charAt(3)
+        val ch4 = input.charAt(4)
+        val ch5 = input.charAt(5)
+        val ch6 = input.charAt(6)
+        month = ch2 * 10 + ch3 - 528 // 528 == '0' * 11
+        day = ch5 * 10 + ch6 - 528   // 528 == '0' * 11
+        ch0 != '-' || ch1 != '-' || ch2 < '0' || ch2 > '9' || ch3 < '0' || ch3 > '9' || ch4 != '-' ||
+        ch5 < '0' || ch5 > '9' || ch6 < '0' || ch6 > '9' || month < 1 || month > 12 || day == 0 ||
+        (day > 28 && day > maxDayForMonth(month))
+      }
+    ) monthDayError()
     MonthDay.of(month, day)
   }
 
   def unsafeParseOffsetDateTime(input: String): OffsetDateTime = {
-    val len = input.length
-    var pos = 0
-    val year = {
-      if (pos + 4 >= len) offsetDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val ch3 = input.charAt(pos + 3)
-      val ch4 = input.charAt(pos + 4)
-      if (ch0 >= '0' && ch0 <= '9') {
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 != '-') charError('-', pos + 4)
-        pos += 5
-        ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
-      } else {
-        val yearNeg = ch0 == '-' || (ch0 != '+' && charsOrDigitError('-', '+', pos))
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 < '0' || ch4 > '9') digitError(pos + 4)
-        pos += 5
-        var year       = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
-        var yearDigits = 4
-        var ch: Char   = '0'
-        while ({
-          if (pos >= len) offsetDateTimeError(pos)
-          ch = input.charAt(pos)
-          pos += 1
-          ch >= '0' && ch <= '9' && yearDigits < 9
-        }) {
-          year = year * 10 + (ch - '0')
-          yearDigits += 1
-        }
-        if (yearNeg) {
-          if (year == 0) yearError(pos - 2)
-          year = -year
-        }
-        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
-        year
-      }
-    }
-    val month = {
-      if (pos + 2 >= len) offsetDateTimeError(pos)
-      val ch0   = input.charAt(pos)
-      val ch1   = input.charAt(pos + 1)
-      val ch2   = input.charAt(pos + 2)
-      val month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (month < 1 || month > 12) monthError(pos + 1)
-      if (ch2 != '-') charError('-', pos + 2)
-      pos += 3
-      month
-    }
-    val day = {
-      if (pos + 2 >= len) offsetDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val day = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (day == 0 || (day > 28 && day > maxDayForYearMonth(year, month))) dayError(pos + 1)
-      if (ch2 != 'T') charError('T', pos + 2)
-      pos += 3
-      day
-    }
-    val hour = {
-      if (pos + 2 >= len) offsetDateTimeError(pos)
-      val ch0  = input.charAt(pos)
-      val ch1  = input.charAt(pos + 1)
-      val ch2  = input.charAt(pos + 2)
-      val hour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (hour > 23) hourError(pos + 1)
-      if (ch2 != ':') charError(':', pos + 2)
-      pos += 3
-      hour
-    }
-    val minute = {
-      if (pos + 1 >= len) offsetDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (ch0 > '5') minuteError(pos + 1)
-      pos += 2
-      ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-    }
-    var second, nano    = 0
-    var nanoDigitWeight = -1
-    if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
-    var ch = input.charAt(pos)
-    pos += 1
-    if (ch == ':') {
-      nanoDigitWeight = -2
-      second = {
-        if (pos + 1 >= len) offsetDateTimeError(pos)
+    val len                   = input.length
+    var pos, year, month, day = 0
+    if (
+      pos + 4 >= len || {
         val ch0 = input.charAt(pos)
         val ch1 = input.charAt(pos + 1)
-        if (ch0 < '0' || ch0 > '9') digitError(pos)
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch0 > '5') secondError(pos + 1)
-        pos += 2
-        ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9' || ch3 < '0' || ch3 > '9' || {
+          if (ch0 >= '0' && ch0 <= '9') {
+            year = ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
+            ch4 != '-'
+          } else {
+            year = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
+            val yearNeg = ch0 == '-' || (ch0 != '+' && offsetDateTimeError())
+            ch4 < '0' || ch4 > '9' || {
+              var yearDigits = 4
+              var ch         = '0'
+              while (
+                pos < len && {
+                  ch = input.charAt(pos)
+                  pos += 1
+                  ch >= '0' && ch <= '9' && yearDigits < 9
+                }
+              ) {
+                year = year * 10 + (ch - '0')
+                yearDigits += 1
+              }
+              yearNeg && {
+                year = -year
+                year == 0
+              } || ch != '-'
+            }
+          }
+        }
+      } || pos + 5 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        val ch5 = input.charAt(pos + 5)
+        pos += 6
+        month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        day = ch3 * 10 + ch4 - 528   // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != '-' || ch3 < '0' || ch3 > '9' ||
+        ch4 < '0' || ch4 > '9' || ch5 != 'T' || month < 1 || month > 12 || day == 0 ||
+        (day > 28 && day > maxDayForYearMonth(year, month))
       }
-      if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
+    ) offsetDateTimeError()
+    var hour, minute = 0
+    if (
+      pos + 4 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        hour = ch0 * 10 + ch1 - 528   // 528 == '0' * 11
+        minute = ch3 * 10 + ch4 - 528 // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != ':' ||
+        ch3 < '0' || ch3 > '9' || ch4 < '0' || ch4 > '9' || ch3 > '5' || hour > 23
+      } || pos >= len
+    ) offsetDateTimeError()
+    var second, nano = 0
+    var ch           = input.charAt(pos)
+    pos += 1
+    if (ch == ':') {
+      if (
+        pos + 1 >= len || {
+          val ch0 = input.charAt(pos)
+          val ch1 = input.charAt(pos + 1)
+          pos += 2
+          second = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+          ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+        } || pos >= len
+      ) offsetDateTimeError()
       ch = input.charAt(pos)
       pos += 1
       if (ch == '.') {
-        nanoDigitWeight = 100000000
+        var nanoDigitWeight = 100000000
         while ({
-          if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
+          if (pos >= len) offsetDateTimeError()
           ch = input.charAt(pos)
           pos += 1
           ch >= '0' && ch <= '9' && nanoDigitWeight != 0
@@ -752,111 +617,89 @@ private[json] object parsers {
     val zoneOffset =
       if (ch == 'Z') ZoneOffset.UTC
       else {
-        val offsetNeg = ch == '-' || (ch != '+' && timezoneSignError(nanoDigitWeight, pos - 1))
-        val offsetHour = {
-          if (pos + 1 >= len) offsetDateTimeError(pos)
-          val ch0        = input.charAt(pos)
-          val ch1        = input.charAt(pos + 1)
-          val offsetHour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-          if (ch0 < '0' || ch0 > '9') digitError(pos)
-          if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-          if (offsetHour > 18) timezoneOffsetHourError(pos + 1)
-          pos += 2
-          offsetHour
-        }
-        var offsetMinute, offsetSecond = 0
+        val offsetNeg   = ch == '-' || (ch != '+' && offsetDateTimeError())
+        var offsetTotal = 0
         if (
-          pos < len && {
-            ch = input.charAt(pos)
-            pos += 1
-            ch == ':'
-          }
-        ) {
-          offsetMinute = {
-            if (pos + 1 >= len) offsetDateTimeError(pos)
+          pos + 1 >= len || {
             val ch0 = input.charAt(pos)
             val ch1 = input.charAt(pos + 1)
-            if (ch0 < '0' || ch0 > '9') digitError(pos)
-            if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-            if (ch0 > '5') timezoneOffsetMinuteError(pos + 1)
             pos += 2
-            ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+            offsetTotal = (ch0 * 10 + ch1 - 528) * 3600 // 528 == '0' * 11
+            ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9'
           }
+        ) offsetDateTimeError()
+        if (pos < len) {
           if (
-            pos < len && {
-              ch = input.charAt(pos)
+            input.charAt(pos) != ':' || {
               pos += 1
-              ch == ':'
-            }
-          ) {
-            offsetSecond = {
-              if (pos + 1 >= len) offsetDateTimeError(pos)
+              pos + 1 >= len
+            } || {
               val ch0 = input.charAt(pos)
               val ch1 = input.charAt(pos + 1)
-              if (ch0 < '0' || ch0 > '9') digitError(pos)
-              if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-              if (ch0 > '5') timezoneOffsetSecondError(pos + 1)
               pos += 2
-              ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+              offsetTotal += (ch0 * 10 + ch1 - 528) * 60 // 528 == '0' * 11
+              ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
             }
+          ) offsetDateTimeError()
+          if (pos < len) {
+            if (
+              input.charAt(pos) != ':' || {
+                pos += 1
+                pos + 1 >= len
+              } || {
+                val ch0 = input.charAt(pos)
+                val ch1 = input.charAt(pos + 1)
+                pos += 2
+                offsetTotal += ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+                ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+              }
+            ) offsetDateTimeError()
           }
         }
-        toZoneOffset(offsetNeg, offsetHour, offsetMinute, offsetSecond, pos)
+        if (offsetTotal > 64800) offsetDateTimeError()
+        toZoneOffset(offsetNeg, offsetTotal)
       }
-    if (pos != len) offsetDateTimeError(pos)
+    if (pos != len) offsetDateTimeError()
     OffsetDateTime.of(year, month, day, hour, minute, second, nano, zoneOffset)
   }
 
   def unsafeParseOffsetTime(input: String): OffsetTime = {
-    val len = input.length
-    var pos = 0
-    val hour = {
-      if (pos + 2 >= len) offsetTimeError(pos)
-      val ch0  = input.charAt(pos)
-      val ch1  = input.charAt(pos + 1)
-      val ch2  = input.charAt(pos + 2)
-      val hour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (hour > 23) hourError(pos + 1)
-      if (ch2 != ':') charError(':', pos + 2)
-      pos += 3
-      hour
-    }
-    val minute = {
-      if (pos + 1 >= len) offsetTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (ch0 > '5') minuteError(pos + 1)
-      pos += 2
-      ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-    }
-    var second, nano    = 0
-    var nanoDigitWeight = -1
-    if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
-    var ch = input.charAt(pos)
-    pos += 1
-    if (ch == ':') {
-      nanoDigitWeight = -2
-      second = {
-        if (pos + 1 >= len) offsetTimeError(pos)
+    val len          = input.length
+    var pos          = 0
+    var hour, minute = 0
+    if (
+      pos + 4 >= len || {
         val ch0 = input.charAt(pos)
         val ch1 = input.charAt(pos + 1)
-        if (ch0 < '0' || ch0 > '9') digitError(pos)
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch0 > '5') secondError(pos + 1)
-        pos += 2
-        ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      }
-      if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        hour = ch0 * 10 + ch1 - 528   // 528 == '0' * 11
+        minute = ch3 * 10 + ch4 - 528 // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != ':' ||
+        ch3 < '0' || ch3 > '9' || ch4 < '0' || ch4 > '9' || ch3 > '5' || hour > 23
+      } || pos >= len
+    ) offsetTimeError()
+    var second, nano = 0
+    var ch           = input.charAt(pos)
+    pos += 1
+    if (ch == ':') {
+      if (
+        pos + 1 >= len || {
+          val ch0 = input.charAt(pos)
+          val ch1 = input.charAt(pos + 1)
+          pos += 2
+          second = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+          ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+        } || pos >= len
+      ) offsetTimeError()
       ch = input.charAt(pos)
       pos += 1
       if (ch == '.') {
-        nanoDigitWeight = 100000000
+        var nanoDigitWeight = 100000000
         while ({
-          if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
+          if (pos >= len) offsetTimeError()
           ch = input.charAt(pos)
           pos += 1
           ch >= '0' && ch <= '9' && nanoDigitWeight != 0
@@ -869,88 +712,76 @@ private[json] object parsers {
     val zoneOffset =
       if (ch == 'Z') ZoneOffset.UTC
       else {
-        val offsetNeg = ch == '-' || (ch != '+' && timezoneSignError(nanoDigitWeight, pos - 1))
-        nanoDigitWeight = -3
-        val offsetHour = {
-          if (pos + 1 >= len) offsetTimeError(pos)
-          val ch0        = input.charAt(pos)
-          val ch1        = input.charAt(pos + 1)
-          val offsetHour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-          if (ch0 < '0' || ch0 > '9') digitError(pos)
-          if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-          if (offsetHour > 18) timezoneOffsetHourError(pos + 1)
-          pos += 2
-          offsetHour
-        }
-        var offsetMinute, offsetSecond = 0
+        val offsetNeg   = ch == '-' || (ch != '+' && offsetTimeError())
+        var offsetTotal = 0
         if (
-          pos < len && {
-            ch = input.charAt(pos)
-            pos += 1
-            ch == ':'
-          }
-        ) {
-          offsetMinute = {
-            if (pos + 1 >= len) offsetTimeError(pos)
+          pos + 1 >= len || {
             val ch0 = input.charAt(pos)
             val ch1 = input.charAt(pos + 1)
-            if (ch0 < '0' || ch0 > '9') digitError(pos)
-            if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-            if (ch0 > '5') timezoneOffsetMinuteError(pos + 1)
             pos += 2
-            ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+            offsetTotal = (ch0 * 10 + ch1 - 528) * 3600 // 528 == '0' * 11
+            ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9'
           }
+        ) offsetTimeError()
+        if (pos < len) {
           if (
-            pos < len && {
-              ch = input.charAt(pos)
+            input.charAt(pos) != ':' || {
               pos += 1
-              ch == ':'
-            }
-          ) {
-            nanoDigitWeight = -4
-            offsetSecond = {
-              if (pos + 1 >= len) offsetTimeError(pos)
+              pos + 1 >= len
+            } || {
               val ch0 = input.charAt(pos)
               val ch1 = input.charAt(pos + 1)
-              if (ch0 < '0' || ch0 > '9') digitError(pos)
-              if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-              if (ch0 > '5') timezoneOffsetSecondError(pos + 1)
               pos += 2
-              ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+              offsetTotal += (ch0 * 10 + ch1 - 528) * 60 // 528 == '0' * 11
+              ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
             }
+          ) offsetTimeError()
+          if (pos < len) {
+            if (
+              input.charAt(pos) != ':' || {
+                pos += 1
+                pos + 1 >= len
+              } || {
+                val ch0 = input.charAt(pos)
+                val ch1 = input.charAt(pos + 1)
+                pos += 2
+                offsetTotal += ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+                ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+              }
+            ) offsetTimeError()
           }
         }
-        toZoneOffset(offsetNeg, offsetHour, offsetMinute, offsetSecond, pos)
+        if (offsetTotal > 64800) offsetTimeError()
+        toZoneOffset(offsetNeg, offsetTotal)
       }
-    if (pos != len) offsetTimeError(pos)
+    if (pos != len) offsetTimeError()
     OffsetTime.of(hour, minute, second, nano, zoneOffset)
   }
 
   def unsafeParsePeriod(input: String): Period = {
     val len                             = input.length
     var pos, state, years, months, days = 0
-    if (pos >= len) periodError(pos)
+    if (pos >= len) periodError()
     var ch = input.charAt(pos)
     pos += 1
     val isNeg = ch == '-'
     if (isNeg) {
-      if (pos >= len) periodError(pos)
+      if (pos >= len) periodError()
       ch = input.charAt(pos)
       pos += 1
     }
-    if (ch != 'P') durationOrPeriodStartError(isNeg, pos - 1)
-    if (pos >= len) periodError(pos)
+    if (ch != 'P' || pos >= len) periodError()
     ch = input.charAt(pos)
     pos += 1
     while ({
-      if (state == 4 && pos >= len) periodError(pos - 1)
+      if (state == 4 && pos >= len) periodError()
       val isNegX = ch == '-'
       if (isNegX) {
-        if (pos >= len) periodError(pos)
+        if (pos >= len) periodError()
         ch = input.charAt(pos)
         pos += 1
       }
-      if (ch < '0' || ch > '9') durationOrPeriodDigitError(isNegX, state <= 1, pos - 1)
+      if (ch < '0' || ch > '9') periodError()
       var x: Int = '0' - ch
       while (
         (pos < len) && {
@@ -963,11 +794,11 @@ private[json] object parsers {
             x = x * 10 + ('0' - ch)
             x > 0
           }
-        ) periodError(pos)
+        ) periodError()
         pos += 1
       }
       if (!(isNeg ^ isNegX)) {
-        if (x == -2147483648) periodError(pos)
+        if (x == -2147483648) periodError()
         x = -x
       }
       if (ch == 'Y' && state <= 0) {
@@ -977,15 +808,15 @@ private[json] object parsers {
         months = x
         state = 2
       } else if (ch == 'W' && state <= 2) {
-        if (x < -306783378 || x > 306783378) periodError(pos)
+        if (x < -306783378 || x > 306783378) periodError()
         days = x * 7
         state = 3
       } else if (ch == 'D') {
         val ds = x.toLong + days
-        if (ds != ds.toInt) periodError(pos)
+        if (ds != ds.toInt) periodError()
         days = ds.toInt
         state = 4
-      } else periodError(state, pos)
+      } else periodError()
       pos += 1
       (pos < len) && {
         ch = input.charAt(pos)
@@ -997,230 +828,175 @@ private[json] object parsers {
   }
 
   def unsafeParseYear(input: String): Year = {
-    val len = input.length
-    var pos = 0
-    val year = {
-      if (pos + 3 >= len) yearError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val ch3 = input.charAt(pos + 3)
-      if (ch0 >= '0' && ch0 <= '9') {
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (len != 4) yearError(pos + 4)
+    val len       = input.length
+    var pos, year = 0
+    if (
+      pos + 3 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
         pos += 4
-        ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
-      } else {
-        val yearNeg = ch0 == '-' || (ch0 != '+' && charsOrDigitError('-', '+', pos))
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        pos += 4
-        var year       = ch1 * 100 + ch2 * 10 + ch3 - 5328 // 53328 == '0' * 111
-        var yearDigits = 3
-        var ch: Char   = '0'
-        while (
-          pos < len && {
-            ch = input.charAt(pos)
-            ch >= '0' && ch <= '9' && yearDigits < 9
+        ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9' || ch3 < '0' || ch3 > '9' || {
+          if (ch0 >= '0' && ch0 <= '9') {
+            year = ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
+            pos != len
+          } else {
+            val yearNeg = ch0 == '-' || (ch0 != '+' && yearError())
+            year = ch1 * 100 + ch2 * 10 + ch3 - 5328 // 53328 == '0' * 111
+            var yearDigits = 3
+            var ch         = '0'
+            while (
+              pos < len && {
+                ch = input.charAt(pos)
+                ch >= '0' && ch <= '9' && yearDigits < 9
+              }
+            ) {
+              year = year * 10 + (ch - '0')
+              yearDigits += 1
+              pos += 1
+            }
+            yearNeg && {
+              year = -year
+              year == 0
+            } || pos != len
           }
-        ) {
-          year = year * 10 + (ch - '0')
-          yearDigits += 1
-          pos += 1
         }
-        if (yearNeg) {
-          if (year == 0) yearError(pos - 1)
-          year = -year
-        }
-        if (pos != len || ch < '0' || ch > '9') {
-          if (yearDigits == 9) yearError(pos)
-          digitError(pos)
-        }
-        year
       }
-    }
+    ) yearError()
     Year.of(year)
   }
 
   def unsafeParseYearMonth(input: String): YearMonth = {
-    val len = input.length
-    var pos = 0
-    val year = {
-      if (pos + 4 >= len) yearMonthError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val ch3 = input.charAt(pos + 3)
-      val ch4 = input.charAt(pos + 4)
-      if (ch0 >= '0' && ch0 <= '9') {
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 != '-') charError('-', pos + 4)
+    val len              = input.length
+    var pos, year, month = 0
+    if (
+      pos + 4 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
         pos += 5
-        ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
-      } else {
-        val yearNeg = ch0 == '-' || (ch0 != '+' && charsOrDigitError('-', '+', pos))
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 < '0' || ch4 > '9') digitError(pos + 4)
-        pos += 5
-        var year       = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
-        var yearDigits = 4
-        var ch: Char   = '0'
-        while ({
-          if (pos >= len) yearMonthError(pos)
-          ch = input.charAt(pos)
-          pos += 1
-          ch >= '0' && ch <= '9' && yearDigits < 9
-        }) {
-          year = year * 10 + (ch - '0')
-          yearDigits += 1
+        ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9' || ch3 < '0' || ch3 > '9' || {
+          if (ch0 >= '0' && ch0 <= '9') {
+            year = ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
+            ch4 != '-'
+          } else {
+            val yearNeg = ch0 == '-' || (ch0 != '+' && yearMonthError())
+            year = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
+            ch4 < '0' || ch4 > '9' || {
+              var yearDigits = 4
+              var ch         = '0'
+              while ({
+                if (pos >= len) yearMonthError()
+                ch = input.charAt(pos)
+                pos += 1
+                ch >= '0' && ch <= '9' && yearDigits < 9
+              }) {
+                year = year * 10 + (ch - '0')
+                yearDigits += 1
+              }
+              yearNeg && {
+                year = -year
+                year == 0
+              } || ch != '-'
+            }
+          }
         }
-        if (yearNeg) {
-          if (year == 0) yearError(pos - 2)
-          year = -year
-        }
-        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
-        year
+      } || pos + 2 != len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        pos += 2
+        month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || month < 1 || month > 12
       }
-    }
-    val month = {
-      if (pos + 1 >= len) yearMonthError(pos)
-      val ch0   = input.charAt(pos)
-      val ch1   = input.charAt(pos + 1)
-      val month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (month < 1 || month > 12) monthError(pos + 1)
-      pos += 2
-      month
-    }
-    if (pos != len) yearMonthError(pos)
+    ) yearMonthError()
     YearMonth.of(year, month)
   }
 
   def unsafeParseZonedDateTime(input: String): ZonedDateTime = {
-    val len = input.length
-    var pos = 0
-    val year = {
-      if (pos + 4 >= len) zonedDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val ch3 = input.charAt(pos + 3)
-      val ch4 = input.charAt(pos + 4)
-      if (ch0 >= '0' && ch0 <= '9') {
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 != '-') charError('-', pos + 4)
-        pos += 5
-        ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
-      } else {
-        val yearNeg = ch0 == '-' || (ch0 != '+' && charsOrDigitError('-', '+', pos))
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch2 < '0' || ch2 > '9') digitError(pos + 2)
-        if (ch3 < '0' || ch3 > '9') digitError(pos + 3)
-        if (ch4 < '0' || ch4 > '9') digitError(pos + 4)
-        pos += 5
-        var year       = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
-        var yearDigits = 4
-        var ch: Char   = '0'
-        while ({
-          if (pos >= len) zonedDateTimeError(pos)
-          ch = input.charAt(pos)
-          pos += 1
-          ch >= '0' && ch <= '9' && yearDigits < 9
-        }) {
-          year = year * 10 + (ch - '0')
-          yearDigits += 1
-        }
-        if (yearNeg) {
-          if (year == 0) yearError(pos - 2)
-          year = -year
-        }
-        if (ch != '-') yearError(yearNeg, yearDigits, pos - 1)
-        year
-      }
-    }
-    val month = {
-      if (pos + 2 >= len) zonedDateTimeError(pos)
-      val ch0   = input.charAt(pos)
-      val ch1   = input.charAt(pos + 1)
-      val ch2   = input.charAt(pos + 2)
-      val month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (month < 1 || month > 12) monthError(pos + 1)
-      if (ch2 != '-') charError('-', pos + 2)
-      pos += 3
-      month
-    }
-    val day = {
-      if (pos + 2 >= len) zonedDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      val ch2 = input.charAt(pos + 2)
-      val day = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (day == 0 || (day > 28 && day > maxDayForYearMonth(year, month))) dayError(pos + 1)
-      if (ch2 != 'T') charError('T', pos + 2)
-      pos += 3
-      day
-    }
-    val hour = {
-      if (pos + 2 >= len) zonedDateTimeError(pos)
-      val ch0  = input.charAt(pos)
-      val ch1  = input.charAt(pos + 1)
-      val ch2  = input.charAt(pos + 2)
-      val hour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (hour > 23) hourError(pos + 1)
-      if (ch2 != ':') charError(':', pos + 2)
-      pos += 3
-      hour
-    }
-    val minute = {
-      if (pos + 1 >= len) zonedDateTimeError(pos)
-      val ch0 = input.charAt(pos)
-      val ch1 = input.charAt(pos + 1)
-      if (ch0 < '0' || ch0 > '9') digitError(pos)
-      if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-      if (ch0 > '5') minuteError(pos + 1)
-      pos += 2
-      ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-    }
-    var second, nano    = 0
-    var nanoDigitWeight = -1
-    if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
-    var ch = input.charAt(pos)
-    pos += 1
-    if (ch == ':') {
-      nanoDigitWeight = -2
-      second = {
-        if (pos + 1 >= len) zonedDateTimeError(pos)
+    val len                                 = input.length
+    var pos, year, month, day, hour, minute = 0
+    if (
+      pos + 4 >= len || {
         val ch0 = input.charAt(pos)
         val ch1 = input.charAt(pos + 1)
-        if (ch0 < '0' || ch0 > '9') digitError(pos)
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (ch0 > '5') secondError(pos + 1)
-        pos += 2
-        ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-      }
-      if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9' || ch3 < '0' || ch3 > '9' || {
+          if (ch0 >= '0' && ch0 <= '9') {
+            year = ch0 * 1000 + ch1 * 100 + ch2 * 10 + ch3 - 53328 // 53328 == '0' * 1111
+            ch4 != '-'
+          } else {
+            val yearNeg = ch0 == '-' || (ch0 != '+' && zonedDateTimeError())
+            year = ch1 * 1000 + ch2 * 100 + ch3 * 10 + ch4 - 53328 // 53328 == '0' * 1111
+            ch4 < '0' || ch4 > '9' || {
+              var yearDigits = 4
+              var ch         = '0'
+              while ({
+                if (pos >= len) zonedDateTimeError()
+                ch = input.charAt(pos)
+                pos += 1
+                ch >= '0' && ch <= '9' && yearDigits < 9
+              }) {
+                year = year * 10 + (ch - '0')
+                yearDigits += 1
+              }
+              yearNeg && {
+                year = -year
+                year == 0
+              } || ch != '-'
+            }
+          }
+        }
+      } || pos + 5 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        val ch5 = input.charAt(pos + 5)
+        pos += 6
+        month = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+        day = ch3 * 10 + ch4 - 528   // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != '-' || ch3 < '0' || ch3 > '9' ||
+        ch4 < '0' || ch4 > '9' || ch5 != 'T' || month < 1 || month > 12 || day == 0 ||
+        (day > 28 && day > maxDayForYearMonth(year, month))
+      } || pos + 4 >= len || {
+        val ch0 = input.charAt(pos)
+        val ch1 = input.charAt(pos + 1)
+        val ch2 = input.charAt(pos + 2)
+        val ch3 = input.charAt(pos + 3)
+        val ch4 = input.charAt(pos + 4)
+        pos += 5
+        hour = ch0 * 10 + ch1 - 528   // 528 == '0' * 11
+        minute = ch3 * 10 + ch4 - 528 // 528 == '0' * 11
+        ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch2 != ':' ||
+        ch3 < '0' || ch3 > '9' || ch4 < '0' || ch4 > '9' || ch3 > '5' || hour > 23
+      } || pos >= len
+    ) zonedDateTimeError()
+    var second, nano = 0
+    var ch           = input.charAt(pos)
+    pos += 1
+    if (ch == ':') {
+      if (
+        pos + 1 >= len || {
+          val ch0 = input.charAt(pos)
+          val ch1 = input.charAt(pos + 1)
+          pos += 2
+          second = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+          ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+        } || pos >= len
+      ) zonedDateTimeError()
       ch = input.charAt(pos)
       pos += 1
       if (ch == '.') {
-        nanoDigitWeight = 100000000
+        var nanoDigitWeight = 100000000
         while ({
-          if (pos >= len) timezoneSignError(nanoDigitWeight, pos)
+          if (pos >= len) zonedDateTimeError()
           ch = input.charAt(pos)
           pos += 1
           ch >= '0' && ch <= '9' && nanoDigitWeight != 0
@@ -1235,94 +1011,89 @@ private[json] object parsers {
       if (ch == 'Z') {
         if (pos < len) {
           ch = input.charAt(pos)
-          if (ch != '[') charError('[', pos)
+          if (ch != '[') zonedDateTimeError()
           pos += 1
         }
         ZoneOffset.UTC
       } else {
-        val offsetNeg = ch == '-' || (ch != '+' && timezoneSignError(nanoDigitWeight, pos - 1))
-        nanoDigitWeight = -3
-        val offsetHour = {
-          if (pos + 1 >= len) zonedDateTimeError(pos)
-          val ch0        = input.charAt(pos)
-          val ch1        = input.charAt(pos + 1)
-          val offsetHour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-          if (ch0 < '0' || ch0 > '9') digitError(pos)
-          if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-          if (offsetHour > 18) timezoneOffsetHourError(pos + 1)
-          pos += 2
-          offsetHour
-        }
-        var offsetMinute, offsetSecond = 0
+        val offsetNeg   = ch == '-' || (ch != '+' && zonedDateTimeError())
+        var offsetTotal = 0
+        if (
+          pos + 1 >= len || {
+            val ch0 = input.charAt(pos)
+            val ch1 = input.charAt(pos + 1)
+            pos += 2
+            offsetTotal = (ch0 * 10 + ch1 - 528) * 3600 // 528 == '0' * 11
+            ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9'
+          }
+        ) zonedDateTimeError()
         if (
           pos < len && {
             ch = input.charAt(pos)
             pos += 1
-            ch == ':' || ch != '[' && charError('[', pos - 1)
+            ch == ':' || ch != '[' && zonedDateTimeError()
           }
         ) {
-          offsetMinute = {
-            if (pos + 1 >= len) zonedDateTimeError(pos)
-            val ch0 = input.charAt(pos)
-            val ch1 = input.charAt(pos + 1)
-            if (ch0 < '0' || ch0 > '9') digitError(pos)
-            if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-            if (ch0 > '5') timezoneOffsetMinuteError(pos + 1)
-            pos += 2
-            ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-          }
+          if (
+            pos + 1 >= len || {
+              val ch0 = input.charAt(pos)
+              val ch1 = input.charAt(pos + 1)
+              pos += 2
+              offsetTotal += (ch0 * 10 + ch1 - 528) * 60 // 528 == '0' * 11
+              ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+            }
+          ) zonedDateTimeError()
           if (
             pos < len && {
               ch = input.charAt(pos)
               pos += 1
-              ch == ':' || ch != '[' && charError('[', pos - 1)
+              ch == ':' || ch != '[' && zonedDateTimeError()
             }
           ) {
-            nanoDigitWeight = -4
-            offsetSecond = {
-              if (pos + 1 >= len) zonedDateTimeError(pos)
-              val ch0 = input.charAt(pos)
-              val ch1 = input.charAt(pos + 1)
-              if (ch0 < '0' || ch0 > '9') digitError(pos)
-              if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-              if (ch0 > '5') timezoneOffsetSecondError(pos + 1)
-              pos += 2
-              ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-            }
+            if (
+              pos + 1 >= len || {
+                val ch0 = input.charAt(pos)
+                val ch1 = input.charAt(pos + 1)
+                pos += 2
+                offsetTotal += ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+                ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+              }
+            ) zonedDateTimeError()
             if (pos < len) {
               ch = input.charAt(pos)
-              if (ch != '[') charError('[', pos)
+              if (ch != '[') zonedDateTimeError()
               pos += 1
             }
           }
         }
-        toZoneOffset(offsetNeg, offsetHour, offsetMinute, offsetSecond, pos)
+        if (offsetTotal > 64800) zonedDateTimeError()
+        toZoneOffset(offsetNeg, offsetTotal)
       }
     if (ch == '[') {
-      val zone =
-        try {
-          val from = pos
-          while ({
-            if (pos >= len) zonedDateTimeError(pos)
-            ch = input.charAt(pos)
-            ch != ']'
-          }) pos += 1
-          val key    = input.substring(from, pos)
-          var zoneId = zoneIds.get(key)
-          if (
-            (zoneId eq null) && {
-              zoneId = ZoneId.of(key)
-              !zoneId.isInstanceOf[ZoneOffset] || zoneId.asInstanceOf[ZoneOffset].getTotalSeconds % 900 == 0
-            }
-          ) zoneIds.put(key, zoneId)
-          zoneId
-        } catch {
-          case _: DateTimeException => zonedDateTimeError(pos - 1)
+      var zoneId: ZoneId = null
+      val from           = pos
+      while ({
+        if (pos >= len) zonedDateTimeError()
+        ch = input.charAt(pos)
+        ch != ']'
+      }) pos += 1
+      val key = input.substring(from, pos)
+      zoneId = zoneIds.get(key)
+      if (
+        (zoneId eq null) && {
+          try zoneId = ZoneId.of(key)
+          catch {
+            case _: DateTimeException => zonedDateTimeError()
+          }
+          !zoneId.isInstanceOf[ZoneOffset] || zoneId.asInstanceOf[ZoneOffset].getTotalSeconds % 900 == 0
         }
-      pos += 1
-      if (pos != len) zonedDateTimeError(pos)
-      ZonedDateTime.ofInstant(localDateTime, zoneOffset, zone)
-    } else ZonedDateTime.ofLocal(localDateTime, zoneOffset, null)
+      ) zoneIds.put(key, zoneId)
+      if (pos + 1 != len) zonedDateTimeError()
+      ZonedDateTime.ofInstant(localDateTime, zoneOffset, zoneId)
+    } else {
+      if (pos != len) zonedDateTimeError()
+      ZonedDateTime.ofLocal(localDateTime, zoneOffset, null)
+    }
   }
 
   def unsafeParseZoneId(input: String): ZoneId =
@@ -1336,103 +1107,82 @@ private[json] object parsers {
       ) zoneIds.put(input, zoneId)
       zoneId
     } catch {
-      case _: DateTimeException => error("illegal zone id", 0)
+      case _: DateTimeException => zoneIdError()
     }
 
   def unsafeParseZoneOffset(input: String): ZoneOffset = {
     val len                  = input.length
     var pos, nanoDigitWeight = 0
-    if (pos >= len) zoneOffsetError(pos)
-    var ch = input.charAt(pos)
+    if (pos >= len) zoneOffsetError()
+    val ch = input.charAt(pos)
     pos += 1
-    if (ch == 'Z') ZoneOffset.UTC
-    else {
-      val offsetNeg = ch == '-' || (ch != '+' && timezoneSignError(nanoDigitWeight, pos - 1))
+    if (ch == 'Z') {
+      if (pos != len) zoneOffsetError()
+      ZoneOffset.UTC
+    } else {
+      val offsetNeg = ch == '-' || (ch != '+' && zoneOffsetError())
       nanoDigitWeight = -3
-      val offsetHour = {
-        if (pos + 1 >= len) zoneOffsetError(pos)
-        val ch0        = input.charAt(pos)
-        val ch1        = input.charAt(pos + 1)
-        val offsetHour = ch0 * 10 + ch1 - 528 // 528 == '0' * 11
-        if (ch0 < '0' || ch0 > '9') digitError(pos)
-        if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-        if (offsetHour > 18) timezoneOffsetHourError(pos + 1)
-        pos += 2
-        offsetHour
-      }
-      var offsetMinute, offsetSecond = 0
+      var offsetTotal = 0
       if (
-        pos < len && {
-          ch = input.charAt(pos)
-          pos += 1
-          ch == ':'
-        }
-      ) {
-        offsetMinute = {
-          if (pos + 1 >= len) zoneOffsetError(pos)
+        pos + 1 >= len || {
           val ch0 = input.charAt(pos)
           val ch1 = input.charAt(pos + 1)
-          if (ch0 < '0' || ch0 > '9') digitError(pos)
-          if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-          if (ch0 > '5') timezoneOffsetMinuteError(pos + 1)
+          offsetTotal = (ch0 * 10 + ch1 - 528) * 3600 // 528 == '0' * 11
           pos += 2
-          ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+          ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9'
         }
+      ) zoneOffsetError()
+      if (pos < len) {
         if (
-          pos < len && {
-            ch = input.charAt(pos)
+          input.charAt(pos) != ':' || {
             pos += 1
-            ch == ':'
-          }
-        ) {
-          nanoDigitWeight = -4
-          offsetSecond = {
-            if (pos + 1 >= len) zoneOffsetError(pos)
+            pos + 1 >= len
+          } || {
             val ch0 = input.charAt(pos)
             val ch1 = input.charAt(pos + 1)
-            if (ch0 < '0' || ch0 > '9') digitError(pos)
-            if (ch1 < '0' || ch1 > '9') digitError(pos + 1)
-            if (ch0 > '5') timezoneOffsetSecondError(pos + 1)
             pos += 2
-            ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+            offsetTotal += (ch0 * 10 + ch1 - 528) * 60 // 528 == '0' * 11
+            ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
           }
+        ) zoneOffsetError()
+        if (pos < len) {
+          if (
+            input.charAt(pos) != ':' || {
+              pos += 1
+              pos + 1 >= len
+            } || {
+              val ch0 = input.charAt(pos)
+              val ch1 = input.charAt(pos + 1)
+              pos += 2
+              offsetTotal += ch0 * 10 + ch1 - 528 // 528 == '0' * 11
+              ch0 < '0' || ch0 > '9' || ch1 < '0' || ch1 > '9' || ch0 > '5'
+            }
+          ) zoneOffsetError()
         }
       }
-      if (pos != len) zoneOffsetError(pos)
-      toZoneOffset(offsetNeg, offsetHour, offsetMinute, offsetSecond, pos)
+      if (offsetTotal > 64800 || pos != len) zoneOffsetError() // 64800 == 18 * 60 * 60
+      toZoneOffset(offsetNeg, offsetTotal)
     }
   }
 
-  private[this] def toZoneOffset(
-    offsetNeg: Boolean,
-    offsetHour: Int,
-    offsetMinute: Int,
-    offsetSecond: Int,
-    pos: Int
-  ): ZoneOffset = {
-    var offsetTotal = offsetHour * 3600 + offsetMinute * 60 + offsetSecond
-    var qp          = offsetTotal * 37283
-    if (offsetTotal > 64800) zoneOffsetError(pos) // 64800 == 18 * 60 * 60
-    if ((qp & 0x1ff8000) == 0) {                  // check if offsetTotal divisible by 900
-      qp >>>= 25                                  // divide offsetTotal by 900
+  private[this] def toZoneOffset(offsetNeg: Boolean, offsetTotal: Int): ZoneOffset = {
+    var qp = offsetTotal * 37283
+    if ((qp & 0x1ff8000) == 0) { // check if offsetTotal divisible by 900
+      qp >>>= 25                 // divide offsetTotal by 900
       if (offsetNeg) qp = -qp
       var zoneOffset = zoneOffsets(qp + 72)
       if (zoneOffset ne null) zoneOffset
       else {
-        if (offsetNeg) offsetTotal = -offsetTotal
-        zoneOffset = ZoneOffset.ofTotalSeconds(offsetTotal)
+        zoneOffset = ZoneOffset.ofTotalSeconds(if (offsetNeg) -offsetTotal else offsetTotal)
         zoneOffsets(qp + 72) = zoneOffset
         zoneOffset
       }
-    } else {
-      if (offsetNeg) offsetTotal = -offsetTotal
-      ZoneOffset.ofTotalSeconds(offsetTotal)
-    }
+    } else ZoneOffset.ofTotalSeconds(if (offsetNeg) -offsetTotal else offsetTotal)
   }
 
-  private[this] def sumSeconds(s1: Long, s2: Long, pos: Int): Long = {
+  private[this] def sumSeconds(s1: Long, s2: Long): Long = {
     val s = s1 + s2
-    if (((s1 ^ s) & (s2 ^ s)) < 0) durationError(pos)
+    if (((s1 ^ s) & (s2 ^ s)) < 0) durationError()
     s
   }
 
@@ -1464,115 +1214,33 @@ private[json] object parsers {
     ((cp ^ cc) & 0x1fc0000000L) != 0 || (((cp >> 37).toInt - cc) & 0x3) == 0
   }
 
-  private[this] def nanoError(nanoDigitWeight: Int, ch: Char, pos: Int): Nothing = {
-    if (nanoDigitWeight == 0) charError(ch, pos)
-    charOrDigitError(ch, pos)
-  }
+  @noinline private[this] def durationError() = error("expected a Duration")
 
-  private[this] def durationOrPeriodStartError(isNeg: Boolean, pos: Int) =
-    error(
-      if (isNeg) "expected 'P'"
-      else "expected 'P' or '-'",
-      pos
-    )
+  @noinline private[this] def instantError() = error("expected an Instant")
 
-  private[this] def durationOrPeriodDigitError(isNegX: Boolean, isNumReq: Boolean, pos: Int): Nothing =
-    error(
-      if (isNegX) "expected digit"
-      else if (isNumReq) "expected '-' or digit"
-      else "expected '\"' or '-' or digit",
-      pos
-    )
+  @noinline private[this] def localDateError() = error("expected a LocalDate")
 
-  private[this] def durationError(state: Int, pos: Int): Nothing =
-    error(
-      (state: @switch) match {
-        case 0 => "expected 'D' or digit"
-        case 1 => "expected 'H' or 'M' or 'S or '.' or digit"
-        case 2 => "expected 'M' or 'S or '.' or digit"
-        case 3 => "expected 'S or '.' or digit"
-      },
-      pos
-    )
+  @noinline private[this] def localDateTimeError() = error("expected a LocalDateTime")
 
-  private[this] def durationError(pos: Int) = error("illegal duration", pos)
+  @noinline private[this] def localTimeError() = error("expected a LocalTime")
 
-  private[this] def timezoneSignError(nanoDigitWeight: Int, pos: Int) =
-    error(
-      if (nanoDigitWeight == -2) "expected '.' or '+' or '-' or 'Z'"
-      else if (nanoDigitWeight == -1) "expected ':' or '+' or '-' or 'Z'"
-      else if (nanoDigitWeight == 0) "expected '+' or '-' or 'Z'"
-      else "expected digit or '+' or '-' or 'Z'",
-      pos
-    )
+  @noinline private[this] def offsetDateTimeError() = error("expected an OffsetDateTime")
 
-  private[this] def instantError(pos: Int) = error("illegal instant", pos)
+  @noinline private[this] def offsetTimeError() = error("expected an OffsetTime")
 
-  private[this] def localDateError(pos: Int) = error("illegal local date", pos)
+  @noinline private[this] def periodError() = error("expected a Period")
 
-  private[this] def localDateTimeError(pos: Int) = error("illegal local date time", pos)
+  @noinline private[this] def monthDayError() = error("expected a MonthDay")
 
-  private[this] def localTimeError(pos: Int) = error("illegal local time", pos)
+  @noinline private[this] def yearMonthError() = error("expected a YearMonth")
 
-  private[this] def offsetDateTimeError(pos: Int) = error("illegal offset date time", pos)
+  @noinline private[this] def zonedDateTimeError() = error("expected a ZonedDateTime")
 
-  private[this] def offsetTimeError(pos: Int) = error("illegal offset time", pos)
+  @noinline private[this] def zoneOffsetError() = error("expected a ZoneOffset")
 
-  private[this] def periodError(state: Int, pos: Int): Nothing =
-    error(
-      (state: @switch) match {
-        case 0 => "expected 'Y' or 'M' or 'W' or 'D' or digit"
-        case 1 => "expected 'M' or 'W' or 'D' or digit"
-        case 2 => "expected 'W' or 'D' or digit"
-        case 3 => "expected 'D' or digit"
-      },
-      pos
-    )
+  @noinline private[this] def zoneIdError() = error("expected a ZoneId")
 
-  private[this] def periodError(pos: Int) = error("illegal period", pos)
+  @noinline private[this] def yearError() = error("expected a Year")
 
-  private[this] def yearMonthError(pos: Int) = error("illegal year month", pos)
-
-  private[this] def zonedDateTimeError(pos: Int) = error("illegal zoned date time", pos)
-
-  private[this] def zoneOffsetError(pos: Int) = error("illegal zone offset", pos)
-
-  private[this] def yearError(yearNeg: Boolean, yearDigits: Int, pos: Int) = {
-    if (!yearNeg && yearDigits == 4) digitError(pos)
-    if (yearDigits == 9) charError('-', pos)
-    charOrDigitError('-', pos)
-  }
-
-  private[this] def yearError(pos: Int) = error("illegal year", pos)
-
-  private[this] def monthError(pos: Int) = error("illegal month", pos)
-
-  private[this] def dayError(pos: Int) = error("illegal day", pos)
-
-  private[this] def hourError(pos: Int) = error("illegal hour", pos)
-
-  private[this] def minuteError(pos: Int) = error("illegal minute", pos)
-
-  private[this] def secondError(pos: Int) = error("illegal second", pos)
-
-  private[this] def timezoneOffsetHourError(pos: Int) = error("illegal timezone offset hour", pos)
-
-  private[this] def timezoneOffsetMinuteError(pos: Int) = error("illegal timezone offset minute", pos)
-
-  private[this] def timezoneOffsetSecondError(pos: Int) = error("illegal timezone offset second", pos)
-
-  private[this] def digitError(pos: Int) = error("expected digit", pos)
-
-  private[this] def charsOrDigitError(ch1: Char, ch2: Char, pos: Int) =
-    error(s"expected '$ch1' or '$ch2' or digit", pos)
-
-  private[this] def charsError(ch1: Char, ch2: Char, pos: Int) = error(s"expected '$ch1' or '$ch2'", pos)
-
-  private[this] def charOrDigitError(ch1: Char, pos: Int) = error(s"expected '$ch1' or digit", pos)
-
-  private[this] def charError(ch: Char, pos: Int) = error(s"expected '$ch'", pos)
-
-  @noinline
-  private[this] def error(msg: String, pos: Int): Nothing =
-    throw new DateTimeException(msg + " at index " + pos) with NoStackTrace
+  private[this] def error(msg: String): Nothing = throw new DateTimeException(msg) with NoStackTrace
 }

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -513,15 +513,15 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(ok3.fromJson[Map[UUID, String]])(
             isRight(equalTo(expectedMap("00000000-0000-0000-0000-000000000000")))
           ) &&
-          assert(bad1.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad2.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad3.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad4.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad5.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad6.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad7.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad8.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad9.fromJson[Map[UUID, String]])(isLeft(containsString("(expected UUID string)")))
+          assert(bad1.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad2.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad3.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad4.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad5.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad6.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad7.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad8.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad9.fromJson[Map[UUID, String]])(isLeft(containsString("(expected a UUID)")))
         },
         test("zio.Chunk") {
           val jsonStr  = """["5XL","2XL","XL"]"""
@@ -557,15 +557,15 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(ok1.fromJson[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4514-9832-4e70afe4b0f8")))) &&
           assert(ok2.fromJson[UUID])(isRight(equalTo(UUID.fromString("64D7C38D-00FD-0014-0032-0070AfE4B0f8")))) &&
           assert(ok3.fromJson[UUID])(isRight(equalTo(UUID.fromString("00000000-0000-0000-0000-000000000000")))) &&
-          assert(bad1.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad2.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad3.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad4.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad5.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad6.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad7.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad8.fromJson[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad9.fromJson[UUID])(isLeft(containsString("(expected UUID string)")))
+          assert(bad1.fromJson[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad2.fromJson[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad3.fromJson[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad4.fromJson[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad5.fromJson[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad6.fromJson[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad7.fromJson[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad8.fromJson[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad9.fromJson[UUID])(isLeft(containsString("(expected a UUID)")))
         },
         test("java.util.Currency") {
           assert(""""USD"""".fromJson[java.util.Currency])(isRight(equalTo(java.util.Currency.getInstance("USD")))) &&
@@ -579,7 +579,7 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(ok1.fromJson[Duration])(isRight(equalTo(Duration.parse("PT1H2M3S")))) &&
           assert(ok2.fromJson[Duration])(isRight(equalTo(Duration.ofNanos(-500000000)))) &&
           assert(bad1.fromJson[Duration])(
-            isLeft(containsString("PT-H is not a valid ISO-8601 format, expected digit at index 3"))
+            isLeft(containsString("expected a Duration"))
           )
         },
         test("java.time.ZonedDateTime") {
@@ -594,13 +594,7 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(ok2.fromJson[ZonedDateTime].map(_.toOffsetDateTime))(
             isRight(equalTo(OffsetDateTime.parse("2018-10-28T03:30+01:00")))
           ) &&
-          assert(bad1.fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2018-10-28T02:30 is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 16)"
-              )
-            )
-          )
+          assert(bad1.fromJson[ZonedDateTime])(isLeft(equalTo("(expected a ZonedDateTime)")))
         },
         test("bothWith") {
           final case class Foo(a: Int)
@@ -1074,15 +1068,15 @@ object DecoderSpec extends ZIOSpecDefault {
           assert(ok1.as[UUID])(isRight(equalTo(UUID.fromString("64d7c38d-2afd-4514-9832-4e70afe4b0f8")))) &&
           assert(ok2.as[UUID])(isRight(equalTo(UUID.fromString("64D7C38D-00FD-0014-0032-0070AFE4B0f8")))) &&
           assert(ok3.as[UUID])(isRight(equalTo(UUID.fromString("00000000-0000-0000-0000-000000000000")))) &&
-          assert(bad1.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad2.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad3.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad4.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad5.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad6.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad7.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad8.as[UUID])(isLeft(containsString("(expected UUID string)"))) &&
-          assert(bad9.as[UUID])(isLeft(containsString("(expected UUID string)")))
+          assert(bad1.as[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad2.as[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad3.as[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad4.as[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad5.as[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad6.as[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad7.as[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad8.as[UUID])(isLeft(containsString("(expected a UUID)"))) &&
+          assert(bad9.as[UUID])(isLeft(containsString("(expected a UUID)")))
         }
       )
     )

--- a/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/JavaTimeSpec.scala
@@ -3,7 +3,6 @@ package zio.json
 import zio.json.ast._
 import zio.test.Assertion._
 import zio.test._
-
 import java.time._
 import java.time.format.DateTimeFormatter
 
@@ -247,7 +246,7 @@ object JavaTimeSpec extends ZIOSpecDefault {
         }
       ),
       suite("Decoder")(
-        test("DayOfWeek") {
+        test("DayOfWeek fromJson") {
           assert(stringify("MONDAY").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.MONDAY))) &&
           assert(stringify("TUESDAY").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.TUESDAY))) &&
           assert(stringify("WEDNESDAY").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.WEDNESDAY))) &&
@@ -256,7 +255,22 @@ object JavaTimeSpec extends ZIOSpecDefault {
           assert(stringify("SATURDAY").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.SATURDAY))) &&
           assert(stringify("SUNDAY").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.SUNDAY))) &&
           assert(stringify("monday").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.MONDAY))) &&
-          assert(stringify("MonDay").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.MONDAY)))
+          assert(stringify("MonDay").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.MONDAY))) &&
+          assert(stringify("MonDa\\u0079").fromJson[DayOfWeek])(isRight(equalTo(DayOfWeek.MONDAY))) &&
+          assert(stringify("Mon").fromJson[DayOfWeek])(isLeft(equalTo("(expected a DayOfWeek)")))
+        },
+        test("DayOfWeek fromJsonAST") {
+          assert(Json.Str("MONDAY").as[DayOfWeek])(isRight(equalTo(DayOfWeek.MONDAY))) &&
+          assert(Json.Str("TUESDAY").as[DayOfWeek])(isRight(equalTo(DayOfWeek.TUESDAY))) &&
+          assert(Json.Str("WEDNESDAY").as[DayOfWeek])(isRight(equalTo(DayOfWeek.WEDNESDAY))) &&
+          assert(Json.Str("THURSDAY").as[DayOfWeek])(isRight(equalTo(DayOfWeek.THURSDAY))) &&
+          assert(Json.Str("FRIDAY").as[DayOfWeek])(isRight(equalTo(DayOfWeek.FRIDAY))) &&
+          assert(Json.Str("SATURDAY").as[DayOfWeek])(isRight(equalTo(DayOfWeek.SATURDAY))) &&
+          assert(Json.Str("SUNDAY").as[DayOfWeek])(isRight(equalTo(DayOfWeek.SUNDAY))) &&
+          assert(Json.Str("monday").as[DayOfWeek])(isRight(equalTo(DayOfWeek.MONDAY))) &&
+          assert(Json.Str("MonDay").as[DayOfWeek])(isRight(equalTo(DayOfWeek.MONDAY))) &&
+          assert(Json.Str("MonDa\\u0079").as[DayOfWeek])(isLeft(equalTo("(expected a DayOfWeek)"))) &&
+          assert(Json.Str("Mon").as[DayOfWeek])(isLeft(equalTo("(expected a DayOfWeek)")))
         },
         test("Duration") {
           assert(stringify("PT24H").fromJson[Duration])(isRight(equalTo(Duration.ofHours(24)))) &&
@@ -286,6 +300,7 @@ object JavaTimeSpec extends ZIOSpecDefault {
           val p = LocalDateTime.of(2020, 1, 1, 12, 36, 0)
           assert(stringify(n).fromJson[LocalDateTime])(isRight(equalTo(n))) &&
           assert(stringify("2020-01-01T12:36").fromJson[LocalDateTime])(isRight(equalTo(p))) &&
+          assert(stringify("2020-01-01T12:36:00").fromJson[LocalDateTime])(isRight(equalTo(p))) &&
           assert(stringify("2020-01-01T12:36:00.").fromJson[LocalDateTime])(isRight(equalTo(p)))
         },
         test("LocalTime") {
@@ -293,9 +308,10 @@ object JavaTimeSpec extends ZIOSpecDefault {
           val p = LocalTime.of(12, 36, 0)
           assert(stringify(n).fromJson[LocalTime])(isRight(equalTo(n))) &&
           assert(stringify("12:36").fromJson[LocalTime])(isRight(equalTo(p))) &&
+          assert(stringify("12:36:00").fromJson[LocalTime])(isRight(equalTo(p))) &&
           assert(stringify("12:36:00.").fromJson[LocalTime])(isRight(equalTo(p)))
         },
-        test("Month") {
+        test("Month fromJson") {
           assert(stringify("JANUARY").fromJson[Month])(isRight(equalTo(Month.JANUARY))) &&
           assert(stringify("FEBRUARY").fromJson[Month])(isRight(equalTo(Month.FEBRUARY))) &&
           assert(stringify("MARCH").fromJson[Month])(isRight(equalTo(Month.MARCH))) &&
@@ -309,7 +325,27 @@ object JavaTimeSpec extends ZIOSpecDefault {
           assert(stringify("NOVEMBER").fromJson[Month])(isRight(equalTo(Month.NOVEMBER))) &&
           assert(stringify("DECEMBER").fromJson[Month])(isRight(equalTo(Month.DECEMBER))) &&
           assert(stringify("december").fromJson[Month])(isRight(equalTo(Month.DECEMBER))) &&
-          assert(stringify("December").fromJson[Month])(isRight(equalTo(Month.DECEMBER)))
+          assert(stringify("December").fromJson[Month])(isRight(equalTo(Month.DECEMBER))) &&
+          assert(stringify("Decembe\\u0072").fromJson[Month])(isRight(equalTo(Month.DECEMBER))) &&
+          assert(stringify("Dec").fromJson[Month])(isLeft(equalTo("(expected a Month)")))
+        },
+        test("Month fromJsonAST") {
+          assert(Json.Str("JANUARY").as[Month])(isRight(equalTo(Month.JANUARY))) &&
+          assert(Json.Str("FEBRUARY").as[Month])(isRight(equalTo(Month.FEBRUARY))) &&
+          assert(Json.Str("MARCH").as[Month])(isRight(equalTo(Month.MARCH))) &&
+          assert(Json.Str("APRIL").as[Month])(isRight(equalTo(Month.APRIL))) &&
+          assert(Json.Str("MAY").as[Month])(isRight(equalTo(Month.MAY))) &&
+          assert(Json.Str("JUNE").as[Month])(isRight(equalTo(Month.JUNE))) &&
+          assert(Json.Str("JULY").as[Month])(isRight(equalTo(Month.JULY))) &&
+          assert(Json.Str("AUGUST").as[Month])(isRight(equalTo(Month.AUGUST))) &&
+          assert(Json.Str("SEPTEMBER").as[Month])(isRight(equalTo(Month.SEPTEMBER))) &&
+          assert(Json.Str("OCTOBER").as[Month])(isRight(equalTo(Month.OCTOBER))) &&
+          assert(Json.Str("NOVEMBER").as[Month])(isRight(equalTo(Month.NOVEMBER))) &&
+          assert(Json.Str("DECEMBER").as[Month])(isRight(equalTo(Month.DECEMBER))) &&
+          assert(Json.Str("december").as[Month])(isRight(equalTo(Month.DECEMBER))) &&
+          assert(Json.Str("December").as[Month])(isRight(equalTo(Month.DECEMBER))) &&
+          assert(Json.Str("Decembe\\u0072").as[Month])(isLeft(equalTo("(expected a Month)"))) &&
+          assert(Json.Str("Dec").as[Month])(isLeft(equalTo("(expected a Month)")))
         },
         test("MonthDay") {
           val n = MonthDay.now()
@@ -362,10 +398,15 @@ object JavaTimeSpec extends ZIOSpecDefault {
           val utc = ZonedDateTime.of(ld, ZoneId.of("Etc/UTC"))
           val gmt = ZonedDateTime.of(ld, ZoneId.of("+00:00"))
 
+          zdtAssert(
+            "+164433183-11-15T12:32:00.076988677Z[Atlantic/Madeira]",
+            OffsetDateTime
+              .parse("+164433183-11-15T12:32:00.076988677Z")
+              .atZoneSameInstant(ZoneId.of("Atlantic/Madeira"))
+          ) &&
           zdtAssert(n.toString, n) &&
           zdtAssert("2020-01-01T12:36:00-05:00[America/New_York]", est) &&
           zdtAssert("2020-01-01T12:36:00Z[Etc/UTC]", utc) &&
-          zdtAssert("2020-01-01T12:36:00.Z[Etc/UTC]", utc) &&
           zdtAssert("2020-01-01T12:36:00+00:00[+00:00]", gmt) &&
           zdtAssert(
             "2018-02-01T00:00Z",
@@ -450,2768 +491,1080 @@ object JavaTimeSpec extends ZIOSpecDefault {
         test("ZoneOffset") {
           assert(stringify("Z").fromJson[ZoneOffset])(isRight(equalTo(ZoneOffset.UTC))) &&
           assert(stringify("+05:00").fromJson[ZoneOffset])(isRight(equalTo(ZoneOffset.ofHours(5)))) &&
-          assert(stringify("-05:00").fromJson[ZoneOffset])(isRight(equalTo(ZoneOffset.ofHours(-5))))
+          assert(stringify("-05:00").fromJson[ZoneOffset])(isRight(equalTo(ZoneOffset.ofHours(-5)))) &&
+          assert(stringify("+05:10:10").fromJson[ZoneOffset])(
+            isRight(equalTo(ZoneOffset.ofHoursMinutesSeconds(5, 10, 10)))
+          )
         }
       ),
       suite("Decoder Sad Path")(
-        test("DayOfWeek") {
-          assert(stringify("foody").fromJson[DayOfWeek])(
-            isLeft(equalTo("(foody is not a valid ISO-8601 format)"))
-          )
-        },
         test("Duration") {
-          assert("""""""".fromJson[Duration])(
-            isLeft(containsString(" is not a valid ISO-8601 format, illegal duration at index 0"))
-          ) &&
-          assert(""""X"""".fromJson[Duration])(
-            isLeft(containsString("X is not a valid ISO-8601 format, expected 'P' or '-' at index 0"))
-          ) &&
-          assert(""""P"""".fromJson[Duration])(
-            isLeft(containsString("P is not a valid ISO-8601 format, illegal duration at index 1"))
-          ) &&
-          assert(""""-"""".fromJson[Duration])(
-            isLeft(containsString("- is not a valid ISO-8601 format, illegal duration at index 1"))
-          ) &&
-          assert(""""-X"""".fromJson[Duration])(
-            isLeft(containsString("-X is not a valid ISO-8601 format, expected 'P' at index 1"))
-          ) &&
-          assert(""""PXD"""".fromJson[Duration])(
-            isLeft(containsString("PXD is not a valid ISO-8601 format, expected '-' or digit at index 1"))
-          ) &&
-          assert(""""P-"""".fromJson[Duration])(
-            isLeft(containsString("P- is not a valid ISO-8601 format, illegal duration at index 2"))
-          ) &&
-          assert(""""P-XD"""".fromJson[Duration])(
-            isLeft(containsString("P-XD is not a valid ISO-8601 format, expected digit at index 2"))
-          ) &&
-          assert(""""P1XD"""".fromJson[Duration])(
-            isLeft(containsString("P1XD is not a valid ISO-8601 format, expected 'D' or digit at index 2"))
-          ) &&
-          assert(""""PT"""".fromJson[Duration])(
-            isLeft(containsString("PT is not a valid ISO-8601 format, illegal duration at index 2"))
-          ) &&
-          assert(""""PT0SX"""".fromJson[Duration])(
-            isLeft(containsString("PT0SX is not a valid ISO-8601 format, illegal duration at index 4"))
-          ) &&
-          assert(""""P1DT"""".fromJson[Duration])(
-            isLeft(containsString("P1DT is not a valid ISO-8601 format, illegal duration at index 4"))
-          ) &&
-          assert(""""P106751991167301D"""".fromJson[Duration])(
-            isLeft(containsString("P106751991167301D is not a valid ISO-8601 format, illegal duration at index 16"))
-          ) &&
-          assert(""""P1067519911673000D"""".fromJson[Duration])(
-            isLeft(containsString("P1067519911673000D is not a valid ISO-8601 format, illegal duration at index 17"))
-          ) &&
-          assert(""""P-106751991167301D"""".fromJson[Duration])(
-            isLeft(containsString("P-106751991167301D is not a valid ISO-8601 format, illegal duration at index 17"))
-          ) &&
-          assert(""""P1DX1H"""".fromJson[Duration])(
-            isLeft(containsString("P1DX1H is not a valid ISO-8601 format, expected 'T' or '\"' at index 3"))
-          ) &&
-          assert(""""P1DTXH"""".fromJson[Duration])(
-            isLeft(containsString("P1DTXH is not a valid ISO-8601 format, expected '-' or digit at index 4"))
-          ) &&
-          assert(""""P1DT-XH"""".fromJson[Duration])(
-            isLeft(containsString("P1DT-XH is not a valid ISO-8601 format, expected digit at index 5"))
-          ) &&
-          assert(""""P1DT1XH"""".fromJson[Duration])(
-            isLeft(
-              containsString(
-                "P1DT1XH is not a valid ISO-8601 format, expected 'H' or 'M' or 'S or '.' or digit at index 5"
-              )
-            )
-          ) &&
-          assert(""""P1DT1H1XM"""".fromJson[Duration])(
-            isLeft(
-              containsString("P1DT1H1XM is not a valid ISO-8601 format, expected 'M' or 'S or '.' or digit at index 7")
-            )
-          ) &&
-          assert(""""P0DT2562047788015216H"""".fromJson[Duration])(
-            isLeft(containsString("P0DT2562047788015216H is not a valid ISO-8601 format, illegal duration at index 20"))
-          ) &&
-          assert(""""P0DT-2562047788015216H"""".fromJson[Duration])(
-            isLeft(
-              containsString("P0DT-2562047788015216H is not a valid ISO-8601 format, illegal duration at index 21")
-            )
-          ) &&
-          assert(""""P0DT153722867280912931M"""".fromJson[Duration])(
-            isLeft(
-              containsString("P0DT153722867280912931M is not a valid ISO-8601 format, illegal duration at index 22")
-            )
-          ) &&
-          assert(""""P0DT-153722867280912931M"""".fromJson[Duration])(
-            isLeft(
-              containsString("P0DT-153722867280912931M is not a valid ISO-8601 format, illegal duration at index 23")
-            )
-          ) &&
-          assert(""""P0DT9223372036854775808S"""".fromJson[Duration])(
-            isLeft(
-              containsString("P0DT9223372036854775808S is not a valid ISO-8601 format, illegal duration at index 23")
-            )
-          ) &&
-          assert(""""P0DT92233720368547758000S"""".fromJson[Duration])(
-            isLeft(
-              containsString("P0DT92233720368547758000S is not a valid ISO-8601 format, illegal duration at index 23")
-            )
-          ) &&
-          assert(""""P0DT-9223372036854775809S"""".fromJson[Duration])(
-            isLeft(
-              containsString("P0DT-9223372036854775809S is not a valid ISO-8601 format, illegal duration at index 23")
-            )
-          ) &&
-          assert(""""P1DT1H1MXS"""".fromJson[Duration])(
-            isLeft(
-              containsString("P1DT1H1MXS is not a valid ISO-8601 format, expected '\"' or '-' or digit at index 8")
-            )
-          ) &&
-          assert(""""P1DT1H1M-XS"""".fromJson[Duration])(
-            isLeft(containsString("P1DT1H1M-XS is not a valid ISO-8601 format, expected digit at index 9"))
-          ) &&
-          assert(""""P1DT1H1M0XS"""".fromJson[Duration])(
-            isLeft(containsString("P1DT1H1M0XS is not a valid ISO-8601 format, expected 'S or '.' or digit at index 9"))
-          ) &&
-          assert(""""P1DT1H1M0.XS"""".fromJson[Duration])(
-            isLeft(containsString("P1DT1H1M0.XS is not a valid ISO-8601 format, expected 'S' or digit at index 10"))
-          ) &&
-          assert(""""P1DT1H1M0.012345678XS"""".fromJson[Duration])(
-            isLeft(containsString("P1DT1H1M0.012345678XS is not a valid ISO-8601 format, expected 'S' at index 19"))
-          ) &&
-          assert(""""P1DT1H1M0.0123456789S"""".fromJson[Duration])(
-            isLeft(containsString("P1DT1H1M0.0123456789S is not a valid ISO-8601 format, expected 'S' at index 19"))
-          ) &&
+          assert("""""""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""X"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""-"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""-X"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""PXD"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P-"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P-XD"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1XD"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""PT"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""PT0SX"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P106751991167301D"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1067519911673000D"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P-106751991167301D"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DX1H"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DTXH"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT-XH"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT1XH"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT1H1XM"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT2562047788015216H"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT-2562047788015216H"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT153722867280912931M"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT-153722867280912931M"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT9223372036854775808S"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT92233720368547758000S"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT-9223372036854775809S"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT1H1MXS"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT1H1M-XS"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT1H1M0XS"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT1H1M0.XS"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT1H1M0.012345678XS"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P1DT1H1M0.0123456789S"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
           assert(""""P0DT0H0M9223372036854775808S"""".fromJson[Duration])(
-            isLeft(
-              containsString(
-                "P0DT0H0M9223372036854775808S is not a valid ISO-8601 format, illegal duration at index 27"
-              )
-            )
+            isLeft(containsString("expected a Duration"))
           ) &&
           assert(""""P0DT0H0M92233720368547758080S"""".fromJson[Duration])(
-            isLeft(
-              containsString(
-                "P0DT0H0M92233720368547758080S is not a valid ISO-8601 format, illegal duration at index 27"
-              )
-            )
+            isLeft(containsString("expected a Duration"))
           ) &&
           assert(""""P0DT0H0M-9223372036854775809S"""".fromJson[Duration])(
-            isLeft(
-              containsString(
-                "P0DT0H0M-9223372036854775809S is not a valid ISO-8601 format, illegal duration at index 27"
-              )
-            )
+            isLeft(containsString("expected a Duration"))
           ) &&
-          assert(""""P106751991167300DT24H"""".fromJson[Duration])(
-            isLeft(containsString("P106751991167300DT24H is not a valid ISO-8601 format, illegal duration at index 20"))
-          ) &&
-          assert(""""P0DT2562047788015215H60M"""".fromJson[Duration])(
-            isLeft(
-              containsString("P0DT2562047788015215H60M is not a valid ISO-8601 format, illegal duration at index 23")
-            )
-          ) &&
-          assert(""""P0DT0H153722867280912930M60S"""".fromJson[Duration])(
-            isLeft(
-              containsString(
-                "P0DT0H153722867280912930M60S is not a valid ISO-8601 format, illegal duration at index 27"
-              )
-            )
-          )
+          assert(""""P106751991167300DT24H"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT2562047788015215H60M"""".fromJson[Duration])(isLeft(containsString("expected a Duration"))) &&
+          assert(""""P0DT0H153722867280912930M60S"""".fromJson[Duration])(isLeft(containsString("expected a Duration")))
         },
         test("Instant") {
-          assert(stringify("").fromJson[Instant])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal instant at index 0)")
-            )
-          ) &&
-          assert(stringify("2020").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020 is not a valid ISO-8601 format, illegal instant at index 0)")
-            )
-          ) &&
-          assert(stringify("2020-0").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-0 is not a valid ISO-8601 format, illegal instant at index 5)")
-            )
-          ) &&
-          assert(stringify("2020-01-0").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal instant at index 8)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T0").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T0 is not a valid ISO-8601 format, illegal instant at index 11)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:0").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:0 is not a valid ISO-8601 format, illegal instant at index 14)")
-            )
-          ) &&
-          assert(stringify("X020-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(X020-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
-            )
-          ) &&
-          assert(stringify("2X20-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2X20-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("20X0-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(20X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("202X-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(202X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("2020X01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020X01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 4)")
-            )
-          ) &&
-          assert(stringify("2020-X1-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-X1-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
-            )
-          ) &&
-          assert(stringify("2020-0X-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-0X-01T01:01Z is not a valid ISO-8601 format, expected digit at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-01X01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01X01T01:01Z is not a valid ISO-8601 format, expected '-' at index 7)")
-            )
-          ) &&
-          assert(stringify("2020-01-X1T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-X1T01:01Z is not a valid ISO-8601 format, expected digit at index 8)")
-            )
-          ) &&
-          assert(stringify("2020-01-0XT01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-0XT01:01Z is not a valid ISO-8601 format, expected digit at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-01-01X01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01X01:01Z is not a valid ISO-8601 format, expected 'T' at index 10)")
-            )
-          ) &&
-          assert(stringify("2020-01-01TX1:01").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01TX1:01 is not a valid ISO-8601 format, expected digit at index 11)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T0X:01").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T0X:01 is not a valid ISO-8601 format, expected digit at index 12)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T24:01").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T24:01 is not a valid ISO-8601 format, illegal hour at index 12)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01X01").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01X01 is not a valid ISO-8601 format, expected ':' at index 13)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:X1").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:X1 is not a valid ISO-8601 format, expected digit at index 14)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:0X").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:0X is not a valid ISO-8601 format, expected digit at index 15)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:60").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:60 is not a valid ISO-8601 format, illegal minute at index 15)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:01X").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01X is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 16)"
-              )
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:01:0").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:0 is not a valid ISO-8601 format, illegal instant at index 17)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:01:X1Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:X1Z is not a valid ISO-8601 format, expected digit at index 17)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:01:0XZ").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:0XZ is not a valid ISO-8601 format, expected digit at index 18)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:01:60Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:60Z is not a valid ISO-8601 format, illegal second at index 18)")
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:01:012").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 19)"
-              )
-            )
-          ) &&
-          assert(stringify("2020-01-01T01:01:01.X").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01.X is not a valid ISO-8601 format, expected digit or '+' or '-' or 'Z' at index 20)"
-              )
-            )
-          ) &&
+          assert(stringify("").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-0").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-0").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T0").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:0").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("X020-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2X20-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("20X0-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("202X-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020X01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-X1-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-0X-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01X01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-X1T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-0XT01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01X01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01TX1:01").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T0X:01").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T24:01").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01X01").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:X1").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:0X").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:60").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:01X").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:01:0").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:01:X1Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:01:0XZ").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:01:60Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:01:012").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-01T01:01:01.X").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
           assert(stringify("2020-01-01T01:01:01.123456789X").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01.123456789X is not a valid ISO-8601 format, expected '+' or '-' or 'Z' at index 29)"
-              )
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
-          assert(stringify("2020-01-01T01:01:01ZX").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01ZX is not a valid ISO-8601 format, illegal instant at index 20)")
-            )
-          ) &&
+          assert(stringify("2020-01-01T01:01:01ZX").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
           assert(stringify("2020-01-01T01:01:01+X1:01:01").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+X1:01:01 is not a valid ISO-8601 format, expected digit at index 20)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
-          assert(stringify("2020-01-01T01:01:01+0").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+0 is not a valid ISO-8601 format, illegal instant at index 20)")
-            )
-          ) &&
+          assert(stringify("2020-01-01T01:01:01+0").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
           assert(stringify("2020-01-01T01:01:01+0X:01:01").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+0X:01:01 is not a valid ISO-8601 format, expected digit at index 21)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+19:01:01").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+19:01:01 is not a valid ISO-8601 format, illegal timezone offset hour at index 21)"
-              )
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01X01:01").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01X01:01 is not a valid ISO-8601 format, illegal instant at index 23)"
-              )
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:0").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:0 is not a valid ISO-8601 format, illegal instant at index 23)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:X1:01").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:X1:01 is not a valid ISO-8601 format, expected digit at index 23)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:0X:01").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:0X:01 is not a valid ISO-8601 format, expected digit at index 24)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:60:01").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:60:01 is not a valid ISO-8601 format, illegal timezone offset minute at index 24)"
-              )
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01X01").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01X01 is not a valid ISO-8601 format, illegal instant at index 26)"
-              )
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:0").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01:0 is not a valid ISO-8601 format, illegal instant at index 26)"
-              )
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:X1").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:01:X1 is not a valid ISO-8601 format, expected digit at index 26)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:0X").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:01:0X is not a valid ISO-8601 format, expected digit at index 27)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:60").fromJson[Instant])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01:60 is not a valid ISO-8601 format, illegal timezone offset second at index 27)"
-              )
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
-          assert(stringify("+X0000-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+X0000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("+1X000-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+1X000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("+10X00-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+10X00-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("+100X0-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+100X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 4)")
-            )
-          ) &&
-          assert(stringify("+1000X-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+1000X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
-            )
-          ) &&
-          assert(stringify("+10000X-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+10000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 6)")
-            )
-          ) &&
-          assert(stringify("+100000X-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+100000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 7)")
-            )
-          ) &&
+          assert(stringify("+X0000-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("+1X000-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("+10X00-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("+100X0-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("+1000X-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("+10000X-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("+100000X-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
           assert(stringify("+1000000X-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+1000000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 8)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("+1000000001-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+1000000001-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 10)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("+3333333333-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(+3333333333-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 10)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
           assert(stringify("-1000000001-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(-1000000001-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 10)")
-            )
+            isLeft(containsString("expected an Instant"))
           ) &&
-          assert(stringify("-0000-01-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(-0000-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 4)")
-            )
-          ) &&
-          assert(stringify("+10000").fromJson[Instant])(
-            isLeft(
-              equalTo("(+10000 is not a valid ISO-8601 format, illegal instant at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-00-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-00-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-13-01T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-13-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-01-00T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-00T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-01-32T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-01-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-02-30T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-02-30T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-03-32T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-03-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-04-31T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-04-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-05-32T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-05-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-06-31T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-06-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-07-32T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-07-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-08-32T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-08-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-09-31T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-09-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-10-32T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-10-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-11-31T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-11-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-12-32T01:01Z").fromJson[Instant])(
-            isLeft(
-              equalTo("(2020-12-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          )
+          assert(stringify("-0000-01-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("+10000").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-00-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-13-01T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-00T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-01-32T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-02-30T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-03-32T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-04-31T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-05-32T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-06-31T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-07-32T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-08-32T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-09-31T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-10-32T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-11-31T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant"))) &&
+          assert(stringify("2020-12-32T01:01Z").fromJson[Instant])(isLeft(containsString("expected an Instant")))
         },
         test("LocalDate") {
-          assert(stringify("").fromJson[LocalDate])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal local date at index 0)")
-            )
-          ) &&
-          assert(stringify("2020").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020 is not a valid ISO-8601 format, illegal local date at index 0)")
-            )
-          ) &&
-          assert(stringify("2020-0").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-0 is not a valid ISO-8601 format, illegal local date at index 5)")
-            )
-          ) &&
-          assert(stringify("2020-01-0").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal local date at index 8)")
-            )
-          ) &&
-          assert(stringify("2020-01-012").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-01-012 is not a valid ISO-8601 format, illegal local date at index 10)")
-            )
-          ) &&
-          assert(stringify("X020-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(X020-01-01 is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
-            )
-          ) &&
-          assert(stringify("2X20-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2X20-01-01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("20X0-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(20X0-01-01 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("202X-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(202X-01-01 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("2020X01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020X01-01 is not a valid ISO-8601 format, expected '-' at index 4)")
-            )
-          ) &&
-          assert(stringify("2020-X1-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-X1-01 is not a valid ISO-8601 format, expected digit at index 5)")
-            )
-          ) &&
-          assert(stringify("2020-0X-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-0X-01 is not a valid ISO-8601 format, expected digit at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-01X01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-01X01 is not a valid ISO-8601 format, expected '-' at index 7)")
-            )
-          ) &&
-          assert(stringify("2020-01-X1").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-01-X1 is not a valid ISO-8601 format, expected digit at index 8)")
-            )
-          ) &&
-          assert(stringify("2020-01-0X").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-01-0X is not a valid ISO-8601 format, expected digit at index 9)")
-            )
-          ) &&
-          assert(stringify("+X0000-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+X0000-01-01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("+1X000-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+1X000-01-01 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("+10X00-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+10X00-01-01 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("+100X0-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+100X0-01-01 is not a valid ISO-8601 format, expected digit at index 4)")
-            )
-          ) &&
-          assert(stringify("+1000X-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+1000X-01-01 is not a valid ISO-8601 format, expected digit at index 5)")
-            )
-          ) &&
-          assert(stringify("+10000X-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+10000X-01-01 is not a valid ISO-8601 format, expected '-' or digit at index 6)")
-            )
-          ) &&
-          assert(stringify("+100000X-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+100000X-01-01 is not a valid ISO-8601 format, expected '-' or digit at index 7)")
-            )
-          ) &&
-          assert(stringify("+1000000X-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+1000000X-01-01 is not a valid ISO-8601 format, expected '-' or digit at index 8)")
-            )
-          ) &&
-          assert(stringify("+1000000000-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+1000000000-01-01 is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
-          ) &&
-          assert(stringify("-1000000000-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(-1000000000-01-01 is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
-          ) &&
-          assert(stringify("-0000-01-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(-0000-01-01 is not a valid ISO-8601 format, illegal year at index 4)")
-            )
-          ) &&
-          assert(stringify("+10000").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(+10000 is not a valid ISO-8601 format, illegal local date at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-00-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-00-01 is not a valid ISO-8601 format, illegal month at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-13-01").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-13-01 is not a valid ISO-8601 format, illegal month at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-01-00").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-01-00 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-01-32").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-01-32 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-02-30").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-02-30 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-03-32").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-03-32 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-04-31").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-04-31 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-05-32").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-05-32 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-06-31").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-06-31 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-07-32").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-07-32 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-08-32").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-08-32 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-09-31").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-09-31 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-10-32").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-10-32 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-11-31").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-11-31 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          ) &&
-          assert(stringify("2020-12-32").fromJson[LocalDate])(
-            isLeft(
-              equalTo("(2020-12-32 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
-          )
+          assert(stringify("").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-0").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-01-0").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-01-012").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("X020-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2X20-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("20X0-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("202X-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020X01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-X1-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-0X-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-01X01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-01-X1").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-01-0X").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+X0000-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+1X000-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+10X00-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+100X0-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+1000X-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+10000X-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+100000X-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+1000000X-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+1000000000-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("-1000000000-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("-0000-01-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("+10000").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-00-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-13-01").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-01-00").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-01-32").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-02-30").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-03-32").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-04-31").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-05-32").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-06-31").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-07-32").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-08-32").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-09-31").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-10-32").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-11-31").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate"))) &&
+          assert(stringify("2020-12-32").fromJson[LocalDate])(isLeft(containsString("expected a LocalDate")))
         },
         test("LocalDateTime") {
-          assert(stringify("").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal local date time at index 0)")
-            )
-          ) &&
-          assert(stringify("2020").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020 is not a valid ISO-8601 format, illegal local date time at index 0)")
-            )
-          ) &&
-          assert(stringify("2020-0").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-0 is not a valid ISO-8601 format, illegal local date time at index 5)")
-            )
-          ) &&
-          assert(stringify("2020-01-0").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal local date time at index 8)")
-            )
-          ) &&
+          assert(stringify("").fromJson[LocalDateTime])(isLeft(containsString("expected a LocalDateTime"))) &&
+          assert(stringify("2020").fromJson[LocalDateTime])(isLeft(containsString("expected a LocalDateTime"))) &&
+          assert(stringify("2020-0").fromJson[LocalDateTime])(isLeft(containsString("expected a LocalDateTime"))) &&
+          assert(stringify("2020-01-0").fromJson[LocalDateTime])(isLeft(containsString("expected a LocalDateTime"))) &&
           assert(stringify("2020-01-01T0").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T0 is not a valid ISO-8601 format, illegal local date time at index 11)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:0").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:0 is not a valid ISO-8601 format, illegal local date time at index 14)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("X020-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(X020-01-01T01:01 is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2X20-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2X20-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("20X0-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(20X0-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("202X-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(202X-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020X01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020X01-01T01:01 is not a valid ISO-8601 format, expected '-' at index 4)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-X1-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-X1-01T01:01 is not a valid ISO-8601 format, expected digit at index 5)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-0X-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-0X-01T01:01 is not a valid ISO-8601 format, expected digit at index 6)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01X01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01X01T01:01 is not a valid ISO-8601 format, expected '-' at index 7)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-X1T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-X1T01:01 is not a valid ISO-8601 format, expected digit at index 8)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-0XT01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-0XT01:01 is not a valid ISO-8601 format, expected digit at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01X01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01X01:01 is not a valid ISO-8601 format, expected 'T' at index 10)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01TX1:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01TX1:01 is not a valid ISO-8601 format, expected digit at index 11)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T0X:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T0X:01 is not a valid ISO-8601 format, expected digit at index 12)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T24:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T24:01 is not a valid ISO-8601 format, illegal hour at index 12)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01X01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01X01 is not a valid ISO-8601 format, expected ':' at index 13)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:X1").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:X1 is not a valid ISO-8601 format, expected digit at index 14)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:0X").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:0X is not a valid ISO-8601 format, expected digit at index 15)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:60").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:60 is not a valid ISO-8601 format, illegal minute at index 15)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01X").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01X is not a valid ISO-8601 format, expected ':' at index 16)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:0").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:0 is not a valid ISO-8601 format, illegal local date time at index 17)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:X1").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:X1 is not a valid ISO-8601 format, expected digit at index 17)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:0X").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:0X is not a valid ISO-8601 format, expected digit at index 18)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:60").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:60 is not a valid ISO-8601 format, illegal second at index 18)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:012").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected '.' at index 19)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01.X").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01.X is not a valid ISO-8601 format, illegal local date time at index 20)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+X0000-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+X0000-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+1X000-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+1X000-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+10X00-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+10X00-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+100X0-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+100X0-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 4)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+1000X-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+1000X-01-01T01:01 is not a valid ISO-8601 format, expected digit at index 5)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+10000X-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+10000X-01-01T01:01 is not a valid ISO-8601 format, expected '-' or digit at index 6)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+100000X-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+100000X-01-01T01:01 is not a valid ISO-8601 format, expected '-' or digit at index 7)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+1000000X-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+1000000X-01-01T01:01 is not a valid ISO-8601 format, expected '-' or digit at index 8)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("+1000000000-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+1000000000-01-01T01:01 is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("-1000000000-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(-1000000000-01-01T01:01 is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("-0000-01-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(-0000-01-01T01:01 is not a valid ISO-8601 format, illegal year at index 4)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
-          assert(stringify("+10000").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(+10000 is not a valid ISO-8601 format, illegal local date time at index 6)")
-            )
-          ) &&
+          assert(stringify("+10000").fromJson[LocalDateTime])(isLeft(containsString("expected a LocalDateTime"))) &&
           assert(stringify("2020-00-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-00-01T01:01 is not a valid ISO-8601 format, illegal month at index 6)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-13-01T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-13-01T01:01 is not a valid ISO-8601 format, illegal month at index 6)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-00T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-00T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-01-32T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-01-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-02-30T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-02-30T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-03-32T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-03-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-04-31T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-04-31T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-05-32T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-05-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-06-31T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-06-31T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-07-32T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-07-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-08-32T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-08-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-09-31T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-09-31T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-10-32T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-10-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-11-31T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-11-31T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           ) &&
           assert(stringify("2020-12-32T01:01").fromJson[LocalDateTime])(
-            isLeft(
-              equalTo("(2020-12-32T01:01 is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a LocalDateTime"))
           )
         },
         test("LocalTime") {
-          assert(stringify("").fromJson[LocalTime])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal local time at index 0)")
-            )
-          ) &&
-          assert(stringify("0").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(0 is not a valid ISO-8601 format, illegal local time at index 0)")
-            )
-          ) &&
-          assert(stringify("01:0").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:0 is not a valid ISO-8601 format, illegal local time at index 3)")
-            )
-          ) &&
-          assert(stringify("X1:01").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(X1:01 is not a valid ISO-8601 format, expected digit at index 0)")
-            )
-          ) &&
-          assert(stringify("0X:01").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(0X:01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("24:01").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(24:01 is not a valid ISO-8601 format, illegal hour at index 1)")
-            )
-          ) &&
-          assert(stringify("01X01").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01X01 is not a valid ISO-8601 format, expected ':' at index 2)")
-            )
-          ) &&
-          assert(stringify("01:X1").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:X1 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("01:0X").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:0X is not a valid ISO-8601 format, expected digit at index 4)")
-            )
-          ) &&
-          assert(stringify("01:60").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:60 is not a valid ISO-8601 format, illegal minute at index 4)")
-            )
-          ) &&
-          assert(stringify("01:01X").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:01X is not a valid ISO-8601 format, expected ':' at index 5)")
-            )
-          ) &&
-          assert(stringify("01:01:0").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:01:0 is not a valid ISO-8601 format, illegal local time at index 6)")
-            )
-          ) &&
-          assert(stringify("01:01:X1").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:01:X1 is not a valid ISO-8601 format, expected digit at index 6)")
-            )
-          ) &&
-          assert(stringify("01:01:0X").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:01:0X is not a valid ISO-8601 format, expected digit at index 7)")
-            )
-          ) &&
-          assert(stringify("01:01:60").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:01:60 is not a valid ISO-8601 format, illegal second at index 7)")
-            )
-          ) &&
-          assert(stringify("01:01:012").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:01:012 is not a valid ISO-8601 format, expected '.' at index 8)")
-            )
-          ) &&
-          assert(stringify("01:01:01.X").fromJson[LocalTime])(
-            isLeft(
-              equalTo("(01:01:01.X is not a valid ISO-8601 format, illegal local time at index 9)")
-            )
-          )
-        },
-        test("Month") {
-          assert(stringify("FebTober").fromJson[Month])(
-            isLeft(equalTo("(FebTober is not a valid ISO-8601 format)"))
-          )
+          assert(stringify("").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("0").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:0").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("X1:01").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("0X:01").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("24:01").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01X01").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:X1").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:0X").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:60").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:01X").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:01:0").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:01:X1").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:01:0X").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:01:60").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:01:012").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime"))) &&
+          assert(stringify("01:01:01.X").fromJson[LocalTime])(isLeft(containsString("expected a LocalTime")))
         },
         test("MonthDay") {
-          assert(stringify("").fromJson[MonthDay])(
-            isLeft(equalTo("( is not a valid ISO-8601 format, illegal month day at index 0)"))
-          ) &&
-          assert(stringify("X-01-01").fromJson[MonthDay])(
-            isLeft(equalTo("(X-01-01 is not a valid ISO-8601 format, expected '-' at index 0)"))
-          ) &&
-          assert(stringify("-X01-01").fromJson[MonthDay])(
-            isLeft(equalTo("(-X01-01 is not a valid ISO-8601 format, expected '-' at index 1)"))
-          ) &&
-          assert(stringify("--X1-01").fromJson[MonthDay])(
-            isLeft(equalTo("(--X1-01 is not a valid ISO-8601 format, expected digit at index 2)"))
-          ) &&
-          assert(stringify("--0X-01").fromJson[MonthDay])(
-            isLeft(equalTo("(--0X-01 is not a valid ISO-8601 format, expected digit at index 3)"))
-          ) &&
-          assert(stringify("--00-01").fromJson[MonthDay])(
-            isLeft(equalTo("(--00-01 is not a valid ISO-8601 format, illegal month at index 3)"))
-          ) &&
-          assert(stringify("--13-01").fromJson[MonthDay])(
-            isLeft(equalTo("(--13-01 is not a valid ISO-8601 format, illegal month at index 3)"))
-          ) &&
-          assert(stringify("--01X01").fromJson[MonthDay])(
-            isLeft(equalTo("(--01X01 is not a valid ISO-8601 format, expected '-' at index 4)"))
-          ) &&
-          assert(stringify("--01-X1").fromJson[MonthDay])(
-            isLeft(equalTo("(--01-X1 is not a valid ISO-8601 format, expected digit at index 5)"))
-          ) &&
-          assert(stringify("--01-0X").fromJson[MonthDay])(
-            isLeft(equalTo("(--01-0X is not a valid ISO-8601 format, expected digit at index 6)"))
-          ) &&
-          assert(stringify("--01-00").fromJson[MonthDay])(
-            isLeft(equalTo("(--01-00 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--01-32").fromJson[MonthDay])(
-            isLeft(equalTo("(--01-32 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--02-30").fromJson[MonthDay])(
-            isLeft(equalTo("(--02-30 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--03-32").fromJson[MonthDay])(
-            isLeft(equalTo("(--03-32 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--04-31").fromJson[MonthDay])(
-            isLeft(equalTo("(--04-31 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--05-32").fromJson[MonthDay])(
-            isLeft(equalTo("(--05-32 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--06-31").fromJson[MonthDay])(
-            isLeft(equalTo("(--06-31 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--07-32").fromJson[MonthDay])(
-            isLeft(equalTo("(--07-32 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--08-32").fromJson[MonthDay])(
-            isLeft(equalTo("(--08-32 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--09-31").fromJson[MonthDay])(
-            isLeft(equalTo("(--09-31 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--10-32").fromJson[MonthDay])(
-            isLeft(equalTo("(--10-32 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--11-31").fromJson[MonthDay])(
-            isLeft(equalTo("(--11-31 is not a valid ISO-8601 format, illegal day at index 6)"))
-          ) &&
-          assert(stringify("--12-32").fromJson[MonthDay])(
-            isLeft(equalTo("(--12-32 is not a valid ISO-8601 format, illegal day at index 6)"))
-          )
+          assert(stringify("").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("X-01-01").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("-X01-01").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--X1-01").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--0X-01").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--00-01").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--13-01").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--01X01").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--01-X1").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--01-0X").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--01-00").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--01-32").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--02-30").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--03-32").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--04-31").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--05-32").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--06-31").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--07-32").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--08-32").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--09-31").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--10-32").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--11-31").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay"))) &&
+          assert(stringify("--12-32").fromJson[MonthDay])(isLeft(containsString("expected a MonthDay")))
         },
         test("OffsetDateTime") {
-          assert(stringify("").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal offset date time at index 0)")
-            )
-          ) &&
-          assert(stringify("2020").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020 is not a valid ISO-8601 format, illegal offset date time at index 0)")
-            )
-          ) &&
-          assert(stringify("2020-0").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-0 is not a valid ISO-8601 format, illegal offset date time at index 5)")
-            )
-          ) &&
+          assert(stringify("").fromJson[OffsetDateTime])(isLeft(containsString("expected an OffsetDateTime"))) &&
+          assert(stringify("2020").fromJson[OffsetDateTime])(isLeft(containsString("expected an OffsetDateTime"))) &&
+          assert(stringify("2020-0").fromJson[OffsetDateTime])(isLeft(containsString("expected an OffsetDateTime"))) &&
           assert(stringify("2020-01-0").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal offset date time at index 8)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T0").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T0 is not a valid ISO-8601 format, illegal offset date time at index 11)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:0").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:0 is not a valid ISO-8601 format, illegal offset date time at index 14)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("X020-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(X020-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2X20-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2X20-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("20X0-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(20X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("202X-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(202X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020X01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020X01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 4)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-X1-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-X1-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-0X-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-0X-01T01:01Z is not a valid ISO-8601 format, expected digit at index 6)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01X01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01X01T01:01Z is not a valid ISO-8601 format, expected '-' at index 7)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-X1T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-X1T01:01Z is not a valid ISO-8601 format, expected digit at index 8)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-0XT01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-0XT01:01Z is not a valid ISO-8601 format, expected digit at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01X01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01X01:01Z is not a valid ISO-8601 format, expected 'T' at index 10)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01TX1:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01TX1:01 is not a valid ISO-8601 format, expected digit at index 11)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T0X:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T0X:01 is not a valid ISO-8601 format, expected digit at index 12)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T24:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T24:01 is not a valid ISO-8601 format, illegal hour at index 12)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
+          ) &&
+          assert(stringify("2020-01-01T01X").fromJson[OffsetDateTime])(
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01X01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01X01 is not a valid ISO-8601 format, expected ':' at index 13)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:X1").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:X1 is not a valid ISO-8601 format, expected digit at index 14)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:0X").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:0X is not a valid ISO-8601 format, expected digit at index 15)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:60").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:60 is not a valid ISO-8601 format, illegal minute at index 15)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01 is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 16)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01X").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01X is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 16)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:0").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:0 is not a valid ISO-8601 format, illegal offset date time at index 17)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:X1Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:X1Z is not a valid ISO-8601 format, expected digit at index 17)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:0XZ").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:0XZ is not a valid ISO-8601 format, expected digit at index 18)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:60Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:60Z is not a valid ISO-8601 format, illegal second at index 18)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 19)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:012").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 19)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01.").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01. is not a valid ISO-8601 format, expected digit or '+' or '-' or 'Z' at index 20)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01.X").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01.X is not a valid ISO-8601 format, expected digit or '+' or '-' or 'Z' at index 20)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01.123456789X").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01.123456789X is not a valid ISO-8601 format, expected '+' or '-' or 'Z' at index 29)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01ZX").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01ZX is not a valid ISO-8601 format, illegal offset date time at index 20)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+X1:01:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+X1:01:01 is not a valid ISO-8601 format, expected digit at index 20)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+0").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+0 is not a valid ISO-8601 format, illegal offset date time at index 20)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+0X:01:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+0X:01:01 is not a valid ISO-8601 format, expected digit at index 21)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+19:01:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+19:01:01 is not a valid ISO-8601 format, illegal timezone offset hour at index 21)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01X01:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01X01:01 is not a valid ISO-8601 format, illegal offset date time at index 23)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:0").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:0 is not a valid ISO-8601 format, illegal offset date time at index 23)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:X1:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:X1:01 is not a valid ISO-8601 format, expected digit at index 23)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:0X:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:0X:01 is not a valid ISO-8601 format, expected digit at index 24)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:60:01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:60:01 is not a valid ISO-8601 format, illegal timezone offset minute at index 24)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01X01").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01X01 is not a valid ISO-8601 format, illegal offset date time at index 26)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:0").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01:0 is not a valid ISO-8601 format, illegal offset date time at index 26)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:X1").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:01:X1 is not a valid ISO-8601 format, expected digit at index 26)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:0X").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:01:0X is not a valid ISO-8601 format, expected digit at index 27)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:60").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01:60 is not a valid ISO-8601 format, illegal timezone offset second at index 27)"
-              )
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+X0000-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+X0000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+1X000-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+1X000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+10X00-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+10X00-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+100X0-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+100X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 4)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+1000X-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+1000X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+10000X-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+10000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 6)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+100000X-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+100000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 7)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+1000000X-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+1000000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 8)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("+1000000000-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+1000000000-01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("-1000000000-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(-1000000000-01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("-0000-01-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(-0000-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 4)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
-          assert(stringify("+10000").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(+10000 is not a valid ISO-8601 format, illegal offset date time at index 6)")
-            )
-          ) &&
+          assert(stringify("+10000").fromJson[OffsetDateTime])(isLeft(containsString("expected an OffsetDateTime"))) &&
           assert(stringify("2020-00-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-00-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-13-01T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-13-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-00T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-00T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-01-32T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-01-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-02-30T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-02-30T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-03-32T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-03-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-04-31T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-04-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-05-32T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-05-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-06-31T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-06-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-07-32T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-07-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-08-32T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-08-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-09-31T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-09-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-10-32T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-10-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-11-31T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-11-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           ) &&
           assert(stringify("2020-12-32T01:01Z").fromJson[OffsetDateTime])(
-            isLeft(
-              equalTo("(2020-12-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected an OffsetDateTime"))
           )
         },
         test("OffsetTime") {
-          assert(stringify("").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal offset time at index 0)")
-            )
-          ) &&
-          assert(stringify("0").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(0 is not a valid ISO-8601 format, illegal offset time at index 0)")
-            )
-          ) &&
-          assert(stringify("01:0").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:0 is not a valid ISO-8601 format, illegal offset time at index 3)")
-            )
-          ) &&
-          assert(stringify("X1:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(X1:01 is not a valid ISO-8601 format, expected digit at index 0)")
-            )
-          ) &&
-          assert(stringify("0X:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(0X:01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("24:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(24:01 is not a valid ISO-8601 format, illegal hour at index 1)")
-            )
-          ) &&
-          assert(stringify("01X01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01X01 is not a valid ISO-8601 format, expected ':' at index 2)")
-            )
-          ) &&
-          assert(stringify("01:X1").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:X1 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("01:0X").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:0X is not a valid ISO-8601 format, expected digit at index 4)")
-            )
-          ) &&
-          assert(stringify("01:60").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:60 is not a valid ISO-8601 format, illegal minute at index 4)")
-            )
-          ) &&
-          assert(stringify("01:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo(
-                "(01:01 is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 5)"
-              )
-            )
-          ) &&
-          assert(stringify("01:01X").fromJson[OffsetTime])(
-            isLeft(
-              equalTo(
-                "(01:01X is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 5)"
-              )
-            )
-          ) &&
-          assert(stringify("01:01:0").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:0 is not a valid ISO-8601 format, illegal offset time at index 6)")
-            )
-          ) &&
-          assert(stringify("01:01:X1Z").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:X1Z is not a valid ISO-8601 format, expected digit at index 6)")
-            )
-          ) &&
-          assert(stringify("01:01:0XZ").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:0XZ is not a valid ISO-8601 format, expected digit at index 7)")
-            )
-          ) &&
-          assert(stringify("01:01:60Z").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:60Z is not a valid ISO-8601 format, illegal second at index 7)")
-            )
-          ) &&
-          assert(stringify("01:01:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo(
-                "(01:01:01 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 8)"
-              )
-            )
-          ) &&
-          assert(stringify("01:01:012").fromJson[OffsetTime])(
-            isLeft(
-              equalTo(
-                "(01:01:012 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 8)"
-              )
-            )
-          ) &&
-          assert(stringify("01:01:01.").fromJson[OffsetTime])(
-            isLeft(
-              equalTo(
-                "(01:01:01. is not a valid ISO-8601 format, expected digit or '+' or '-' or 'Z' at index 9)"
-              )
-            )
-          ) &&
-          assert(stringify("01:01:01.X").fromJson[OffsetTime])(
-            isLeft(
-              equalTo(
-                "(01:01:01.X is not a valid ISO-8601 format, expected digit or '+' or '-' or 'Z' at index 9)"
-              )
-            )
-          ) &&
+          assert(stringify("").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("0").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:0").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("X1:01").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("0X:01").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("24:01").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01X01").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:X1").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:0X").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:60").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01X").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:0").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:X1Z").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:0XZ").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:60Z").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:01").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:012").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:01.").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:01.X").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
           assert(stringify("01:01:01.123456789X").fromJson[OffsetTime])(
-            isLeft(
-              equalTo(
-                "(01:01:01.123456789X is not a valid ISO-8601 format, expected '+' or '-' or 'Z' at index 18)"
-              )
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
-          assert(stringify("01:01:01ZX").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01ZX is not a valid ISO-8601 format, illegal offset time at index 9)")
-            )
-          ) &&
+          assert(stringify("01:01:01ZX").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
           assert(stringify("01:01:01+X1:01:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+X1:01:01 is not a valid ISO-8601 format, expected digit at index 9)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
-          assert(stringify("01:01:01+0").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+0 is not a valid ISO-8601 format, illegal offset time at index 9)")
-            )
-          ) &&
+          assert(stringify("01:01:01+0").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
           assert(stringify("01:01:01+0X:01:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+0X:01:01 is not a valid ISO-8601 format, expected digit at index 10)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
           assert(stringify("01:01:01+19:01:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+19:01:01 is not a valid ISO-8601 format, illegal timezone offset hour at index 10)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
           assert(stringify("01:01:01+01X01:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01X01:01 is not a valid ISO-8601 format, illegal offset time at index 12)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
-          assert(stringify("01:01:01+01:0").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:0 is not a valid ISO-8601 format, illegal offset time at index 12)")
-            )
-          ) &&
+          assert(stringify("01:01:01+01X").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
+          assert(stringify("01:01:01+01:0").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
           assert(stringify("01:01:01+01:X1:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:X1:01 is not a valid ISO-8601 format, expected digit at index 12)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
           assert(stringify("01:01:01+01:0X:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:0X:01 is not a valid ISO-8601 format, expected digit at index 13)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
           assert(stringify("01:01:01+01:60:01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:60:01 is not a valid ISO-8601 format, illegal timezone offset minute at index 13)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
+          assert(stringify("01:01:01+01:01X").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime"))) &&
           assert(stringify("01:01:01+01:01X01").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:01X01 is not a valid ISO-8601 format, illegal offset time at index 15)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
           assert(stringify("01:01:01+01:01:0").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:01:0 is not a valid ISO-8601 format, illegal offset time at index 15)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
           assert(stringify("01:01:01+01:01:X1").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:01:X1 is not a valid ISO-8601 format, expected digit at index 15)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
           assert(stringify("01:01:01+01:01:0X").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:01:0X is not a valid ISO-8601 format, expected digit at index 16)")
-            )
+            isLeft(containsString("expected an OffsetTime"))
           ) &&
-          assert(stringify("01:01:01+01:01:60").fromJson[OffsetTime])(
-            isLeft(
-              equalTo("(01:01:01+01:01:60 is not a valid ISO-8601 format, illegal timezone offset second at index 16)")
-            )
-          )
+          assert(stringify("01:01:01+01:01:60").fromJson[OffsetTime])(isLeft(containsString("expected an OffsetTime")))
         },
         test("Period") {
-          assert(stringify("").fromJson[Period])(
-            isLeft(equalTo("( is not a valid ISO-8601 format, illegal period at index 0)"))
-          ) &&
-          assert(stringify("X").fromJson[Period])(
-            isLeft(equalTo("(X is not a valid ISO-8601 format, expected 'P' or '-' at index 0)"))
-          ) &&
-          assert(stringify("P").fromJson[Period])(
-            isLeft(equalTo("(P is not a valid ISO-8601 format, illegal period at index 1)"))
-          ) &&
-          assert(stringify("-").fromJson[Period])(
-            isLeft(equalTo("(- is not a valid ISO-8601 format, illegal period at index 1)"))
-          ) &&
-          assert(stringify("PXY").fromJson[Period])(
-            isLeft(equalTo("(PXY is not a valid ISO-8601 format, expected '-' or digit at index 1)"))
-          ) &&
-          assert(stringify("P-").fromJson[Period])(
-            isLeft(equalTo("(P- is not a valid ISO-8601 format, illegal period at index 2)"))
-          ) &&
-          assert(stringify("P-XY").fromJson[Period])(
-            isLeft(equalTo("(P-XY is not a valid ISO-8601 format, expected digit at index 2)"))
-          ) &&
-          assert(stringify("P1XY").fromJson[Period])(
-            isLeft(
-              equalTo("(P1XY is not a valid ISO-8601 format, expected 'Y' or 'M' or 'W' or 'D' or digit at index 2)")
-            )
-          ) &&
-          assert(stringify("P2147483648Y").fromJson[Period])(
-            isLeft(equalTo("(P2147483648Y is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P21474836470Y").fromJson[Period])(
-            isLeft(equalTo("(P21474836470Y is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P-2147483649Y").fromJson[Period])(
-            isLeft(equalTo("(P-2147483649Y is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P2147483648M").fromJson[Period])(
-            isLeft(equalTo("(P2147483648M is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P21474836470M").fromJson[Period])(
-            isLeft(equalTo("(P21474836470M is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P-2147483649M").fromJson[Period])(
-            isLeft(equalTo("(P-2147483649M is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P2147483648W").fromJson[Period])(
-            isLeft(equalTo("(P2147483648W is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P21474836470W").fromJson[Period])(
-            isLeft(equalTo("(P21474836470W is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P-2147483649W").fromJson[Period])(
-            isLeft(equalTo("(P-2147483649W is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P2147483648D").fromJson[Period])(
-            isLeft(equalTo("(P2147483648D is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P21474836470D").fromJson[Period])(
-            isLeft(equalTo("(P21474836470D is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P-2147483649D").fromJson[Period])(
-            isLeft(equalTo("(P-2147483649D is not a valid ISO-8601 format, illegal period at index 11)"))
-          ) &&
-          assert(stringify("P1YXM").fromJson[Period])(
-            isLeft(equalTo("(P1YXM is not a valid ISO-8601 format, expected '-' or digit at index 3)"))
-          ) &&
-          assert(stringify("P1Y-XM").fromJson[Period])(
-            isLeft(equalTo("(P1Y-XM is not a valid ISO-8601 format, expected digit at index 4)"))
-          ) &&
-          assert(stringify("P1Y1XM").fromJson[Period])(
-            isLeft(equalTo("(P1Y1XM is not a valid ISO-8601 format, expected 'M' or 'W' or 'D' or digit at index 4)"))
-          ) &&
-          assert(stringify("P1Y2147483648M").fromJson[Period])(
-            isLeft(equalTo("(P1Y2147483648M is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y21474836470M").fromJson[Period])(
-            isLeft(equalTo("(P1Y21474836470M is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y-2147483649M").fromJson[Period])(
-            isLeft(equalTo("(P1Y-2147483649M is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y2147483648W").fromJson[Period])(
-            isLeft(equalTo("(P1Y2147483648W is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y21474836470W").fromJson[Period])(
-            isLeft(equalTo("(P1Y21474836470W is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y-2147483649W").fromJson[Period])(
-            isLeft(equalTo("(P1Y-2147483649W is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y2147483648D").fromJson[Period])(
-            isLeft(equalTo("(P1Y2147483648D is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y21474836470D").fromJson[Period])(
-            isLeft(equalTo("(P1Y21474836470D is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y-2147483649D").fromJson[Period])(
-            isLeft(equalTo("(P1Y-2147483649D is not a valid ISO-8601 format, illegal period at index 13)"))
-          ) &&
-          assert(stringify("P1Y1MXW").fromJson[Period])(
-            isLeft(equalTo("(P1Y1MXW is not a valid ISO-8601 format, expected '\"' or '-' or digit at index 5)"))
-          ) &&
-          assert(stringify("P1Y1M-XW").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M-XW is not a valid ISO-8601 format, expected digit at index 6)"))
-          ) &&
-          assert(stringify("P1Y1M1XW").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M1XW is not a valid ISO-8601 format, expected 'W' or 'D' or digit at index 6)"))
-          ) &&
-          assert(stringify("P1Y1M306783379W").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M306783379W is not a valid ISO-8601 format, illegal period at index 14)"))
-          ) &&
-          assert(stringify("P1Y1M3067833790W").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M3067833790W is not a valid ISO-8601 format, illegal period at index 14)"))
-          ) &&
-          assert(stringify("P1Y1M-306783379W").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M-306783379W is not a valid ISO-8601 format, illegal period at index 15)"))
-          ) &&
-          assert(stringify("P1Y1M2147483648D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M2147483648D is not a valid ISO-8601 format, illegal period at index 15)"))
-          ) &&
-          assert(stringify("P1Y1M21474836470D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M21474836470D is not a valid ISO-8601 format, illegal period at index 15)"))
-          ) &&
-          assert(stringify("P1Y1M-2147483649D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M-2147483649D is not a valid ISO-8601 format, illegal period at index 15)"))
-          ) &&
-          assert(stringify("P1Y1M1WXD").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M1WXD is not a valid ISO-8601 format, expected '\"' or '-' or digit at index 7)"))
-          ) &&
-          assert(stringify("P1Y1M1W-XD").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M1W-XD is not a valid ISO-8601 format, expected digit at index 8)"))
-          ) &&
-          assert(stringify("P1Y1M1W1XD").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M1W1XD is not a valid ISO-8601 format, expected 'D' or digit at index 8)"))
-          ) &&
-          assert(stringify("P1Y1M306783378W8D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M306783378W8D is not a valid ISO-8601 format, illegal period at index 16)"))
-          ) &&
-          assert(stringify("P1Y1M-306783378W-8D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M-306783378W-8D is not a valid ISO-8601 format, illegal period at index 18)"))
-          ) &&
-          assert(stringify("P1Y1M1W2147483647D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M1W2147483647D is not a valid ISO-8601 format, illegal period at index 17)"))
-          ) &&
-          assert(stringify("P1Y1M-1W-2147483648D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M-1W-2147483648D is not a valid ISO-8601 format, illegal period at index 19)"))
-          ) &&
-          assert(stringify("P1Y1M0W2147483648D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M0W2147483648D is not a valid ISO-8601 format, illegal period at index 17)"))
-          ) &&
-          assert(stringify("P1Y1M0W21474836470D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M0W21474836470D is not a valid ISO-8601 format, illegal period at index 17)"))
-          ) &&
-          assert(stringify("P1Y1M0W-2147483649D").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M0W-2147483649D is not a valid ISO-8601 format, illegal period at index 17)"))
-          ) &&
-          assert(stringify("P1Y1M1W1DX").fromJson[Period])(
-            isLeft(equalTo("(P1Y1M1W1DX is not a valid ISO-8601 format, illegal period at index 9)"))
-          )
+          assert(stringify("").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("X").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("-").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("PXY").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P-").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P-XY").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1XY").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P2147483648Y").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P21474836470Y").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P-2147483649Y").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P2147483648M").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P21474836470M").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P-2147483649M").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P2147483648W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P21474836470W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P-2147483649W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P2147483648D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P21474836470D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P-2147483649D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1YXM").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y-XM").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1XM").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y2147483648M").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y21474836470M").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y-2147483649M").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y2147483648W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y21474836470W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y-2147483649W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y2147483648D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y21474836470D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y-2147483649D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1MXW").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M-XW").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M1XW").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M306783379W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M3067833790W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M-306783379W").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M2147483648D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M21474836470D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M-2147483649D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M1WXD").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M1W-XD").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M1W1XD").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M306783378W8D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M-306783378W-8D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M1W2147483647D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M-1W-2147483648D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M0W2147483648D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M0W21474836470D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M0W-2147483649D").fromJson[Period])(isLeft(containsString("expected a Period"))) &&
+          assert(stringify("P1Y1M1W1DX").fromJson[Period])(isLeft(containsString("expected a Period")))
         },
         test("Year") {
-          assert(stringify("").fromJson[Year])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal year at index 0)")
-            )
-          ) &&
-          assert(stringify("2").fromJson[Year])(
-            isLeft(
-              equalTo("(2 is not a valid ISO-8601 format, illegal year at index 0)")
-            )
-          ) &&
-          assert(stringify("22").fromJson[Year])(
-            isLeft(
-              equalTo("(22 is not a valid ISO-8601 format, illegal year at index 0)")
-            )
-          ) &&
-          assert(stringify("222").fromJson[Year])(
-            isLeft(
-              equalTo("(222 is not a valid ISO-8601 format, illegal year at index 0)")
-            )
-          ) &&
-          assert(stringify("X020").fromJson[Year])(
-            isLeft(
-              equalTo("(X020 is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
-            )
-          ) &&
-          assert(stringify("2X20").fromJson[Year])(
-            isLeft(
-              equalTo("(2X20 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("20X0").fromJson[Year])(
-            isLeft(
-              equalTo("(20X0 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("202X").fromJson[Year])(
-            isLeft(
-              equalTo("(202X is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("+X0000").fromJson[Year])(
-            isLeft(
-              equalTo("(+X0000 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("+1X000").fromJson[Year])(
-            isLeft(
-              equalTo("(+1X000 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("+10X00").fromJson[Year])(
-            isLeft(
-              equalTo("(+10X00 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("+100X0").fromJson[Year])(
-            isLeft(
-              equalTo("(+100X0 is not a valid ISO-8601 format, expected digit at index 4)")
-            )
-          ) &&
-          assert(stringify("+1000X").fromJson[Year])(
-            isLeft(
-              equalTo("(+1000X is not a valid ISO-8601 format, expected digit at index 5)")
-            )
-          ) &&
-          assert(stringify("+10000X").fromJson[Year])(
-            isLeft(
-              equalTo("(+10000X is not a valid ISO-8601 format, expected digit at index 6)")
-            )
-          ) &&
-          assert(stringify("+100000X").fromJson[Year])(
-            isLeft(
-              equalTo("(+100000X is not a valid ISO-8601 format, expected digit at index 7)")
-            )
-          ) &&
-          assert(stringify("+1000000X").fromJson[Year])(
-            isLeft(
-              equalTo("(+1000000X is not a valid ISO-8601 format, expected digit at index 8)")
-            )
-          ) &&
-          assert(stringify("+1000000000").fromJson[Year])(
-            isLeft(
-              equalTo("(+1000000000 is not a valid ISO-8601 format, illegal year at index 10)")
-            )
-          ) &&
-          assert(stringify("-1000000000").fromJson[Year])(
-            isLeft(
-              equalTo("(-1000000000 is not a valid ISO-8601 format, illegal year at index 10)")
-            )
-          ) &&
-          assert(stringify("-0000").fromJson[Year])(
-            isLeft(
-              equalTo("(-0000 is not a valid ISO-8601 format, illegal year at index 4)")
-            )
-          ) &&
-          assert(stringify("10000").fromJson[Year])(
-            isLeft(
-              equalTo("(10000 is not a valid ISO-8601 format, illegal year at index 4)")
-            )
-          )
+          assert(stringify("").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("2").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("22").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("222").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("X020").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("2X20").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("20X0").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("202X").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+X0000").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+1X000").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+10X00").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+100X0").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+1000X").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+10000X").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+100000X").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+1000000X").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("+1000000000").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("-1000000000").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("-0000").fromJson[Year])(isLeft(containsString("expected a Year"))) &&
+          assert(stringify("10000").fromJson[Year])(isLeft(containsString("expected a Year")))
         },
         test("YearMonth") {
-          assert(stringify("").fromJson[YearMonth])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal year month at index 0)")
-            )
-          ) &&
-          assert(stringify("2020").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2020 is not a valid ISO-8601 format, illegal year month at index 0)")
-            )
-          ) &&
-          assert(stringify("2020-0").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2020-0 is not a valid ISO-8601 format, illegal year month at index 5)")
-            )
-          ) &&
-          assert(stringify("2020-012").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2020-012 is not a valid ISO-8601 format, illegal year month at index 7)")
-            )
-          ) &&
-          assert(stringify("X020-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(X020-01 is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
-            )
-          ) &&
-          assert(stringify("2X20-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2X20-01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("20X0-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(20X0-01 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("202X-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(202X-01 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("2020X01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2020X01 is not a valid ISO-8601 format, expected '-' at index 4)")
-            )
-          ) &&
-          assert(stringify("2020-X1").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2020-X1 is not a valid ISO-8601 format, expected digit at index 5)")
-            )
-          ) &&
-          assert(stringify("2020-0X").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2020-0X is not a valid ISO-8601 format, expected digit at index 6)")
-            )
-          ) &&
-          assert(stringify("+X0000-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+X0000-01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("+1X000-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+1X000-01 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("+10X00-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+10X00-01 is not a valid ISO-8601 format, expected digit at index 3)")
-            )
-          ) &&
-          assert(stringify("+100X0-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+100X0-01 is not a valid ISO-8601 format, expected digit at index 4)")
-            )
-          ) &&
-          assert(stringify("+1000X-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+1000X-01 is not a valid ISO-8601 format, expected digit at index 5)")
-            )
-          ) &&
-          assert(stringify("+10000X-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+10000X-01 is not a valid ISO-8601 format, expected '-' or digit at index 6)")
-            )
-          ) &&
-          assert(stringify("+100000X-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+100000X-01 is not a valid ISO-8601 format, expected '-' or digit at index 7)")
-            )
-          ) &&
-          assert(stringify("+1000000X-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+1000000X-01 is not a valid ISO-8601 format, expected '-' or digit at index 8)")
-            )
-          ) &&
-          assert(stringify("+1000000000-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+1000000000-01 is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
-          ) &&
-          assert(stringify("-1000000000-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(-1000000000-01 is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
-          ) &&
-          assert(stringify("-0000-01").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(-0000-01 is not a valid ISO-8601 format, illegal year at index 4)")
-            )
-          ) &&
-          assert(stringify("+10000").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(+10000 is not a valid ISO-8601 format, illegal year month at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-00").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2020-00 is not a valid ISO-8601 format, illegal month at index 6)")
-            )
-          ) &&
-          assert(stringify("2020-13").fromJson[YearMonth])(
-            isLeft(
-              equalTo("(2020-13 is not a valid ISO-8601 format, illegal month at index 6)")
-            )
-          )
+          assert(stringify("").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2020").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2020-0").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2020-012").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("X020-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2X20-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("20X0-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("202X-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2020X01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2020-X1").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2020-0X").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+X0000-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+1X000-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+10X00-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+100X0-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+1000X-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+10000X-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+100000X-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+1000000X-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+1000000000-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("-1000000000-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("-0000-01").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("+10000").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2020-00").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth"))) &&
+          assert(stringify("2020-13").fromJson[YearMonth])(isLeft(containsString("expected a YearMonth")))
         },
         test("ZonedDateTime") {
-          assert(stringify("").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal zoned date time at index 0)")
-            )
-          ) &&
-          assert(stringify("2020").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020 is not a valid ISO-8601 format, illegal zoned date time at index 0)")
-            )
-          ) &&
-          assert(stringify("2020-0").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-0 is not a valid ISO-8601 format, illegal zoned date time at index 5)")
-            )
-          ) &&
-          assert(stringify("2020-01-0").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-0 is not a valid ISO-8601 format, illegal zoned date time at index 8)")
-            )
-          ) &&
+          assert(stringify("").fromJson[ZonedDateTime])(isLeft(containsString("expected a ZonedDateTime"))) &&
+          assert(stringify("2020").fromJson[ZonedDateTime])(isLeft(containsString("expected a ZonedDateTime"))) &&
+          assert(stringify("2020-0").fromJson[ZonedDateTime])(isLeft(containsString("expected a ZonedDateTime"))) &&
+          assert(stringify("2020-01-0").fromJson[ZonedDateTime])(isLeft(containsString("expected a ZonedDateTime"))) &&
           assert(stringify("2020-01-01T0").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T0 is not a valid ISO-8601 format, illegal zoned date time at index 11)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:0").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:0 is not a valid ISO-8601 format, illegal zoned date time at index 14)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("X020-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(X020-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or '+' or digit at index 0)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2X20-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2X20-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("20X0-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(20X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("202X-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(202X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020X01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020X01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 4)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-X1-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-X1-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-0X-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-0X-01T01:01Z is not a valid ISO-8601 format, expected digit at index 6)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01X01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01X01T01:01Z is not a valid ISO-8601 format, expected '-' at index 7)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-X1T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-X1T01:01Z is not a valid ISO-8601 format, expected digit at index 8)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-0XT01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-0XT01:01Z is not a valid ISO-8601 format, expected digit at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01X01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01X01:01Z is not a valid ISO-8601 format, expected 'T' at index 10)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01TX1:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01TX1:01 is not a valid ISO-8601 format, expected digit at index 11)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T0X:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T0X:01 is not a valid ISO-8601 format, expected digit at index 12)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T24:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T24:01 is not a valid ISO-8601 format, illegal hour at index 12)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01X01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01X01 is not a valid ISO-8601 format, expected ':' at index 13)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:X1").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:X1 is not a valid ISO-8601 format, expected digit at index 14)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:0X").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:0X is not a valid ISO-8601 format, expected digit at index 15)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:60").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:60 is not a valid ISO-8601 format, illegal minute at index 15)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01 is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 16)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01X").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01X is not a valid ISO-8601 format, expected ':' or '+' or '-' or 'Z' at index 16)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:0").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:0 is not a valid ISO-8601 format, illegal zoned date time at index 17)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:X1Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:X1Z is not a valid ISO-8601 format, expected digit at index 17)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:0XZ").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:0XZ is not a valid ISO-8601 format, expected digit at index 18)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:60Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:60Z is not a valid ISO-8601 format, illegal second at index 18)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 19)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:012").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:012 is not a valid ISO-8601 format, expected '.' or '+' or '-' or 'Z' at index 19)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01.").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01. is not a valid ISO-8601 format, expected digit or '+' or '-' or 'Z' at index 20)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01.X").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01.X is not a valid ISO-8601 format, expected digit or '+' or '-' or 'Z' at index 20)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01.123456789X").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01.123456789X is not a valid ISO-8601 format, expected '+' or '-' or 'Z' at index 29)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01ZX").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01ZX is not a valid ISO-8601 format, expected '[' at index 20)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+X1:01:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+X1:01:01 is not a valid ISO-8601 format, expected digit at index 20)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+0").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+0 is not a valid ISO-8601 format, illegal zoned date time at index 20)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+0X:01:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+0X:01:01 is not a valid ISO-8601 format, expected digit at index 21)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+19:01:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+19:01:01 is not a valid ISO-8601 format, illegal timezone offset hour at index 21)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01X01:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01X01:01 is not a valid ISO-8601 format, expected '[' at index 22)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:0").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:0 is not a valid ISO-8601 format, illegal zoned date time at index 23)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:X1:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:X1:01 is not a valid ISO-8601 format, expected digit at index 23)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:0X:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:0X:01 is not a valid ISO-8601 format, expected digit at index 24)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:60:01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:60:01 is not a valid ISO-8601 format, illegal timezone offset minute at index 24)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01X01").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01X01 is not a valid ISO-8601 format, expected '[' at index 25)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:0").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01:0 is not a valid ISO-8601 format, illegal zoned date time at index 26)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:X1").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:01:X1 is not a valid ISO-8601 format, expected digit at index 26)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:0X").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:01:0X is not a valid ISO-8601 format, expected digit at index 27)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:01X").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01:01+01:01:01X is not a valid ISO-8601 format, expected '[' at index 28)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01:01+01:01:60").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo(
-                "(2020-01-01T01:01:01+01:01:60 is not a valid ISO-8601 format, illegal timezone offset second at index 27)"
-              )
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+X0000-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+X0000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 1)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+1X000-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+1X000-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 2)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+10X00-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+10X00-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 3)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+100X0-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+100X0-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 4)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+1000X-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+1000X-01-01T01:01Z is not a valid ISO-8601 format, expected digit at index 5)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+10000X-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+10000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 6)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+100000X-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+100000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 7)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+1000000X-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+1000000X-01-01T01:01Z is not a valid ISO-8601 format, expected '-' or digit at index 8)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("+1000000000-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+1000000000-01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("-1000000000-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(-1000000000-01-01T01:01Z is not a valid ISO-8601 format, expected '-' at index 10)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("-0000-01-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(-0000-01-01T01:01Z is not a valid ISO-8601 format, illegal year at index 4)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
-          assert(stringify("+10000").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(+10000 is not a valid ISO-8601 format, illegal zoned date time at index 6)")
-            )
-          ) &&
+          assert(stringify("+10000").fromJson[ZonedDateTime])(isLeft(containsString("expected a ZonedDateTime"))) &&
           assert(stringify("2020-00-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-00-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-13-01T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-13-01T01:01Z is not a valid ISO-8601 format, illegal month at index 6)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-00T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-00T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-32T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-02-30T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-02-30T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-03-32T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-03-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-04-31T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-04-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-05-32T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-05-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-06-31T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-06-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-07-32T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-07-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-08-32T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-08-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-09-31T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-09-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-10-32T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-10-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-11-31T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-11-31T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-12-32T01:01Z").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-12-32T01:01Z is not a valid ISO-8601 format, illegal day at index 9)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01Z[").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01Z[ is not a valid ISO-8601 format, illegal zoned date time at index 17)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01Z[X]").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01Z[X] is not a valid ISO-8601 format, illegal zoned date time at index 18)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           ) &&
           assert(stringify("2020-01-01T01:01Z[GMT]X").fromJson[ZonedDateTime])(
-            isLeft(
-              equalTo("(2020-01-01T01:01Z[GMT]X is not a valid ISO-8601 format, illegal zoned date time at index 22)")
-            )
+            isLeft(containsString("expected a ZonedDateTime"))
           )
         },
         test("ZoneId") {
-          assert(stringify("America/New York").fromJson[ZoneId])(
-            isLeft(equalTo("(America/New York is not a valid ISO-8601 format, illegal zone id at index 0)"))
-          ) &&
-          assert(stringify("Solar_System/Mars").fromJson[ZoneId])(
-            isLeft(equalTo("(Solar_System/Mars is not a valid ISO-8601 format, illegal zone id at index 0)"))
-          )
+          assert(stringify("America/New York").fromJson[ZoneId])(isLeft(containsString("expected a ZoneId"))) &&
+          assert(stringify("Solar_System/Mars").fromJson[ZoneId])(isLeft(containsString("expected a ZoneId")))
         },
         test("ZoneOffset") {
-          assert(stringify("").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("( is not a valid ISO-8601 format, illegal zone offset at index 0)")
-            )
-          ) &&
-          assert(stringify("X").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(X is not a valid ISO-8601 format, expected '+' or '-' or 'Z' at index 0)")
-            )
-          ) &&
-          assert(stringify("+X1:01:01").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(+X1:01:01 is not a valid ISO-8601 format, expected digit at index 1)")
-            )
-          ) &&
-          assert(stringify("+0").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(+0 is not a valid ISO-8601 format, illegal zone offset at index 1)")
-            )
-          ) &&
-          assert(stringify("+0X:01:01").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(+0X:01:01 is not a valid ISO-8601 format, expected digit at index 2)")
-            )
-          ) &&
-          assert(stringify("+19:01:01").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo(
-                "(+19:01:01 is not a valid ISO-8601 format, illegal timezone offset hour at index 2)"
-              )
-            )
-          ) &&
-          assert(stringify("+01X01:01").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo(
-                "(+01X01:01 is not a valid ISO-8601 format, illegal zone offset at index 4)"
-              )
-            )
-          ) &&
-          assert(stringify("+01:0").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(+01:0 is not a valid ISO-8601 format, illegal zone offset at index 4)")
-            )
-          ) &&
-          assert(stringify("+01:X1:01").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(+01:X1:01 is not a valid ISO-8601 format, expected digit at index 4)")
-            )
-          ) &&
-          assert(stringify("+01:0X:01").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(+01:0X:01 is not a valid ISO-8601 format, expected digit at index 5)")
-            )
-          ) &&
-          assert(stringify("+01:60:01").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo(
-                "(+01:60:01 is not a valid ISO-8601 format, illegal timezone offset minute at index 5)"
-              )
-            )
-          ) &&
-          assert(stringify("+01:01X01").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo(
-                "(+01:01X01 is not a valid ISO-8601 format, illegal zone offset at index 7)"
-              )
-            )
-          ) &&
-          assert(stringify("+01:01:0").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo(
-                "(+01:01:0 is not a valid ISO-8601 format, illegal zone offset at index 7)"
-              )
-            )
-          ) &&
-          assert(stringify("+01:01:X1").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(+01:01:X1 is not a valid ISO-8601 format, expected digit at index 7)")
-            )
-          ) &&
-          assert(stringify("+01:01:0X").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo("(+01:01:0X is not a valid ISO-8601 format, expected digit at index 8)")
-            )
-          ) &&
-          assert(stringify("+01:01:60").fromJson[ZoneOffset])(
-            isLeft(
-              equalTo(
-                "(+01:01:60 is not a valid ISO-8601 format, illegal timezone offset second at index 8)"
-              )
-            )
-          )
+          assert(stringify("").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("X").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+X1:01:01").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+0").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+0X:01:01").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+19:01:01").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01X01:01").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01X").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:0").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:X1:01").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:0X:01").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:60:01").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:01X").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:01X01").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:01:0").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:01:X1").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:01:0X").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset"))) &&
+          assert(stringify("+01:01:60").fromJson[ZoneOffset])(isLeft(containsString("expected a ZoneOffset")))
         }
       )
     )


### PR DESCRIPTION
Tested with Scala 3 and JDK-21 on Intel® Core™ i7-11800H:

#### Before
```txt
Benchmark                              (size)   Mode  Cnt       Score       Error  Units
ArrayOfDurationsReading.zioJson           128  thrpt    5  123514.564 ±  7058.428  ops/s
ArrayOfInstantsReading.zioJson            128  thrpt    5  126454.550 ±  2399.503  ops/s
ArrayOfLocalDateTimesReading.zioJson      128  thrpt    5  124816.111 ±  2885.822  ops/s
ArrayOfLocalDatesReading.zioJson          128  thrpt    5  245092.966 ±  5915.764  ops/s
ArrayOfLocalTimesReading.zioJson          128  thrpt    5  193194.227 ± 13685.945  ops/s
ArrayOfOffsetDateTimesReading.zioJson     128  thrpt    5  119288.522 ±  3867.994  ops/s
ArrayOfOffsetTimesReading.zioJson         128  thrpt    5  149473.450 ±  8164.808  ops/s
ArrayOfPeriodsReading.zioJson             128  thrpt    5  131909.258 ± 11856.573  ops/s
ArrayOfZoneIdsReading.zioJson             128  thrpt    5  173918.355 ±  6621.408  ops/s
ArrayOfZoneOffsetsReading.zioJson         128  thrpt    5  282783.266 ± 10619.279  ops/s
ArrayOfZonedDateTimesReading.zioJson      128  thrpt    5   56711.917 ±   568.806  ops/s
```

#### After
```txt
Benchmark                              (size)   Mode  Cnt       Score       Error  Units
ArrayOfDurationsReading.zioJson           128  thrpt    5  139635.386 ±  6279.622  ops/s
ArrayOfInstantsReading.zioJson            128  thrpt    5  145895.788 ±  2712.227  ops/s
ArrayOfLocalDateTimesReading.zioJson      128  thrpt    5  145501.719 ±   954.572  ops/s
ArrayOfLocalDatesReading.zioJson          128  thrpt    5  256254.145 ±  4308.849  ops/s
ArrayOfLocalTimesReading.zioJson          128  thrpt    5  204250.156 ±  7884.575  ops/s
ArrayOfOffsetDateTimesReading.zioJson     128  thrpt    5  120077.595 ±  2159.185  ops/s
ArrayOfOffsetTimesReading.zioJson         128  thrpt    5  163593.607 ±  5666.016  ops/s
ArrayOfPeriodsReading.zioJson             128  thrpt    5  132556.463 ±  4627.411  ops/s
ArrayOfZoneIdsReading.zioJson             128  thrpt    5  194228.482 ±  9299.752  ops/s
ArrayOfZoneOffsetsReading.zioJson         128  thrpt    5  293216.532 ±  4029.065  ops/s
ArrayOfZonedDateTimesReading.zioJson      128  thrpt    5   58358.983 ±  1603.588  ops/s
```