### PR TITLE
Introduce AbstractJsonEncoder/Decoder to reduce bytecode size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           .mkString("\n            ")
         val returns = (1 to i).map(p => s"a$p").mkString(", ")
         s"""implicit def tuple$i[$tparams](implicit $implicits): JsonDecoder[Tuple$i[$tparams]] =
-           |    new JsonDecoder[Tuple$i[$tparams]] {
+           |    new JsonDecoder.AbstractJsonDecoder[Tuple$i[$tparams]] {
            |      private[this] val traces: Array[JsonError] = (0 to ${i - 1}).map(JsonError.ArrayAccess(_)).toArray
            |      def unsafeDecode(trace: List[JsonError], in: RetractReader): Tuple$i[$tparams] = {
            |        Lexer.char(trace, in, '[')
@@ -195,7 +195,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           .map(p => s"A$p.unsafeEncode(t._$p, indent, out)")
           .mkString("\n        if (indent.isEmpty) out.write(',') else out.write(\", \")\n        ")
         s"""implicit def tuple$i[$tparams](implicit $implicits): JsonEncoder[Tuple$i[$tparams]] =
-           |    new JsonEncoder[Tuple$i[$tparams]] {
+           |    new JsonEncoder.AbstractJsonEncoder[Tuple$i[$tparams]] {
            |      def unsafeEncode(t: Tuple$i[$tparams], indent: Option[Int], out: internal.Write): Unit = {
            |        out.write('[')
            |        $work

--- a/zio-json/jvm/src/test/scala/zio/json/data/geojson/GeoJSON.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/data/geojson/GeoJSON.scala
@@ -120,7 +120,7 @@ package handrolled {
     // custom decoders and is not a requirement to use the JsonDecoder[GeoJSON]
     // custom decoder (below) which is necessary to avert a DOS attack.
     implicit lazy val zioJsonJsonDecoder: JsonDecoder[Geometry] =
-      new JsonDecoder[Geometry] {
+      new JsonDecoder.AbstractJsonDecoder[Geometry] {
         import zio.json._
         import JsonDecoder.JsonError
         import internal._
@@ -270,7 +270,7 @@ package handrolled {
     // potentially complex and even skipping over it is expensive... it's a bit
     // of a corner case.
     implicit lazy val zioJsonJsonDecoder: JsonDecoder[GeoJSON] =
-      new JsonDecoder[GeoJSON] {
+      new JsonDecoder.AbstractJsonDecoder[GeoJSON] {
         import zio.json._
         import JsonDecoder.JsonError
         import internal._

--- a/zio-json/shared/src/main/scala-2.13/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-2.13/zio/json/JsonEncoderVersionSpecific.scala
@@ -7,7 +7,7 @@ import scala.collection.immutable
 
 private[json] trait JsonEncoderVersionSpecific {
   implicit def arraySeq[A: JsonEncoder: scala.reflect.ClassTag]: JsonEncoder[immutable.ArraySeq[A]] =
-    new JsonEncoder[immutable.ArraySeq[A]] {
+    new JsonEncoder.AbstractJsonEncoder[immutable.ArraySeq[A]] {
       private[this] val arrayEnc = JsonEncoder.array[A]
 
       override def isEmpty(as: immutable.ArraySeq[A]): Boolean = as.isEmpty

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -541,7 +541,7 @@ object DeriveJsonDecoder {
       ctx.subtypes.forall(_.typeclass.isInstanceOf[CaseObjectDecoder[JsonDecoder, _]])
     if (discrim.isEmpty && isEnumeration) {
       if (names.length <= 64) {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
             val idx = Lexer.enumeration(trace, in, matrix1)
             if (idx >= 0) tcs(idx).asInstanceOf[CaseObjectDecoder[JsonDecoder, A]].ctx.rawConstruct(Nil)
@@ -559,7 +559,7 @@ object DeriveJsonDecoder {
             }
         }
       } else {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
             val idx = Lexer.enumeration128(trace, in, matrix1, matrix2)
             if (idx >= 0) tcs(idx).asInstanceOf[CaseObjectDecoder[JsonDecoder, A]].ctx.rawConstruct(Nil)
@@ -580,7 +580,7 @@ object DeriveJsonDecoder {
     } else if (discrim.isEmpty) {
       // We're not allowing extra fields in this encoding
       if (names.length <= 64) {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           private[this] val spans = names.map(JsonError.ObjectAccess)
 
           def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
@@ -607,7 +607,7 @@ object DeriveJsonDecoder {
             }
         }
       } else {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           private[this] val spans = names.map(JsonError.ObjectAccess)
 
           def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
@@ -636,7 +636,7 @@ object DeriveJsonDecoder {
       }
     } else {
       if (names.length <= 64) {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           private[this] val hintfield  = discrim.get
           private[this] val hintmatrix = new StringMatrix(Array(hintfield))
           private[this] val spans      = names.map(JsonError.Message)
@@ -676,7 +676,7 @@ object DeriveJsonDecoder {
             }
         }
       } else {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           private[this] val hintfield  = discrim.get
           private[this] val hintmatrix = new StringMatrix(Array(hintfield))
           private[this] val spans      = names.map(JsonError.Message)
@@ -723,7 +723,7 @@ object DeriveJsonDecoder {
 }
 
 object DeriveJsonEncoder {
-  private lazy val caseObjectEncoder = new JsonEncoder[Any] {
+  private lazy val caseObjectEncoder = new JsonEncoder.AbstractJsonEncoder[Any] {
     override def isEmpty(a: Any): Boolean = true
 
     def unsafeEncode(a: Any, indent: Option[Int], out: Write): Unit = out.write("{}")
@@ -742,7 +742,7 @@ object DeriveJsonEncoder {
       val explicitEmptyCollections = ctx.annotations.collectFirst { case a: jsonExplicitEmptyCollections => a.encoding }
         .getOrElse(config.explicitEmptyCollections.encoding)
       val params = ctx.parameters.filter(p => p.annotations.collectFirst { case _: jsonExclude => () }.isEmpty).toArray
-      new JsonEncoder[A] {
+      new JsonEncoder.AbstractJsonEncoder[A] {
         private[this] lazy val fields = params.map { p =>
           FieldEncoder(
             p = p,
@@ -816,7 +816,7 @@ object DeriveJsonEncoder {
     lazy val isEnumeration = config.enumValuesAsStrings &&
       ctx.subtypes.forall(_.typeclass == caseObjectEncoder)
     if (discrim.isEmpty && isEnumeration) {
-      new JsonEncoder[A] {
+      new JsonEncoder.AbstractJsonEncoder[A] {
         private[this] val casts = ctx.subtypes.map(_.cast).toArray
 
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = {
@@ -832,7 +832,7 @@ object DeriveJsonEncoder {
         }
       }
     } else if (discrim.isEmpty) {
-      new JsonEncoder[A] {
+      new JsonEncoder.AbstractJsonEncoder[A] {
         private[this] val casts = ctx.subtypes.map(_.cast).toArray
 
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = {
@@ -856,7 +856,7 @@ object DeriveJsonEncoder {
         }
       }
     } else {
-      new JsonEncoder[A] {
+      new JsonEncoder.AbstractJsonEncoder[A] {
         private[this] val casts                = ctx.subtypes.map(_.cast).toArray
         private[this] val hintFieldName        = discrim.get
         private[this] val encodedHintFieldName = JsonEncoder.string.encodeJson(hintFieldName, None).toString

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -723,7 +723,7 @@ object DeriveJsonDecoder {
 }
 
 object DeriveJsonEncoder {
-  private lazy val caseObjectEncoder = new JsonEncoder.AbstractJsonEncoder[Any] {
+  private lazy val caseObjectEncoder: JsonEncoder[Any] = new JsonEncoder.AbstractJsonEncoder[Any] {
     override def isEmpty(a: Any): Boolean = true
 
     def unsafeEncode(a: Any, indent: Option[Int], out: Write): Unit = out.write("{}")

--- a/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/JsonEncoderVersionSpecific.scala
@@ -8,7 +8,7 @@ import scala.compiletime.ops.any.IsConst
 
 private[json] trait JsonEncoderVersionSpecific {
   implicit def arraySeq[A: JsonEncoder: scala.reflect.ClassTag]: JsonEncoder[immutable.ArraySeq[A]] =
-    new JsonEncoder[immutable.ArraySeq[A]] {
+    new JsonEncoder.AbstractJsonEncoder[immutable.ArraySeq[A]] {
       private[this] val arrayEnc = JsonEncoder.array[A]
 
       override def isEmpty(as: immutable.ArraySeq[A]): Boolean = as.isEmpty

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -534,7 +534,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
         !ctx.isEnum && ctx.subtypes.forall(_.isObject))
     if (discrim.isEmpty && isEnumeration) {
       if (names.length <= 64) {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
             val idx = Lexer.enumeration(trace, in, matrix1)
             if (idx >= 0) tcs(idx).asInstanceOf[CaseObjectDecoder[JsonDecoder, A]].ctx.rawConstruct(Nil)
@@ -551,7 +551,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
             }
         }
       } else {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
             val idx = Lexer.enumeration128(trace, in, matrix1, matrix2)
             if (idx >= 0) tcs(idx).asInstanceOf[CaseObjectDecoder[JsonDecoder, A]].ctx.rawConstruct(Nil)
@@ -571,7 +571,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
     } else if (discrim.isEmpty) {
       // We're not allowing extra fields in this encoding
       if (names.length <= 64) {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           private val spans = names.map(JsonError.ObjectAccess(_))
 
           def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
@@ -598,7 +598,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
             }
         }
       } else {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           private val spans = names.map(JsonError.ObjectAccess(_))
 
           def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
@@ -627,7 +627,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
       }
     } else {
       if (names.length <= 64) {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           private val hintfield = discrim.get
           private val hintmatrix = new StringMatrix(Array(hintfield))
           private val spans = names.map(JsonError.Message(_))
@@ -667,7 +667,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
             }
         }
       } else {
-        new JsonDecoder[A] {
+        new JsonDecoder.AbstractJsonDecoder[A] {
           private val hintfield = discrim.get
           private val hintmatrix = new StringMatrix(Array(hintfield))
           private val spans = names.map(JsonError.Message(_))
@@ -719,7 +719,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
   }
 }
 
-private lazy val caseObjectEncoder = new JsonEncoder[Any] {
+private lazy val caseObjectEncoder = new JsonEncoder.AbstractJsonEncoder[Any] {
   override def isEmpty(a: Any): Boolean = true
 
   def unsafeEncode(a: Any, indent: Option[Int], out: Write): Unit = out.write("{}")
@@ -753,7 +753,7 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
       val params = IArray.genericWrapArray(ctx.params.filterNot { param =>
         param.annotations.collectFirst { case _: jsonExclude => () }.isDefined
       }).toArray
-      new JsonEncoder[A] {
+      new JsonEncoder.AbstractJsonEncoder[A] {
         private lazy val fields = params.map { p =>
           FieldEncoder(
             p = p,
@@ -829,7 +829,7 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
       (ctx.isEnum && ctx.subtypes.forall(_.typeclass == caseObjectEncoder) ||
         !ctx.isEnum && ctx.subtypes.forall(_.isObject))
     if (discrim.isEmpty && isEnumeration) {
-      new JsonEncoder[A] {
+      new JsonEncoder.AbstractJsonEncoder[A] {
         private val casts = IArray.genericWrapArray(ctx.subtypes.map(_.cast)).toArray
 
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = {
@@ -845,7 +845,7 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
         }
       }
     } else if (discrim.isEmpty) {
-      new JsonEncoder[A] {
+      new JsonEncoder.AbstractJsonEncoder[A] {
         private val casts = IArray.genericWrapArray(ctx.subtypes.map(_.cast)).toArray
 
         def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = {
@@ -869,7 +869,7 @@ sealed class JsonEncoderDerivation(config: JsonCodecConfiguration) extends Deriv
         }
       }
     } else {
-      new JsonEncoder[A] {
+      new JsonEncoder.AbstractJsonEncoder[A] {
         private val casts = IArray.genericWrapArray(ctx.subtypes.map(_.cast)).toArray
         private val hintFieldName = discrim.get
         private val encodedHintFieldName = JsonEncoder.string.encodeJson(hintFieldName, None).toString

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -719,7 +719,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
   }
 }
 
-private lazy val caseObjectEncoder = new JsonEncoder.AbstractJsonEncoder[Any] {
+private lazy val caseObjectEncoder: JsonEncoder[Any] = new JsonEncoder.AbstractJsonEncoder[Any] {
   override def isEmpty(a: Any): Boolean = true
 
   def unsafeEncode(a: Any, indent: Option[Int], out: Write): Unit = out.write("{}")

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -66,7 +66,7 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
   final def bothLeft[B](that: => JsonDecoder[B]): JsonDecoder[A] = bothWith(that)((a, _) => a)
 
   final def bothWith[B, C](that: => JsonDecoder[B])(f: (A, B) => C): JsonDecoder[C] =
-    new JsonDecoder[C] {
+    new JsonDecoder.AbstractJsonDecoder[C] {
       override def unsafeDecode(trace: List[JsonError], in: RetractReader): C = {
         val rr = RecordingReader(in)
         val a  = self.unsafeDecode(trace, rr)
@@ -116,7 +116,7 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
    * ```
    */
   final def orElse[A1 >: A](that: => JsonDecoder[A1]): JsonDecoder[A1] =
-    new JsonDecoder[A1] {
+    new JsonDecoder.AbstractJsonDecoder[A1] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): A1 = {
         val rr = RecordingReader(in)
         try self.unsafeDecode(trace, rr)
@@ -236,6 +236,9 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
 }
 
 object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with JsonDecoderVersionSpecific {
+
+  /** Abstract class of the `JsonDecoder` trait to reduce class file size in subclasses. */
+  abstract class AbstractJsonDecoder[A] extends JsonDecoder[A]
   type JsonError = zio.json.JsonError
   val JsonError = zio.json.JsonError
 
@@ -250,15 +253,16 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
       extends Exception("If you see this, a developer made a mistake using JsonDecoder")
       with NoStackTrace
 
-  def peekChar[A](partialFunction: PartialFunction[Char, JsonDecoder[A]]): JsonDecoder[A] = new JsonDecoder[A] {
-    override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
-      val c = in.nextNonWhitespace()
-      if (partialFunction.isDefinedAt(c)) {
-        in.retract()
-        partialFunction(c).unsafeDecode(trace, in)
-      } else Lexer.error(s"missing case in `peekChar` for '${c}''", trace)
+  def peekChar[A](partialFunction: PartialFunction[Char, JsonDecoder[A]]): JsonDecoder[A] =
+    new JsonDecoder.AbstractJsonDecoder[A] {
+      override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
+        val c = in.nextNonWhitespace()
+        if (partialFunction.isDefinedAt(c)) {
+          in.retract()
+          partialFunction(c).unsafeDecode(trace, in)
+        } else Lexer.error(s"missing case in `peekChar` for '${c}''", trace)
+      }
     }
-  }
 
   def suspend[A](decoder0: => JsonDecoder[A]): JsonDecoder[A] =
     new MappedJsonDecoder[A] {
@@ -273,7 +277,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
       override def unsafeFromJsonAST(trace: List[JsonError], json: Json): A = decoder.unsafeFromJsonAST(trace, json)
     }
 
-  implicit val string: JsonDecoder[String] = new JsonDecoder[String] {
+  implicit val string: JsonDecoder[String] = new JsonDecoder.AbstractJsonDecoder[String] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): String = Lexer.string(trace, in).toString
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): String =
@@ -283,7 +287,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
       }
   }
 
-  implicit val boolean: JsonDecoder[Boolean] = new JsonDecoder[Boolean] {
+  implicit val boolean: JsonDecoder[Boolean] = new JsonDecoder.AbstractJsonDecoder[Boolean] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Boolean = Lexer.boolean(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Boolean =
@@ -293,7 +297,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
       }
   }
 
-  implicit val char: JsonDecoder[Char] = new JsonDecoder[Char] {
+  implicit val char: JsonDecoder[Char] = new JsonDecoder.AbstractJsonDecoder[Char] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Char = Lexer.char(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Char =
@@ -305,7 +309,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
 
   implicit val symbol: JsonDecoder[Symbol] = string.map(Symbol(_))
 
-  implicit val byte: JsonDecoder[Byte] = new JsonDecoder[Byte] {
+  implicit val byte: JsonDecoder[Byte] = new JsonDecoder.AbstractJsonDecoder[Byte] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Byte =
       if (in.nextNonWhitespace() != '"') {
         in.retract()
@@ -335,7 +339,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     }
   }
 
-  implicit val short: JsonDecoder[Short] = new JsonDecoder[Short] {
+  implicit val short: JsonDecoder[Short] = new JsonDecoder.AbstractJsonDecoder[Short] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Short =
       if (in.nextNonWhitespace() != '"') {
         in.retract()
@@ -365,7 +369,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     }
   }
 
-  implicit val int: JsonDecoder[Int] = new JsonDecoder[Int] {
+  implicit val int: JsonDecoder[Int] = new JsonDecoder.AbstractJsonDecoder[Int] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Int =
       if (in.nextNonWhitespace() != '"') {
         in.retract()
@@ -394,7 +398,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
       Lexer.error("expected a Int", trace)
     }
   }
-  implicit val long: JsonDecoder[Long] = new JsonDecoder[Long] {
+  implicit val long: JsonDecoder[Long] = new JsonDecoder.AbstractJsonDecoder[Long] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Long =
       if (in.nextNonWhitespace() != '"') {
         in.retract()
@@ -424,36 +428,37 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     }
   }
 
-  implicit val bigInteger: JsonDecoder[java.math.BigInteger] = new JsonDecoder[java.math.BigInteger] {
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): java.math.BigInteger =
-      if (in.nextNonWhitespace() != '"') {
-        in.retract()
-        Lexer.bigInteger(trace, in)
-      } else {
-        val a = Lexer.bigInteger(trace, in)
-        val c = in.readChar()
-        if (c != '"') Lexer.error("'\"'", c, trace)
-        a
-      }
+  implicit val bigInteger: JsonDecoder[java.math.BigInteger] =
+    new JsonDecoder.AbstractJsonDecoder[java.math.BigInteger] {
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): java.math.BigInteger =
+        if (in.nextNonWhitespace() != '"') {
+          in.retract()
+          Lexer.bigInteger(trace, in)
+        } else {
+          val a = Lexer.bigInteger(trace, in)
+          val c = in.readChar()
+          if (c != '"') Lexer.error("'\"'", c, trace)
+          a
+        }
 
-    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): java.math.BigInteger = {
-      json match {
-        case n: Json.Num =>
-          try return n.value.toBigIntegerExact
-          catch {
-            case _: ArithmeticException =>
-          }
-        case s: Json.Str =>
-          try return UnsafeNumbers.bigInteger_(new FastStringReader(s.value), true, Lexer.NumberMaxBits)
-          catch {
-            case _: UnexpectedEnd | UnsafeNumbers.UnsafeNumber =>
-          }
-        case _ =>
+      override def unsafeFromJsonAST(trace: List[JsonError], json: Json): java.math.BigInteger = {
+        json match {
+          case n: Json.Num =>
+            try return n.value.toBigIntegerExact
+            catch {
+              case _: ArithmeticException =>
+            }
+          case s: Json.Str =>
+            try return UnsafeNumbers.bigInteger_(new FastStringReader(s.value), true, Lexer.NumberMaxBits)
+            catch {
+              case _: UnexpectedEnd | UnsafeNumbers.UnsafeNumber =>
+            }
+          case _ =>
+        }
+        Lexer.error(s"expected a $NumberMaxBits-bit BigInteger", trace)
       }
-      Lexer.error(s"expected a $NumberMaxBits-bit BigInteger", trace)
     }
-  }
-  implicit val scalaBigInt: JsonDecoder[BigInt] = new JsonDecoder[BigInt] {
+  implicit val scalaBigInt: JsonDecoder[BigInt] = new JsonDecoder.AbstractJsonDecoder[BigInt] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): BigInt =
       if (in.nextNonWhitespace() != '"') {
         in.retract()
@@ -482,7 +487,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
       Lexer.error(s"expected a $NumberMaxBits-bit BigInt", trace)
     }
   }
-  implicit val float: JsonDecoder[Float] = new JsonDecoder[Float] {
+  implicit val float: JsonDecoder[Float] = new JsonDecoder.AbstractJsonDecoder[Float] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Float =
       if (in.nextNonWhitespace() != '"') {
         in.retract()
@@ -508,7 +513,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
       Lexer.error("expected a Float", trace)
     }
   }
-  implicit val double: JsonDecoder[Double] = new JsonDecoder[Double] {
+  implicit val double: JsonDecoder[Double] = new JsonDecoder.AbstractJsonDecoder[Double] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Double =
       if (in.nextNonWhitespace() != '"') {
         in.retract()
@@ -534,33 +539,34 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
       Lexer.error("expected a Double", trace)
     }
   }
-  implicit val bigDecimal: JsonDecoder[java.math.BigDecimal] = new JsonDecoder[java.math.BigDecimal] {
-    def unsafeDecode(trace: List[JsonError], in: RetractReader): java.math.BigDecimal =
-      if (in.nextNonWhitespace() != '"') {
-        in.retract()
-        Lexer.bigDecimal(trace, in)
-      } else {
-        val a = Lexer.bigDecimal(trace, in)
-        val c = in.readChar()
-        if (c != '"') Lexer.error("'\"'", c, trace)
-        a
-      }
+  implicit val bigDecimal: JsonDecoder[java.math.BigDecimal] =
+    new JsonDecoder.AbstractJsonDecoder[java.math.BigDecimal] {
+      def unsafeDecode(trace: List[JsonError], in: RetractReader): java.math.BigDecimal =
+        if (in.nextNonWhitespace() != '"') {
+          in.retract()
+          Lexer.bigDecimal(trace, in)
+        } else {
+          val a = Lexer.bigDecimal(trace, in)
+          val c = in.readChar()
+          if (c != '"') Lexer.error("'\"'", c, trace)
+          a
+        }
 
-    override def unsafeFromJsonAST(trace: List[JsonError], json: Json): java.math.BigDecimal = {
-      json match {
-        case n: Json.Num =>
-          return n.value
-        case s: Json.Str =>
-          try return UnsafeNumbers.bigDecimal_(new FastStringReader(s.value), true, Lexer.NumberMaxBits)
-          catch {
-            case _: UnexpectedEnd | UnsafeNumbers.UnsafeNumber =>
-          }
-        case _ =>
+      override def unsafeFromJsonAST(trace: List[JsonError], json: Json): java.math.BigDecimal = {
+        json match {
+          case n: Json.Num =>
+            return n.value
+          case s: Json.Str =>
+            try return UnsafeNumbers.bigDecimal_(new FastStringReader(s.value), true, Lexer.NumberMaxBits)
+            catch {
+              case _: UnexpectedEnd | UnsafeNumbers.UnsafeNumber =>
+            }
+          case _ =>
+        }
+        Lexer.error(s"expected a BigDecimal with $NumberMaxBits-bit mantissa", trace)
       }
-      Lexer.error(s"expected a BigDecimal with $NumberMaxBits-bit mantissa", trace)
     }
-  }
-  implicit val scalaBigDecimal: JsonDecoder[BigDecimal] = new JsonDecoder[BigDecimal] {
+  implicit val scalaBigDecimal: JsonDecoder[BigDecimal] = new JsonDecoder.AbstractJsonDecoder[BigDecimal] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): BigDecimal =
       if (in.nextNonWhitespace() != '"') {
         in.retract()
@@ -613,7 +619,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
   // but does not support the "discriminator field" encoding with a field named
   // "value" used by some libraries.
   implicit def either[A, B](implicit A: JsonDecoder[A], B: JsonDecoder[B]): JsonDecoder[Either[A, B]] =
-    new JsonDecoder[Either[A, B]] {
+    new JsonDecoder.AbstractJsonDecoder[Either[A, B]] {
       private[this] val names  = Array("a", "Left", "left", "b", "Right", "right")
       private[this] val matrix = new StringMatrix(names)
       private[this] val spans  = names.map(new JsonError.ObjectAccess(_))
@@ -688,7 +694,7 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
 
   // FIXME: remove in the next major version
   private[json] def mapStringOrFail[A](f: String => Either[String, A]): JsonDecoder[A] =
-    new JsonDecoder[A] {
+    new JsonDecoder.AbstractJsonDecoder[A] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): A =
         f(string.unsafeDecode(trace, in)) match {
           case Right(value) => value
@@ -932,7 +938,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
 
   import java.time._
 
-  implicit val dayOfWeek: JsonDecoder[DayOfWeek] = new JsonDecoder[DayOfWeek] {
+  implicit val dayOfWeek: JsonDecoder[DayOfWeek] = new JsonDecoder.AbstractJsonDecoder[DayOfWeek] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): DayOfWeek = Lexer.dayOfWeek(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): DayOfWeek = {
@@ -947,7 +953,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a DayOfWeek", trace)
     }
   }
-  implicit val duration: JsonDecoder[Duration] = new JsonDecoder[Duration] {
+  implicit val duration: JsonDecoder[Duration] = new JsonDecoder.AbstractJsonDecoder[Duration] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Duration = Lexer.duration(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Duration = {
@@ -962,7 +968,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a Duration", trace)
     }
   }
-  implicit val instant: JsonDecoder[Instant] = new JsonDecoder[Instant] {
+  implicit val instant: JsonDecoder[Instant] = new JsonDecoder.AbstractJsonDecoder[Instant] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Instant = Lexer.instant(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Instant = {
@@ -977,7 +983,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected an Instant", trace)
     }
   }
-  implicit val localDate: JsonDecoder[LocalDate] = new JsonDecoder[LocalDate] {
+  implicit val localDate: JsonDecoder[LocalDate] = new JsonDecoder.AbstractJsonDecoder[LocalDate] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): LocalDate = Lexer.localDate(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): LocalDate = {
@@ -992,7 +998,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a LocalDate", trace)
     }
   }
-  implicit val localDateTime: JsonDecoder[LocalDateTime] = new JsonDecoder[LocalDateTime] {
+  implicit val localDateTime: JsonDecoder[LocalDateTime] = new JsonDecoder.AbstractJsonDecoder[LocalDateTime] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): LocalDateTime = Lexer.localDateTime(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): LocalDateTime = {
@@ -1007,7 +1013,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a LocalDateTime", trace)
     }
   }
-  implicit val localTime: JsonDecoder[LocalTime] = new JsonDecoder[LocalTime] {
+  implicit val localTime: JsonDecoder[LocalTime] = new JsonDecoder.AbstractJsonDecoder[LocalTime] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): LocalTime = Lexer.localTime(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): LocalTime = {
@@ -1022,7 +1028,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a LocalTime", trace)
     }
   }
-  implicit val month: JsonDecoder[Month] = new JsonDecoder[Month] {
+  implicit val month: JsonDecoder[Month] = new JsonDecoder.AbstractJsonDecoder[Month] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Month = Lexer.month(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Month = {
@@ -1037,7 +1043,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a Month", trace)
     }
   }
-  implicit val monthDay: JsonDecoder[MonthDay] = new JsonDecoder[MonthDay] {
+  implicit val monthDay: JsonDecoder[MonthDay] = new JsonDecoder.AbstractJsonDecoder[MonthDay] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): MonthDay = Lexer.monthDay(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): MonthDay = {
@@ -1052,7 +1058,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a MonthDay", trace)
     }
   }
-  implicit val offsetDateTime: JsonDecoder[OffsetDateTime] = new JsonDecoder[OffsetDateTime] {
+  implicit val offsetDateTime: JsonDecoder[OffsetDateTime] = new JsonDecoder.AbstractJsonDecoder[OffsetDateTime] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): OffsetDateTime = Lexer.offsetDateTime(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): OffsetDateTime = {
@@ -1067,7 +1073,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected an OffsetDateTime", trace)
     }
   }
-  implicit val offsetTime: JsonDecoder[OffsetTime] = new JsonDecoder[OffsetTime] {
+  implicit val offsetTime: JsonDecoder[OffsetTime] = new JsonDecoder.AbstractJsonDecoder[OffsetTime] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): OffsetTime = Lexer.offsetTime(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): OffsetTime = {
@@ -1082,7 +1088,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected an OffsetTime", trace)
     }
   }
-  implicit val period: JsonDecoder[Period] = new JsonDecoder[Period] {
+  implicit val period: JsonDecoder[Period] = new JsonDecoder.AbstractJsonDecoder[Period] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Period = Lexer.period(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Period = {
@@ -1097,7 +1103,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a Period", trace)
     }
   }
-  implicit val year: JsonDecoder[Year] = new JsonDecoder[Year] {
+  implicit val year: JsonDecoder[Year] = new JsonDecoder.AbstractJsonDecoder[Year] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Year = Lexer.year(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): Year = {
@@ -1112,7 +1118,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a Year", trace)
     }
   }
-  implicit val yearMonth: JsonDecoder[YearMonth] = new JsonDecoder[YearMonth] {
+  implicit val yearMonth: JsonDecoder[YearMonth] = new JsonDecoder.AbstractJsonDecoder[YearMonth] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): YearMonth = Lexer.yearMonth(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): YearMonth = {
@@ -1127,7 +1133,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a YearMonth", trace)
     }
   }
-  implicit val zonedDateTime: JsonDecoder[ZonedDateTime] = new JsonDecoder[ZonedDateTime] {
+  implicit val zonedDateTime: JsonDecoder[ZonedDateTime] = new JsonDecoder.AbstractJsonDecoder[ZonedDateTime] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): ZonedDateTime = Lexer.zonedDateTime(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): ZonedDateTime = {
@@ -1142,7 +1148,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a ZonedDateTime", trace)
     }
   }
-  implicit val zoneId: JsonDecoder[ZoneId] = new JsonDecoder[ZoneId] {
+  implicit val zoneId: JsonDecoder[ZoneId] = new JsonDecoder.AbstractJsonDecoder[ZoneId] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): ZoneId =
       try parsers.unsafeParseZoneId(Lexer.string(trace, in).toString)
       catch {
@@ -1161,7 +1167,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
       Lexer.error("expected a ZoneId", trace)
     }
   }
-  implicit val zoneOffset: JsonDecoder[ZoneOffset] = new JsonDecoder[ZoneOffset] {
+  implicit val zoneOffset: JsonDecoder[ZoneOffset] = new JsonDecoder.AbstractJsonDecoder[ZoneOffset] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): ZoneOffset = Lexer.zoneOffset(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): ZoneOffset = {
@@ -1187,7 +1193,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
         new Left(s"${strip(s)} is not a valid ISO-8601 format")
     }
 
-  implicit val uuid: JsonDecoder[UUID] = new JsonDecoder[UUID] {
+  implicit val uuid: JsonDecoder[UUID] = new JsonDecoder.AbstractJsonDecoder[UUID] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): UUID = Lexer.uuid(trace, in)
 
     override def unsafeFromJsonAST(trace: List[JsonError], json: Json): UUID = {
@@ -1203,7 +1209,7 @@ private[json] trait DecoderLowPriority3 extends DecoderLowPriority4 {
     }
   }
 
-  implicit val currency: JsonDecoder[java.util.Currency] = new JsonDecoder[java.util.Currency] {
+  implicit val currency: JsonDecoder[java.util.Currency] = new JsonDecoder.AbstractJsonDecoder[java.util.Currency] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): java.util.Currency =
       try java.util.Currency.getInstance(Lexer.string(trace, in).toString)
       catch {

--- a/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonEncoder.scala
@@ -31,7 +31,7 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
    * Returns a new encoder, with a new input type, which can be transformed to the old input type by the specified
    * user-defined function.
    */
-  final def contramap[B](f: B => A): JsonEncoder[B] = new JsonEncoder[B] {
+  final def contramap[B](f: B => A): JsonEncoder[B] = new JsonEncoder.AbstractJsonEncoder[B] {
     override def unsafeEncode(b: B, indent: Option[Int], out: Write): Unit =
       self.unsafeEncode(f(b), indent, out)
 
@@ -114,6 +114,9 @@ trait JsonEncoder[A] extends JsonEncoderPlatformSpecific[A] {
 }
 
 object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with JsonEncoderVersionSpecific {
+
+  /** Abstract class of the `JsonEncoder` trait to reduce class file size in subclasses. */
+  abstract class AbstractJsonEncoder[A] extends JsonEncoder[A]
   private class FastStringWritePool {
     private[this] var weakRef: java.lang.ref.WeakReference[Array[FastStringWrite]] =
       new java.lang.ref.WeakReference(Array(new FastStringWrite(64)))
@@ -146,7 +149,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
 
   @inline def apply[A](implicit a: JsonEncoder[A]): JsonEncoder[A] = a
 
-  implicit val string: JsonEncoder[String] = new JsonEncoder[String] {
+  implicit val string: JsonEncoder[String] = new JsonEncoder.AbstractJsonEncoder[String] {
     override def unsafeEncode(a: String, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       val len = a.length
@@ -190,7 +193,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
     }
   }
 
-  implicit val char: JsonEncoder[Char] = new JsonEncoder[Char] {
+  implicit val char: JsonEncoder[Char] = new JsonEncoder.AbstractJsonEncoder[Char] {
     override def unsafeEncode(a: Char, indent: Option[Int], out: Write): Unit =
       (a: @switch) match {
         case '"'  => out.write('"', '\\', '"', '"')
@@ -213,14 +216,14 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
   }
 
   // FIXME: remove in the next major version
-  private[json] def explicit[A](f: A => String, g: A => Json): JsonEncoder[A] = new JsonEncoder[A] {
+  private[json] def explicit[A](f: A => String, g: A => Json): JsonEncoder[A] = new JsonEncoder.AbstractJsonEncoder[A] {
     def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = out.write(f(a))
 
     override def toJsonAST(a: A): Either[String, Json] = new Right(g(a))
   }
 
   // FIXME: remove in the next major version
-  private[json] def stringify[A](f: A => String): JsonEncoder[A] = new JsonEncoder[A] {
+  private[json] def stringify[A](f: A => String): JsonEncoder[A] = new JsonEncoder.AbstractJsonEncoder[A] {
     def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       out.write(f(a))
@@ -232,7 +235,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
 
   // FIXME: add tests
   def suspend[A](encoder0: => JsonEncoder[A]): JsonEncoder[A] =
-    new JsonEncoder[A] {
+    new JsonEncoder.AbstractJsonEncoder[A] {
       lazy val encoder = encoder0
 
       override def unsafeEncode(a: A, indent: Option[Int], out: Write): Unit = encoder.unsafeEncode(a, indent, out)
@@ -244,7 +247,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
       override def toJsonAST(a: A): Either[String, Json] = encoder.toJsonAST(a)
     }
 
-  implicit val boolean: JsonEncoder[Boolean] = new JsonEncoder[Boolean] {
+  implicit val boolean: JsonEncoder[Boolean] = new JsonEncoder.AbstractJsonEncoder[Boolean] {
     def unsafeEncode(a: Boolean, indent: Option[Int], out: Write): Unit =
       if (a) out.write('t', 'r', 'u', 'e')
       else out.write('f', 'a', 'l', 's', 'e')
@@ -252,70 +255,73 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
     override def toJsonAST(a: Boolean): Either[String, Json] = new Right(Json.Bool(a))
   }
   implicit val symbol: JsonEncoder[Symbol] = string.contramap(_.name)
-  implicit val byte: JsonEncoder[Byte]     = new JsonEncoder[Byte] {
+  implicit val byte: JsonEncoder[Byte]     = new JsonEncoder.AbstractJsonEncoder[Byte] {
     def unsafeEncode(a: Byte, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a.toInt, out)
 
     override def toJsonAST(a: Byte): Either[String, Json] = new Right(Json.Num(a.toInt))
   }
-  implicit val short: JsonEncoder[Short] = new JsonEncoder[Short] {
+  implicit val short: JsonEncoder[Short] = new JsonEncoder.AbstractJsonEncoder[Short] {
     def unsafeEncode(a: Short, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a.toInt, out)
 
     override def toJsonAST(a: Short): Either[String, Json] = new Right(Json.Num(a.toInt))
   }
-  implicit val int: JsonEncoder[Int] = new JsonEncoder[Int] {
+  implicit val int: JsonEncoder[Int] = new JsonEncoder.AbstractJsonEncoder[Int] {
     def unsafeEncode(a: Int, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a, out)
 
     override def toJsonAST(a: Int): Either[String, Json] = new Right(Json.Num(a))
   }
-  implicit val long: JsonEncoder[Long] = new JsonEncoder[Long] {
+  implicit val long: JsonEncoder[Long] = new JsonEncoder.AbstractJsonEncoder[Long] {
     def unsafeEncode(a: Long, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a, out)
 
     override def toJsonAST(a: Long): Either[String, Json] = new Right(Json.Num(a))
   }
-  implicit val bigInteger: JsonEncoder[java.math.BigInteger] = new JsonEncoder[java.math.BigInteger] {
-    def unsafeEncode(a: java.math.BigInteger, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a, out)
+  implicit val bigInteger: JsonEncoder[java.math.BigInteger] =
+    new JsonEncoder.AbstractJsonEncoder[java.math.BigInteger] {
+      def unsafeEncode(a: java.math.BigInteger, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a, out)
 
-    override def toJsonAST(a: java.math.BigInteger): Either[String, Json] = new Right(Json.Num(a))
-  }
-  implicit val scalaBigInt: JsonEncoder[BigInt] = new JsonEncoder[BigInt] {
+      override def toJsonAST(a: java.math.BigInteger): Either[String, Json] = new Right(Json.Num(a))
+    }
+  implicit val scalaBigInt: JsonEncoder[BigInt] = new JsonEncoder.AbstractJsonEncoder[BigInt] {
     def unsafeEncode(a: BigInt, indent: Option[Int], out: Write): Unit =
       if (a.isValidLong) SafeNumbers.write(a.longValue, out)
       else SafeNumbers.write(a.bigInteger, out)
 
     override def toJsonAST(a: BigInt): Either[String, Json] = new Right(Json.Num(a))
   }
-  implicit val double: JsonEncoder[Double] = new JsonEncoder[Double] {
+  implicit val double: JsonEncoder[Double] = new JsonEncoder.AbstractJsonEncoder[Double] {
     def unsafeEncode(a: Double, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a, out)
 
     override def toJsonAST(a: Double): Either[String, Json] = new Right(Json.Num(a))
   }
-  implicit val float: JsonEncoder[Float] = new JsonEncoder[Float] {
+  implicit val float: JsonEncoder[Float] = new JsonEncoder.AbstractJsonEncoder[Float] {
     def unsafeEncode(a: Float, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a, out)
 
     override def toJsonAST(a: Float): Either[String, Json] = new Right(Json.Num(a))
   }
-  implicit val bigDecimal: JsonEncoder[java.math.BigDecimal] = new JsonEncoder[java.math.BigDecimal] {
-    def unsafeEncode(a: java.math.BigDecimal, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a, out)
+  implicit val bigDecimal: JsonEncoder[java.math.BigDecimal] =
+    new JsonEncoder.AbstractJsonEncoder[java.math.BigDecimal] {
+      def unsafeEncode(a: java.math.BigDecimal, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a, out)
 
-    override def toJsonAST(a: java.math.BigDecimal): Either[String, Json] = new Right(new Json.Num(a))
-  }
-  implicit val scalaBigDecimal: JsonEncoder[BigDecimal] = new JsonEncoder[BigDecimal] {
+      override def toJsonAST(a: java.math.BigDecimal): Either[String, Json] = new Right(new Json.Num(a))
+    }
+  implicit val scalaBigDecimal: JsonEncoder[BigDecimal] = new JsonEncoder.AbstractJsonEncoder[BigDecimal] {
     def unsafeEncode(a: BigDecimal, indent: Option[Int], out: Write): Unit = SafeNumbers.write(a.bigDecimal, out)
 
     override def toJsonAST(a: BigDecimal): Either[String, Json] = new Right(new Json.Num(a.bigDecimal))
   }
 
-  implicit def option[A](implicit A: JsonEncoder[A]): JsonEncoder[Option[A]] = new JsonEncoder[Option[A]] {
-    def unsafeEncode(oa: Option[A], indent: Option[Int], out: Write): Unit =
-      if (oa eq None) out.write('n', 'u', 'l', 'l')
-      else A.unsafeEncode(oa.get, indent, out)
+  implicit def option[A](implicit A: JsonEncoder[A]): JsonEncoder[Option[A]] =
+    new JsonEncoder.AbstractJsonEncoder[Option[A]] {
+      def unsafeEncode(oa: Option[A], indent: Option[Int], out: Write): Unit =
+        if (oa eq None) out.write('n', 'u', 'l', 'l')
+        else A.unsafeEncode(oa.get, indent, out)
 
-    override def isNothing(oa: Option[A]): Boolean = (oa eq None) || A.isNothing(oa.get)
+      override def isNothing(oa: Option[A]): Boolean = (oa eq None) || A.isNothing(oa.get)
 
-    override def toJsonAST(oa: Option[A]): Either[String, Json] =
-      if (oa eq None) rightNull
-      else A.toJsonAST(oa.get)
-  }
+      override def toJsonAST(oa: Option[A]): Either[String, Json] =
+        if (oa eq None) rightNull
+        else A.toJsonAST(oa.get)
+    }
 
   def bump(indent: Option[Int]): Option[Int] =
     if (indent ne None) new Some(indent.get + 1)
@@ -337,7 +343,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
     }
 
   implicit def either[A, B](implicit A: JsonEncoder[A], B: JsonEncoder[B]): JsonEncoder[Either[A, B]] =
-    new JsonEncoder[Either[A, B]] {
+    new JsonEncoder.AbstractJsonEncoder[Either[A, B]] {
       def unsafeEncode(eab: Either[A, B], indent: Option[Int], out: Write): Unit = {
         out.write('{')
         if (indent.isDefined) unsafeEncodePadded(eab, indent, out)
@@ -377,7 +383,7 @@ object JsonEncoder extends GeneratedTupleEncoders with EncoderLowPriority1 with 
     }
 
   def orElseEither[A, B](implicit A: JsonEncoder[A], B: JsonEncoder[B]): JsonEncoder[Either[A, B]] =
-    new JsonEncoder[Either[A, B]] {
+    new JsonEncoder.AbstractJsonEncoder[Either[A, B]] {
       def unsafeEncode(eab: Either[A, B], indent: Option[Int], out: Write): Unit =
         eab match {
           case Left(a)  => A.unsafeEncode(a, indent, out)
@@ -391,7 +397,7 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
   this: JsonEncoder.type =>
 
   implicit def array[A](implicit A: JsonEncoder[A], classTag: scala.reflect.ClassTag[A]): JsonEncoder[Array[A]] =
-    new JsonEncoder[Array[A]] {
+    new JsonEncoder.AbstractJsonEncoder[Array[A]] {
       override def isEmpty(as: Array[A]): Boolean = as.isEmpty
 
       def unsafeEncode(as: Array[A], indent: Option[Int], out: Write): Unit =
@@ -458,7 +464,7 @@ private[json] trait EncoderLowPriority1 extends EncoderLowPriority2 {
   implicit def treeSet[A: JsonEncoder]: JsonEncoder[immutable.TreeSet[A]] = iterable[A, immutable.TreeSet]
 
   implicit def list[A](implicit A: JsonEncoder[A]): JsonEncoder[List[A]] =
-    new JsonEncoder[List[A]] {
+    new JsonEncoder.AbstractJsonEncoder[List[A]] {
       override def isEmpty(as: List[A]): Boolean = as eq Nil
 
       def unsafeEncode(as: List[A], indent: Option[Int], out: Write): Unit =
@@ -537,7 +543,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
   this: JsonEncoder.type =>
 
   implicit def iterable[A, T[X] <: Iterable[X]](implicit A: JsonEncoder[A]): JsonEncoder[T[A]] =
-    new JsonEncoder[T[A]] {
+    new JsonEncoder.AbstractJsonEncoder[T[A]] {
       override def isEmpty(as: T[A]): Boolean = as.isEmpty
 
       def unsafeEncode(as: T[A], indent: Option[Int], out: Write): Unit =
@@ -592,7 +598,7 @@ private[json] trait EncoderLowPriority2 extends EncoderLowPriority3 {
   def keyValueIterable[K, A, T[X, Y] <: Iterable[(X, Y)]](implicit
     K: JsonFieldEncoder[K],
     A: JsonEncoder[A]
-  ): JsonEncoder[T[K, A]] = new JsonEncoder[T[K, A]] {
+  ): JsonEncoder[T[K, A]] = new JsonEncoder.AbstractJsonEncoder[T[K, A]] {
     override def isEmpty(a: T[K, A]): Boolean = a.isEmpty
 
     def unsafeEncode(kvs: T[K, A], indent: Option[Int], out: Write): Unit =
@@ -668,7 +674,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
 
   import java.time._
 
-  implicit val dayOfWeek: JsonEncoder[DayOfWeek] = new JsonEncoder[DayOfWeek] {
+  implicit val dayOfWeek: JsonEncoder[DayOfWeek] = new JsonEncoder.AbstractJsonEncoder[DayOfWeek] {
     def unsafeEncode(a: DayOfWeek, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       out.write(a.toString)
@@ -679,7 +685,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(a.toString))
   }
 
-  implicit val duration: JsonEncoder[Duration] = new JsonEncoder[Duration] {
+  implicit val duration: JsonEncoder[Duration] = new JsonEncoder.AbstractJsonEncoder[Duration] {
     def unsafeEncode(a: Duration, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -690,7 +696,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val instant: JsonEncoder[Instant] = new JsonEncoder[Instant] {
+  implicit val instant: JsonEncoder[Instant] = new JsonEncoder.AbstractJsonEncoder[Instant] {
     def unsafeEncode(a: Instant, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -701,7 +707,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val localDate: JsonEncoder[LocalDate] = new JsonEncoder[LocalDate] {
+  implicit val localDate: JsonEncoder[LocalDate] = new JsonEncoder.AbstractJsonEncoder[LocalDate] {
     def unsafeEncode(a: LocalDate, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -712,7 +718,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val localDateTime: JsonEncoder[LocalDateTime] = new JsonEncoder[LocalDateTime] {
+  implicit val localDateTime: JsonEncoder[LocalDateTime] = new JsonEncoder.AbstractJsonEncoder[LocalDateTime] {
     def unsafeEncode(a: LocalDateTime, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -723,7 +729,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val localTime: JsonEncoder[LocalTime] = new JsonEncoder[LocalTime] {
+  implicit val localTime: JsonEncoder[LocalTime] = new JsonEncoder.AbstractJsonEncoder[LocalTime] {
     def unsafeEncode(a: LocalTime, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -734,7 +740,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val month: JsonEncoder[Month] = new JsonEncoder[Month] {
+  implicit val month: JsonEncoder[Month] = new JsonEncoder.AbstractJsonEncoder[Month] {
     def unsafeEncode(a: Month, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       out.write(a.toString)
@@ -745,7 +751,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(a.toString))
   }
 
-  implicit val monthDay: JsonEncoder[MonthDay] = new JsonEncoder[MonthDay] {
+  implicit val monthDay: JsonEncoder[MonthDay] = new JsonEncoder.AbstractJsonEncoder[MonthDay] {
     def unsafeEncode(a: MonthDay, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -756,7 +762,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val offsetDateTime: JsonEncoder[OffsetDateTime] = new JsonEncoder[OffsetDateTime] {
+  implicit val offsetDateTime: JsonEncoder[OffsetDateTime] = new JsonEncoder.AbstractJsonEncoder[OffsetDateTime] {
     def unsafeEncode(a: OffsetDateTime, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -767,7 +773,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val offsetTime: JsonEncoder[OffsetTime] = new JsonEncoder[OffsetTime] {
+  implicit val offsetTime: JsonEncoder[OffsetTime] = new JsonEncoder.AbstractJsonEncoder[OffsetTime] {
     def unsafeEncode(a: OffsetTime, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -778,7 +784,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val period: JsonEncoder[Period] = new JsonEncoder[Period] {
+  implicit val period: JsonEncoder[Period] = new JsonEncoder.AbstractJsonEncoder[Period] {
     def unsafeEncode(a: Period, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -789,7 +795,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val year: JsonEncoder[Year] = new JsonEncoder[Year] {
+  implicit val year: JsonEncoder[Year] = new JsonEncoder.AbstractJsonEncoder[Year] {
     def unsafeEncode(a: Year, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -800,7 +806,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val yearMonth: JsonEncoder[YearMonth] = new JsonEncoder[YearMonth] {
+  implicit val yearMonth: JsonEncoder[YearMonth] = new JsonEncoder.AbstractJsonEncoder[YearMonth] {
     def unsafeEncode(a: YearMonth, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -811,7 +817,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val zonedDateTime: JsonEncoder[ZonedDateTime] = new JsonEncoder[ZonedDateTime] {
+  implicit val zonedDateTime: JsonEncoder[ZonedDateTime] = new JsonEncoder.AbstractJsonEncoder[ZonedDateTime] {
     def unsafeEncode(a: ZonedDateTime, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -822,7 +828,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val zoneId: JsonEncoder[ZoneId] = new JsonEncoder[ZoneId] {
+  implicit val zoneId: JsonEncoder[ZoneId] = new JsonEncoder.AbstractJsonEncoder[ZoneId] {
     def unsafeEncode(a: ZoneId, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       out.write(a.getId)
@@ -833,7 +839,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(a.getId))
   }
 
-  implicit val zoneOffset: JsonEncoder[ZoneOffset] = new JsonEncoder[ZoneOffset] {
+  implicit val zoneOffset: JsonEncoder[ZoneOffset] = new JsonEncoder.AbstractJsonEncoder[ZoneOffset] {
     def unsafeEncode(a: ZoneOffset, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       serializers.write(a, out)
@@ -844,7 +850,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(serializers.toString(a)))
   }
 
-  implicit val uuid: JsonEncoder[UUID] = new JsonEncoder[UUID] {
+  implicit val uuid: JsonEncoder[UUID] = new JsonEncoder.AbstractJsonEncoder[UUID] {
     def unsafeEncode(a: UUID, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       SafeNumbers.write(a, out)
@@ -855,7 +861,7 @@ private[json] trait EncoderLowPriority3 extends EncoderLowPriority4 {
       new Right(new Json.Str(SafeNumbers.toString(a)))
   }
 
-  implicit val currency: JsonEncoder[java.util.Currency] = new JsonEncoder[java.util.Currency] {
+  implicit val currency: JsonEncoder[java.util.Currency] = new JsonEncoder.AbstractJsonEncoder[java.util.Currency] {
     def unsafeEncode(a: java.util.Currency, indent: Option[Int], out: Write): Unit = {
       out.write('"')
       out.write(a.toString)

--- a/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
+++ b/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
@@ -392,7 +392,7 @@ object Json {
       new Obj(Chunk.single(key -> value))
 
     private lazy val objd                  = JsonDecoder.keyValueChunk[String, Json]
-    implicit val decoder: JsonDecoder[Obj] = new JsonDecoder[Obj] {
+    implicit val decoder: JsonDecoder[Obj] = new JsonDecoder.AbstractJsonDecoder[Obj] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Obj =
         Obj(objd.unsafeDecode(trace, in))
 
@@ -403,7 +403,7 @@ object Json {
         }
     }
     private lazy val obje                  = JsonEncoder.keyValueChunk[String, Json]
-    implicit val encoder: JsonEncoder[Obj] = new JsonEncoder[Obj] {
+    implicit val encoder: JsonEncoder[Obj] = new JsonEncoder.AbstractJsonEncoder[Obj] {
       def unsafeEncode(a: Obj, indent: Option[Int], out: Write): Unit =
         obje.unsafeEncode(a.fields, indent, out)
 
@@ -445,7 +445,7 @@ object Json {
       else new Arr(Chunk(elements: _*))
 
     private lazy val arrd                  = JsonDecoder.chunk[Json]
-    implicit val decoder: JsonDecoder[Arr] = new JsonDecoder[Arr] {
+    implicit val decoder: JsonDecoder[Arr] = new JsonDecoder.AbstractJsonDecoder[Arr] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Arr =
         Arr(arrd.unsafeDecode(trace, in))
 
@@ -456,7 +456,7 @@ object Json {
         }
     }
     private lazy val arre                  = JsonEncoder.chunk[Json]
-    implicit val encoder: JsonEncoder[Arr] = new JsonEncoder[Arr] {
+    implicit val encoder: JsonEncoder[Arr] = new JsonEncoder.AbstractJsonEncoder[Arr] {
       def unsafeEncode(a: Arr, indent: Option[Int], out: Write): Unit =
         arre.unsafeEncode(a.elements, indent, out)
 
@@ -478,7 +478,7 @@ object Json {
       if (value) True
       else False
 
-    implicit val decoder: JsonDecoder[Bool] = new JsonDecoder[Bool] {
+    implicit val decoder: JsonDecoder[Bool] = new JsonDecoder.AbstractJsonDecoder[Bool] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Bool =
         Bool(JsonDecoder.boolean.unsafeDecode(trace, in))
 
@@ -488,7 +488,7 @@ object Json {
           case _       => Lexer.error("Not a bool value", trace)
         }
     }
-    implicit val encoder: JsonEncoder[Bool] = new JsonEncoder[Bool] {
+    implicit val encoder: JsonEncoder[Bool] = new JsonEncoder.AbstractJsonEncoder[Bool] {
       def unsafeEncode(a: Bool, indent: Option[Int], out: Write): Unit =
         JsonEncoder.boolean.unsafeEncode(a.value, indent, out)
 
@@ -502,7 +502,7 @@ object Json {
     override def mapString(f: String => String): Json.Str = new Json.Str(f(value))
   }
   object Str {
-    implicit val decoder: JsonDecoder[Str] = new JsonDecoder[Str] {
+    implicit val decoder: JsonDecoder[Str] = new JsonDecoder.AbstractJsonDecoder[Str] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Str =
         Str(JsonDecoder.string.unsafeDecode(trace, in))
 
@@ -512,7 +512,7 @@ object Json {
           case _      => Lexer.error("Not a string value", trace)
         }
     }
-    implicit val encoder: JsonEncoder[Str] = new JsonEncoder[Str] {
+    implicit val encoder: JsonEncoder[Str] = new JsonEncoder.AbstractJsonEncoder[Str] {
       def unsafeEncode(a: Str, indent: Option[Int], out: Write): Unit =
         JsonEncoder.string.unsafeEncode(a.value, indent, out)
 
@@ -546,7 +546,7 @@ object Json {
     def apply(value: Float): Num  = new Num(new java.math.BigDecimal(SafeNumbers.toString(value)))
     def apply(value: Double): Num = new Num(new java.math.BigDecimal(SafeNumbers.toString(value)))
 
-    implicit val decoder: JsonDecoder[Num] = new JsonDecoder[Num] {
+    implicit val decoder: JsonDecoder[Num] = new JsonDecoder.AbstractJsonDecoder[Num] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Num =
         Num(JsonDecoder.bigDecimal.unsafeDecode(trace, in))
 
@@ -556,7 +556,7 @@ object Json {
           case _      => Lexer.error("Not a number", trace)
         }
     }
-    implicit val encoder: JsonEncoder[Num] = new JsonEncoder[Num] {
+    implicit val encoder: JsonEncoder[Num] = new JsonEncoder.AbstractJsonEncoder[Num] {
       def unsafeEncode(a: Num, indent: Option[Int], out: Write): Unit =
         JsonEncoder.bigDecimal.unsafeEncode(a.value, indent, out)
 
@@ -568,7 +568,7 @@ object Json {
   type Null = Null.type
   case object Null extends Json {
     private[this] val nullChars: Array[Char]     = "null".toCharArray
-    implicit val decoder: JsonDecoder[Null.type] = new JsonDecoder[Null.type] {
+    implicit val decoder: JsonDecoder[Null.type] = new JsonDecoder.AbstractJsonDecoder[Null.type] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): Null.type = {
         Lexer.readChars(trace, in, nullChars, "null")
         Null
@@ -579,7 +579,7 @@ object Json {
         Null
       }
     }
-    implicit val encoder: JsonEncoder[Null.type] = new JsonEncoder[Null.type] {
+    implicit val encoder: JsonEncoder[Null.type] = new JsonEncoder.AbstractJsonEncoder[Null.type] {
       def unsafeEncode(a: Null.type, indent: Option[Int], out: Write): Unit =
         out.write("null")
 
@@ -591,7 +591,7 @@ object Json {
     override def asNull: Some[Unit] = new Some(())
   }
 
-  implicit val decoder: JsonDecoder[Json] = new JsonDecoder[Json] {
+  implicit val decoder: JsonDecoder[Json] = new JsonDecoder.AbstractJsonDecoder[Json] {
     def unsafeDecode(trace: List[JsonError], in: RetractReader): Json = {
       val c = in.nextNonWhitespace()
       in.retract()
@@ -611,7 +611,7 @@ object Json {
     override final def unsafeFromJsonAST(trace: List[JsonError], json: Json): Json =
       json
   }
-  implicit val encoder: JsonEncoder[Json] = new JsonEncoder[Json] {
+  implicit val encoder: JsonEncoder[Json] = new JsonEncoder.AbstractJsonEncoder[Json] {
     def unsafeEncode(a: Json, indent: Option[Int], out: Write): Unit =
       a match {
         case j: Obj  => Obj.encoder.unsafeEncode(j, indent, out)


### PR DESCRIPTION
Add abstract classes in companion objects that extend the traits. Using these instead of the traits directly prevents re-implementing default methods in each anonymous class, reducing class file size.

Measured ~20% reduction in compiled bytecode for zio-json-jvm.