### PR TITLE
Use Trusted Publishing (OIDC) for Publishing Docs to NPM‌ Registry

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -30,29 +30,40 @@ jobs:
       run: sbt  +publishLocal
     - name: Check website build process
       run: sbt docs/clean; sbt  docs/buildWebsite
-  publish-docs:
-    name: Publish Docs
+  release-docs:
+    name: Release Docs
     runs-on: ubuntu-latest
+    continue-on-error: false
+    needs:
+      - release
     if: ${{ ((github.event_name == 'release') && (github.event.action == 'published')) || (github.event_name == 'workflow_dispatch') }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
-    - name: Git Checkout
-      uses: actions/checkout@v6.0.2
-      with:
-        fetch-depth: '0'
-    - name: Setup Action
-      uses: coursier/setup-action@v2
-      with:
-        jvm: temurin:17
-        apps: sbt
-    - name: Setup NodeJs
-      uses: actions/setup-node@v6
-      with:
-        node-version: 16.x
-        registry-url: https://registry.npmjs.org
-    - name: Publish Docs to NPM Registry
-      run: sbt  docs/publishToNpm
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Git Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: '0'
+      - name: Install libuv
+        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
+      - name: Setup Scala
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: '17'
+          check-latest: true
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
+      - name: Cache Dependencies
+        uses: coursier/cache-action@v7
+      - name: Setup NodeJs
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.12.0
+          registry-url: https://registry.npmjs.org
+      - name: Publish Docs to NPM Registry
+        run: sbt docs/publishToNpm
   generate-readme:
     name: Generate README
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the documentation publishing workflow in `.github/workflows/site.yml` to improve reliability, security, and compatibility. The main changes involve renaming the job, updating setup steps, and enhancing the environment for building and releasing documentation.

**Workflow improvements and job renaming:**

* Renamed the `publish-docs` job to `release-docs` and updated its trigger and dependencies to ensure it only runs after a release or manual dispatch, and only after the `release` job completes.

**Environment and setup enhancements:**

* Added steps to install `libuv1-dev`, updated Java setup to use `actions/setup-java` with Corretto 17, and added a dedicated SBT setup step for improved environment consistency.
* Updated Node.js setup to use version `24.12.0` (was `16.x`) for compatibility with the latest tooling.

**Security and caching:**

* Added explicit permissions for `id-token: write` and `contents: read` to enhance security during the release process.
* Introduced dependency caching with `coursier/cache-action` to speed up builds.