### PR TITLE
Fix error message for invalid boolean

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -153,7 +153,7 @@ object Lexer {
     if (c == 't' && in.readChar() == 'r' && in.readChar() == 'u' && in.readChar() == 'e') true
     else if (c == 'f' && in.readChar() == 'a' && in.readChar() == 'l' && in.readChar() == 's' && in.readChar() == 'e')
       false
-    else error("expected a Boolean", c, trace)
+    else error("expected a Boolean", trace)
   }
 
   def byte(trace: List[JsonError], in: RetractReader): Byte =

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -34,6 +34,11 @@ object DecoderSpec extends ZIOSpecDefault {
           assert("\"\u0000\"".fromJson[Char])(isLeft(equalTo("""(invalid control in string)"""))) &&
           assert("\"\\u0000\"".replace('0', 'g').fromJson[Char])(isLeft(equalTo("""(invalid charcode in string)""")))
         },
+        test("boolean") {
+          assert("true".fromJson[Boolean])(isRight(equalTo(true))) &&
+          assert("false".fromJson[Boolean])(isRight(equalTo(false))) &&
+          assert("x".fromJson[Boolean])(isLeft(equalTo("(expected a Boolean)")))
+        },
         test("byte") {
           assert("-128".fromJson[Byte])(isRight(equalTo(Byte.MinValue))) &&
           assert("127".fromJson[Byte])(isRight(equalTo(Byte.MaxValue))) &&


### PR DESCRIPTION
This PR fixes wrong error message when decoding invalid boolean value:

```scala
println("x".fromJson[Boolean])
```
Was: `(expected expected a Boolean got 'x')`. 
Fixed: `(expected a Boolean)`