### PR TITLE
Fix MiMa check for JS and Native platforms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -243,6 +243,10 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       exclude[Problem]("zio.JsonPackagePlatformSpecific.*"),
       exclude[Problem]("zio.json.JsonDecoderPlatformSpecific.*"),
       exclude[Problem]("zio.json.JsonEncoderPlatformSpecific.*"),
+      exclude[Problem]("zio.json.JsonDecoder#AbstractJsonDecoder.decodeJsonStream*"),
+      exclude[Problem]("zio.json.JsonDecoder#AbstractJsonDecoder.decodeJsonPipeline*"),
+      exclude[Problem]("zio.json.JsonEncoder#AbstractJsonEncoder.encodeJson*Pipeline"),
+      exclude[Problem]("zio.json.JsonEncoder#AbstractJsonEncoder.encodeJsonStream"),
       exclude[Problem]("zio.json.package.*")
     ),
     libraryDependencies ++= Seq(
@@ -257,6 +261,10 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       exclude[Problem]("zio.JsonPackagePlatformSpecific.*"),
       exclude[Problem]("zio.json.JsonDecoderPlatformSpecific.*"),
       exclude[Problem]("zio.json.JsonEncoderPlatformSpecific.*"),
+      exclude[Problem]("zio.json.JsonDecoder#AbstractJsonDecoder.decodeJsonStream*"),
+      exclude[Problem]("zio.json.JsonDecoder#AbstractJsonDecoder.decodeJsonPipeline*"),
+      exclude[Problem]("zio.json.JsonEncoder#AbstractJsonEncoder.encodeJson*Pipeline"),
+      exclude[Problem]("zio.json.JsonEncoder#AbstractJsonEncoder.encodeJsonStream"),
       exclude[Problem]("zio.json.package.*")
     ),
     libraryDependencies ++= Seq(


### PR DESCRIPTION
## Summary

- Add MiMa binary compatibility filters for JVM-only stream methods (`decodeJsonStream`, `decodeJsonPipeline`, `encodeJsonStream`, `encodeJsonLinesPipeline`, `encodeJsonArrayPipeline`) on `AbstractJsonDecoder` and `AbstractJsonEncoder` that don't exist on JS/Native platforms
- Fixes the `mima_check` CI failure visible in #1557

## Test plan

- [x] `mima_check` CI job passes