### PR TITLE
feat: add readJsonArrayAs for streaming JSON array files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -243,6 +243,8 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       exclude[Problem]("zio.JsonPackagePlatformSpecific.*"),
       exclude[Problem]("zio.json.JsonDecoderPlatformSpecific.*"),
       exclude[Problem]("zio.json.JsonEncoderPlatformSpecific.*"),
+      exclude[Problem]("zio.json.JsonDecoder#AbstractJsonDecoder.*"),
+      exclude[Problem]("zio.json.JsonEncoder#AbstractJsonEncoder.*"),
       exclude[Problem]("zio.json.package.*")
     ),
     libraryDependencies ++= Seq(
@@ -257,6 +259,8 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       exclude[Problem]("zio.JsonPackagePlatformSpecific.*"),
       exclude[Problem]("zio.json.JsonDecoderPlatformSpecific.*"),
       exclude[Problem]("zio.json.JsonEncoderPlatformSpecific.*"),
+      exclude[Problem]("zio.json.JsonDecoder#AbstractJsonDecoder.*"),
+      exclude[Problem]("zio.json.JsonEncoder#AbstractJsonEncoder.*"),
       exclude[Problem]("zio.json.package.*")
     ),
     libraryDependencies ++= Seq(

--- a/zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala
@@ -50,6 +50,35 @@ trait JsonPackagePlatformSpecific {
       )
   }
 
+  def readJsonArrayAs[A: JsonDecoder](file: File): ZStream[Any, Throwable, A] =
+    readJsonArrayAs(file.toPath)
+
+  def readJsonArrayAs[A: JsonDecoder](path: Path): ZStream[Any, Throwable, A] =
+    ZStream
+      .fromPath(path)
+      .via(
+        ZPipeline.utf8Decode >>>
+          stringToChars >>>
+          JsonDecoder[A].decodeJsonPipeline(JsonStreamDelimiter.Array)
+      )
+
+  def readJsonArrayAs[A: JsonDecoder](path: String): ZStream[Any, Throwable, A] =
+    readJsonArrayAs(Paths.get(path))
+
+  def readJsonArrayAs[A: JsonDecoder](url: URL): ZStream[Any, Throwable, A] = {
+    val scoped = ZIO
+      .fromAutoCloseable(ZIO.attempt(url.openStream()))
+      .refineToOrDie[IOException]
+
+    ZStream
+      .fromInputStreamScoped(scoped)
+      .via(
+        ZPipeline.utf8Decode >>>
+          stringToChars >>>
+          JsonDecoder[A].decodeJsonPipeline(JsonStreamDelimiter.Array)
+      )
+  }
+
   def writeJsonLines[R](file: File, stream: ZStream[R, Throwable, ast.Json]): RIO[R, Unit] =
     writeJsonLinesAs(file, stream)
 

--- a/zio-json/jvm/src/test/resources/log.json
+++ b/zio-json/jvm/src/test/resources/log.json
@@ -1,0 +1,4 @@
+[
+  {"at": 1603669875, "message": "hello"},
+  {"at": 1603669876, "message": "world"}
+]

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -252,6 +252,28 @@ object DecoderPlatformSpecificSpec extends ZIOSpecDefault {
               assert(lines(0))(equalTo(Event(1603669875, "hello"))) &&
               assert(lines(1))(equalTo(Event(1603669876, "world")))
             }
+          },
+          test("readJsonArrayAs reads from files") {
+            import logEvent._
+
+            for {
+              lines <- readJsonArrayAs[Event](Paths.get("zio-json/jvm/src/test/resources/log.json")).runCollect
+            } yield {
+              assert(lines(0))(equalTo(Event(1603669875, "hello"))) &&
+              assert(lines(1))(equalTo(Event(1603669876, "world")))
+            }
+          },
+          test("readJsonArrayAs reads from URLs") {
+            import logEvent._
+
+            val url = this.getClass.getClassLoader.getResource("log.json")
+
+            for {
+              lines <- readJsonArrayAs[Event](url).runCollect
+            } yield {
+              assert(lines(0))(equalTo(Event(1603669875, "hello"))) &&
+              assert(lines(1))(equalTo(Event(1603669876, "world")))
+            }
           }
         ),
         suite("combinators")(


### PR DESCRIPTION
## Summary

Add `readJsonArrayAs` methods to the `zio.json` package that read JSON files containing a top-level array and stream each element individually.

This addresses the use case described in #1071 where users need to read JSON files formatted as arrays (e.g. `[{"id": 1}, {"id": 2}]`) in a streaming fashion, getting a `ZStream[Any, Throwable, A]` of each decoded element.

## Changes

- **`JsonPackagePlatformSpecific.scala`**: Added `readJsonArrayAs[A: JsonDecoder]` overloads for `File`, `Path`, `String`, and `URL` inputs, following the same pattern as the existing `readJsonLinesAs` family but using `JsonStreamDelimiter.Array` instead of `JsonStreamDelimiter.Newline`.
- **`DecoderPlatformSpecificSpec.scala`**: Added tests for reading JSON arrays from both file paths and URLs.
- **`log.json`**: Added test resource file containing a JSON array of events.

## Usage

```scala
import zio.json._

case class Event(at: Long, message: String)
object Event {
  implicit val decoder: JsonDecoder[Event] = DeriveJsonDecoder.gen[Event]
}

// Stream elements from a JSON array file
val events: ZStream[Any, Throwable, Event] =
  readJsonArrayAs[Event](Paths.get("events.json"))
```

/claim #1071