### PR TITLE
Optimize decoding ast variants of tuple and both

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,9 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         val work = (1 to i)
           .map(p => s"val a$p = A$p.unsafeDecode(traces(${p - 1}) :: trace, in)")
           .mkString("\n        Lexer.char(trace, in, ',')\n        ")
+        val work2 = (1 to i)
+          .map(p => s"val a$p = A$p.unsafeFromJsonAST(traces(${p - 1}) :: trace, arr($p - 1))")
+          .mkString("\n            ")
         val returns = (1 to i).map(p => s"a$p").mkString(", ")
 
         s"""implicit def tuple$i[$tparams](implicit $implicits): JsonDecoder[Tuple$i[$tparams]] =
@@ -153,6 +156,18 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
            |        Lexer.char(trace, in, ']')
            |        new Tuple$i($returns)
            |      }
+           |      override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Tuple$i[$tparams] = {
+           |        json match {
+           |          case a: Json.Arr =>
+           |            val arr = a.elements
+           |            if (arr.length != $i) {
+           |              Lexer.error("Expected array of size $i", trace)
+           |            }
+           |            $work2
+           |            new Tuple$i($returns)
+           |          case _ => Lexer.error("Not an array", trace)
+           |        }
+           |      }
            |    }""".stripMargin
       }
       IO.write(
@@ -160,6 +175,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         s"""package zio.json
            |
            |import zio.json.internal._
+           |import zio.json.ast._
            |
            |private[json] trait GeneratedTupleDecoders { this: JsonDecoder.type =>
            |  ${decoders.mkString("\n\n  ")}

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -74,6 +74,12 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
         val b = that.unsafeDecode(trace, rr)
         f(a, b)
       }
+
+      override def unsafeFromJsonAST(trace: List[JsonError], json: Json): C = {
+        val a = self.unsafeFromJsonAST(trace, json)
+        val b = that.unsafeFromJsonAST(trace, json)
+        f(a, b)
+      }
     }
 
   /**

--- a/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/DecoderSpec.scala
@@ -235,10 +235,27 @@ object DecoderSpec extends ZIOSpecDefault {
           )
         },
         test("tuples") {
-          assert("""["a",3]""".fromJson[(String, Int)])(isRight(equalTo(("a", 3))))
-          assert("""["a","b"]""".fromJson[(String, Int)])(isLeft(equalTo("[1](expected an Int)")))
+          assert("""["a",3]""".fromJson[(String, Int)])(isRight(equalTo(("a", 3)))) &&
+          assert("""["a","b"]""".fromJson[(String, Int)])(isLeft(equalTo("[1](expected an Int)"))) &&
           assert("""[[0.1,0.2],[0.3,0.4],[-0.3,-]]""".fromJson[Seq[(Double, Double)]])(
             isLeft(equalTo("[2][1](expected a Double)"))
+          )
+        },
+        test("tuples - ast") {
+          val a = Json.Arr(Json.Str("a"), Json.Num(3))
+          val b = Json.Arr(Json.Str("a"), Json.Str("b"))
+          val c = Json.Arr(
+            Json.Arr(Json.Num(0.1), Json.Num(0.2)),
+            Json.Arr(Json.Num(0.3), Json.Num(0.4)),
+            Json.Arr(Json.Num(-0.3), Json.Null)
+          )
+          val d = Json.Arr(Json.Num(0.1))
+
+          assertTrue(
+            a.as[(String, Int)].is(_.right) == ("a"    -> 3),
+            b.as[(String, String)].is(_.right) == ("a" -> "b"),
+            c.as[List[(Double, Double)]].is(_.left) == """[2][1](expected a Double)""",
+            d.as[(Double, Double)].is(_.left) == "(Expected array of size 2)"
           )
         },
         test("parameterless products") {
@@ -617,6 +634,19 @@ object DecoderSpec extends ZIOSpecDefault {
           val json = """{"a": 1, "b": "foo"}"""
           assertTrue(
             json.fromJson[(Foo, Bar)] == Right((Foo(1), Bar("foo")))
+          )
+        },
+        test("bothWith - ast") {
+          final case class Foo(a: Int)
+          final case class Bar(b: String)
+
+          val fooDecoder: JsonDecoder[Foo]                       = DeriveJsonDecoder.gen
+          val barDecoder: JsonDecoder[Bar]                       = DeriveJsonDecoder.gen
+          implicit val fooAndBarDecoder: JsonDecoder[(Foo, Bar)] = fooDecoder.both(barDecoder)
+
+          val json = Json.Obj("a" -> Json.Num(1), "b" -> Json.Str("foo"))
+          assertTrue(
+            json.as[(Foo, Bar)] == Right((Foo(1), Bar("foo")))
           )
         },
         test("option custom codec") {


### PR DESCRIPTION
When decoding from AST values `JsonDecoder` defaults to a non-optimal solution of re-encoding the json and parsing from a string. In the case of `tupleX` and the `both` variants we can do better by reading the ast directly instead.