### PR TITLE
Add enumeratum interop

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,17 +36,17 @@ addCommandAlias("prepare", "fmt")
 
 addCommandAlias(
   "testJVM",
-  "zioJsonJVM/test; zioJsonYaml/test; zioJsonInteropHttp4s/test; zioJsonGolden/test; zioJsonInteropRefinedJVM/test"
+  "zioJsonJVM/test; zioJsonYaml/test; zioJsonInteropHttp4s/test; zioJsonGolden/test; zioJsonInteropRefinedJVM/test; zioJsonInteropEnumeratumJVM/test"
 )
 
 addCommandAlias(
   "testJS",
-  "zioJsonJS/test; zioJsonInteropRefinedJS/test"
+  "zioJsonJS/test; zioJsonInteropRefinedJS/test; zioJsonInteropEnumeratumJS/test"
 )
 
 addCommandAlias(
   "testNative",
-  "zioJsonNative/test; zioJsonInteropRefinedNative/test"
+  "zioJsonNative/test; zioJsonInteropRefinedNative/test; zioJsonInteropEnumeratumNative/test"
 )
 
 addCommandAlias(
@@ -90,6 +90,9 @@ lazy val zioJsonRoot = project
     zioJsonInteropScalaz7x.js,
     zioJsonInteropScalaz7x.jvm,
     zioJsonInteropScalaz7x.native,
+    zioJsonInteropEnumeratum.js,
+    zioJsonInteropEnumeratum.jvm,
+    zioJsonInteropEnumeratum.native,
     zioJsonGolden
   )
 
@@ -389,6 +392,25 @@ lazy val zioJsonInteropScalaz7x = crossProject(JSPlatform, JVMPlatform, NativePl
   )
   .enablePlugins(BuildInfoPlugin)
 
+lazy val zioJsonInteropEnumeratum = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .in(file("zio-json-interop-enumeratum"))
+  .dependsOn(zioJson)
+  .settings(stdSettings("zio-json-interop-enumeratum"))
+  .settings(buildInfoSettings("zio.json.interop.enumeratum"))
+  .settings(
+    scalacOptions ++= {
+      if (scalaVersion.value == Scala3) Seq("-Yretain-trees") else Seq.empty
+    },
+    libraryDependencies ++= Seq(
+      "com.beachape" %%% "enumeratum"   % "1.9.7",
+      "dev.zio"      %%% "zio-test"     % zioVersion % Test,
+      "dev.zio"      %%% "zio-test-sbt" % zioVersion % Test
+    ),
+    mimaPreviousArtifacts := Set(),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+  )
+  .enablePlugins(BuildInfoPlugin)
+
 lazy val docs = project
   .in(file("zio-json-docs"))
   .dependsOn(
@@ -398,7 +420,8 @@ lazy val docs = project
     zioJsonMacrosJVM,
     zioJsonInteropHttp4s,
     zioJsonInteropRefined.jvm,
-    zioJsonInteropScalaz7x.jvm
+    zioJsonInteropScalaz7x.jvm,
+    zioJsonInteropEnumeratum.jvm
   )
   .settings(
     crossScalaVersions -= Scala3,
@@ -414,6 +437,7 @@ lazy val docs = project
       zioJsonInteropHttp4s,
       zioJsonInteropRefined.jvm,
       zioJsonInteropScalaz7x.jvm,
+      zioJsonInteropEnumeratum.jvm,
       zioJsonGolden
     ),
     mimaPreviousArtifacts := Set(),

--- a/docs/interop/enumeratum.md
+++ b/docs/interop/enumeratum.md
@@ -1,0 +1,100 @@
+---
+id: enumeratum
+title: "Enumeratum Interop"
+---
+
+## Installation
+
+```scala
+libraryDependencies ++= Seq(
+  "dev.zio" %% "zio-json-interop-enumeratum" % "@VERSION@"
+)
+```
+
+## Imports
+
+Unlike other interop modules which require a `zio.json.interop.*` import (e.g. `import zio.json.interop.refined._`), the enumeratum integration lives in the `enumeratum` package itself. The traits are available directly via the standard enumeratum imports:
+
+```scala
+import enumeratum._         // for string enums (ZioJsonEnum, ZioJsonKeyEnum)
+import enumeratum.values._  // for value enums (IntZioJsonEnum, LongZioJsonEnum, etc.)
+```
+
+## String Enums
+
+Mix in `ZioJsonEnum` to get implicit `JsonEncoder` and `JsonDecoder` instances for your enum entries. Add `ZioJsonKeyEnum` if you also need to use them as JSON object keys.
+
+```scala
+import enumeratum._
+import zio.json._
+
+sealed trait ShirtSize extends EnumEntry
+
+case object ShirtSize extends Enum[ShirtSize] with ZioJsonEnum[ShirtSize] with ZioJsonKeyEnum[ShirtSize] {
+  case object Small  extends ShirtSize
+  case object Medium extends ShirtSize
+  case object Large  extends ShirtSize
+
+  val values = findValues
+}
+```
+
+```scala
+ShirtSize.Small.toJson
+// "Small"
+
+""""Large"""".fromJson[ShirtSize]
+// Right(Large)
+
+""""XLarge"""".fromJson[ShirtSize]
+// Left('XLarge' is not a member of enum ShirtSize)
+```
+
+Lowercase/uppercase encoders and decoders are also available:
+
+```scala
+implicit val enc: JsonEncoder[ShirtSize] = ZioJson.encoderLowercase(ShirtSize)
+implicit val dec: JsonDecoder[ShirtSize] = ZioJson.decoderLowercaseOnly(ShirtSize)
+```
+
+## Value Enums
+
+For value-based enums (`IntEnum`, `LongEnum`, `StringEnum`, etc.), mix in the corresponding trait:
+
+| Value Type | Trait                |
+|------------|----------------------|
+| `Int`      | `IntZioJsonEnum`     |
+| `Long`     | `LongZioJsonEnum`    |
+| `Short`    | `ShortZioJsonEnum`   |
+| `String`   | `StringZioJsonEnum`  |
+| `Char`     | `CharZioJsonEnum`    |
+| `Byte`     | `ByteZioJsonEnum`    |
+
+Each trait provides implicit `JsonEncoder`, `JsonDecoder`, `JsonFieldEncoder`, and `JsonFieldDecoder` instances.
+
+```scala
+import enumeratum.values._
+import zio.json._
+
+sealed abstract class LibraryItem(val value: Int, val name: String) extends IntEnumEntry
+
+case object LibraryItem extends IntEnum[LibraryItem] with IntZioJsonEnum[LibraryItem] {
+  case object Book     extends LibraryItem(value = 1, name = "book")
+  case object Movie    extends LibraryItem(value = 2, name = "movie")
+  case object Magazine extends LibraryItem(value = 3, name = "magazine")
+  case object CD       extends LibraryItem(value = 4, name = "cd")
+
+  val values = findValues
+}
+```
+
+```scala
+LibraryItem.Book.toJson
+// 1
+
+"3".fromJson[LibraryItem]
+// Right(Magazine)
+
+"999".fromJson[LibraryItem]
+// Left('999' is not a member of enum LibraryItem)
+```

--- a/docs/interop/index.md
+++ b/docs/interop/index.md
@@ -3,9 +3,10 @@ id: index
 title: "Interop modules"
 ---
 
-Integrations are provided several popular libraries, which are published as separate artifacts:
+Integrations are provided for several popular libraries, which are published as separate artifacts:
 
 * [Akka Http](akka-http.md)
+* [Enumeratum](enumeratum.md)
 * [HTTP4s](http4s.md)
 * [Refined](refined.md)
 * [Scalaz 7.x](scalaz-7x.md)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -19,6 +19,7 @@ const sidebars = {
           collapsed: true,
           items: [
             "interop/akka-http",
+            "interop/enumeratum",
             "interop/http4s",
             "interop/refined",
             "interop/scalaz-7x"

--- a/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/ZioJson.scala
+++ b/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/ZioJson.scala
@@ -1,0 +1,42 @@
+package enumeratum
+
+import zio.json.{ JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder }
+
+object ZioJson {
+
+  def encoder[A <: EnumEntry](@annotation.unused e: Enum[A]): JsonEncoder[A] =
+    stringEncoder.contramap(_.entryName)
+
+  def encoderLowercase[A <: EnumEntry](@annotation.unused e: Enum[A]): JsonEncoder[A] =
+    stringEncoder.contramap(_.entryName.toLowerCase)
+
+  def encoderUppercase[A <: EnumEntry](@annotation.unused e: Enum[A]): JsonEncoder[A] =
+    stringEncoder.contramap(_.entryName.toUpperCase)
+
+  def decoder[A <: EnumEntry](e: Enum[A]): JsonDecoder[A] =
+    stringDecoder.mapOrFail(s => fromOption(e.withNameOption(s), s, e.toString))
+
+  def decoderLowercaseOnly[A <: EnumEntry](e: Enum[A]): JsonDecoder[A] =
+    stringDecoder.mapOrFail(s => fromOption(e.withNameLowercaseOnlyOption(s), s, e.toString))
+
+  def decoderUppercaseOnly[A <: EnumEntry](e: Enum[A]): JsonDecoder[A] =
+    stringDecoder.mapOrFail(s => fromOption(e.withNameUppercaseOnlyOption(s), s, e.toString))
+
+  def decoderCaseInsensitive[A <: EnumEntry](e: Enum[A]): JsonDecoder[A] =
+    stringDecoder.mapOrFail(s => fromOption(e.withNameInsensitiveOption(s), s, e.toString))
+
+  def keyEncoder[A <: EnumEntry](@annotation.unused e: Enum[A]): JsonFieldEncoder[A] =
+    stringFieldEncoder.contramap(_.entryName)
+
+  def keyDecoder[A <: EnumEntry](e: Enum[A]): JsonFieldDecoder[A] =
+    stringFieldDecoder.mapOrFail(s => fromOption(e.withNameOption(s), s, e.toString))
+
+  private[enumeratum] def fromOption[A](opt: Option[A], input: String, enumName: String): Either[String, A] =
+    opt.toRight(s"'$input' is not a member of enum $enumName")
+
+  private val stringEncoder      = JsonEncoder[String]
+  private val stringDecoder      = JsonDecoder[String]
+  private val stringFieldEncoder = JsonFieldEncoder[String]
+  private val stringFieldDecoder = JsonFieldDecoder[String]
+
+}

--- a/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/ZioJsonEnum.scala
+++ b/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/ZioJsonEnum.scala
@@ -1,0 +1,45 @@
+package enumeratum
+
+import zio.json.{ JsonDecoder, JsonEncoder }
+
+/**
+ * Helper trait that adds implicit zio-json encoders and decoders for an [[Enum]]'s members
+ *
+ * Example:
+ *
+ * {{{
+ * scala> import enumeratum._
+ * scala> import zio.json._
+ *
+ * scala> sealed trait ShirtSize extends EnumEntry
+ * scala> case object ShirtSize extends Enum[ShirtSize] with ZioJsonEnum[ShirtSize] {
+ *     |  case object Small  extends ShirtSize
+ *     |  case object Medium extends ShirtSize
+ *     |  case object Large  extends ShirtSize
+ *     |  val values = findValues
+ *     | }
+ *
+ * scala> val size: ShirtSize = ShirtSize.Small
+ *
+ * scala> size.toJson
+ * res0: String = "Small"
+ *
+ * scala> """"Large"""".fromJson[ShirtSize]
+ * res1: Either[String, ShirtSize] = Right(Large)
+ *
+ * scala> """"XLarge"""".fromJson[ShirtSize]
+ * res2: Either[String, ShirtSize] = Left('XLarge' is not a member of enum ShirtSize)
+ * }}}
+ */
+trait ZioJsonEnum[A <: EnumEntry] { this: Enum[A] =>
+
+  /**
+   * Implicit JsonEncoder for this enum
+   */
+  implicit val zioJsonEncoder: JsonEncoder[A] = ZioJson.encoder(this)
+
+  /**
+   * Implicit JsonDecoder for this enum
+   */
+  implicit val zioJsonDecoder: JsonDecoder[A] = ZioJson.decoder(this)
+}

--- a/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/ZioJsonKeyEnum.scala
+++ b/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/ZioJsonKeyEnum.scala
@@ -1,0 +1,12 @@
+package enumeratum
+
+import zio.json.{ JsonFieldDecoder, JsonFieldEncoder }
+
+/**
+ * Helper trait that adds implicit zio-json JsonFieldEncoder/JsonFieldDecoder for an [[Enum]]'s members, allowing them
+ * to be used as JSON object keys.
+ */
+trait ZioJsonKeyEnum[A <: EnumEntry] { this: Enum[A] =>
+  implicit val zioJsonKeyEncoder: JsonFieldEncoder[A] = ZioJson.keyEncoder(this)
+  implicit val zioJsonKeyDecoder: JsonFieldDecoder[A] = ZioJson.keyDecoder(this)
+}

--- a/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/values/ZioJson.scala
+++ b/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/values/ZioJson.scala
@@ -1,0 +1,27 @@
+package enumeratum.values
+
+import zio.json.{ JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder }
+
+object ZioJson {
+
+  def encoder[ValueType: JsonEncoder, EntryType <: ValueEnumEntry[ValueType]](
+    @annotation.unused e: ValueEnum[ValueType, EntryType]
+  ): JsonEncoder[EntryType] =
+    JsonEncoder[ValueType].contramap(_.value)
+
+  def decoder[ValueType: JsonDecoder, EntryType <: ValueEnumEntry[ValueType]](
+    e: ValueEnum[ValueType, EntryType]
+  ): JsonDecoder[EntryType] =
+    JsonDecoder[ValueType].mapOrFail(v => enumeratum.ZioJson.fromOption(e.withValueOpt(v), v.toString, e.toString))
+
+  def keyEncoder[ValueType, EntryType <: ValueEnumEntry[ValueType]](
+    @annotation.unused e: ValueEnum[ValueType, EntryType]
+  )(implicit fe: JsonFieldEncoder[ValueType]): JsonFieldEncoder[EntryType] =
+    fe.contramap(_.value)
+
+  def keyDecoder[ValueType, EntryType <: ValueEnumEntry[ValueType]](
+    e: ValueEnum[ValueType, EntryType]
+  )(implicit fd: JsonFieldDecoder[ValueType]): JsonFieldDecoder[EntryType] =
+    fd.mapOrFail(v => enumeratum.ZioJson.fromOption(e.withValueOpt(v), v.toString, e.toString))
+
+}

--- a/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/values/ZioJsonFieldInstances.scala
+++ b/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/values/ZioJsonFieldInstances.scala
@@ -1,0 +1,42 @@
+package enumeratum.values
+
+import zio.json.{ JsonError, JsonFieldDecoder, JsonFieldEncoder }
+import zio.json.internal.Lexer
+
+private[enumeratum] object ZioJsonFieldInstances {
+
+  implicit val shortFieldEncoder: JsonFieldEncoder[Short] = new JsonFieldEncoder[Short] {
+    def unsafeEncodeField(in: Short): String = in.toString
+  }
+
+  implicit val shortFieldDecoder: JsonFieldDecoder[Short] = new JsonFieldDecoder[Short] {
+    def unsafeDecodeField(trace: List[JsonError], in: String): Short =
+      try in.toShort
+      catch {
+        case _: NumberFormatException => Lexer.error(s"Invalid Short: $in", trace)
+      }
+  }
+
+  implicit val byteFieldEncoder: JsonFieldEncoder[Byte] = new JsonFieldEncoder[Byte] {
+    def unsafeEncodeField(in: Byte): String = in.toString
+  }
+
+  implicit val byteFieldDecoder: JsonFieldDecoder[Byte] = new JsonFieldDecoder[Byte] {
+    def unsafeDecodeField(trace: List[JsonError], in: String): Byte =
+      try in.toByte
+      catch {
+        case _: NumberFormatException => Lexer.error(s"Invalid Byte: $in", trace)
+      }
+  }
+
+  implicit val charFieldEncoder: JsonFieldEncoder[Char] = new JsonFieldEncoder[Char] {
+    def unsafeEncodeField(in: Char): String = in.toString
+  }
+
+  implicit val charFieldDecoder: JsonFieldDecoder[Char] = new JsonFieldDecoder[Char] {
+    def unsafeDecodeField(trace: List[JsonError], in: String): Char =
+      if (in.length == 1) in.charAt(0)
+      else Lexer.error(s"Invalid Char: $in", trace)
+  }
+
+}

--- a/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/values/ZioJsonValueEnum.scala
+++ b/zio-json-interop-enumeratum/shared/src/main/scala/enumeratum/values/ZioJsonValueEnum.scala
@@ -1,0 +1,120 @@
+package enumeratum.values
+
+import zio.json.{ JsonDecoder, JsonEncoder, JsonFieldDecoder, JsonFieldEncoder }
+
+trait ZioJsonValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
+  this: ValueEnum[ValueType, EntryType] =>
+
+  /**
+   * Implicit JsonEncoder for this enum
+   */
+  implicit def zioJsonEncoder: JsonEncoder[EntryType]
+
+  /**
+   * Implicit JsonDecoder for this enum
+   */
+  implicit def zioJsonDecoder: JsonDecoder[EntryType]
+
+  /**
+   * Implicit JsonFieldEncoder for this enum
+   */
+  implicit def zioJsonKeyEncoder: JsonFieldEncoder[EntryType]
+
+  /**
+   * Implicit JsonFieldDecoder for this enum
+   */
+  implicit def zioJsonKeyDecoder: JsonFieldDecoder[EntryType]
+}
+
+/**
+ * ZioJsonValueEnum for IntEnumEntry
+ *
+ * {{{
+ * scala> import enumeratum.values._
+ * scala> import zio.json._
+ *
+ * scala> sealed abstract class ShirtSize(val value: Int) extends IntEnumEntry
+ * scala> case object ShirtSize extends IntEnum[ShirtSize] with IntZioJsonEnum[ShirtSize] {
+ *     |  case object Small  extends ShirtSize(1)
+ *     |  case object Medium extends ShirtSize(2)
+ *     |  case object Large  extends ShirtSize(3)
+ *     |  val values = findValues
+ *     | }
+ *
+ * scala> val size: ShirtSize = ShirtSize.Small
+ *
+ * scala> size.toJson
+ * res0: String = 1
+ *
+ * scala> "3".fromJson[ShirtSize]
+ * res1: Either[String, ShirtSize] = Right(Large)
+ *
+ * scala> "10".fromJson[ShirtSize]
+ * res2: Either[String, ShirtSize] = Left('10' is not a member of enum ShirtSize)
+ * }}}
+ */
+trait IntZioJsonEnum[EntryType <: IntEnumEntry] extends ZioJsonValueEnum[Int, EntryType] {
+  this: ValueEnum[Int, EntryType] =>
+  implicit val zioJsonEncoder: JsonEncoder[EntryType]         = ZioJson.encoder(this)
+  implicit val zioJsonDecoder: JsonDecoder[EntryType]         = ZioJson.decoder(this)
+  implicit val zioJsonKeyEncoder: JsonFieldEncoder[EntryType] = ZioJson.keyEncoder(this)
+  implicit val zioJsonKeyDecoder: JsonFieldDecoder[EntryType] = ZioJson.keyDecoder(this)
+}
+
+/**
+ * ZioJsonValueEnum for LongEnumEntry
+ */
+trait LongZioJsonEnum[EntryType <: LongEnumEntry] extends ZioJsonValueEnum[Long, EntryType] {
+  this: ValueEnum[Long, EntryType] =>
+  implicit val zioJsonEncoder: JsonEncoder[EntryType]         = ZioJson.encoder(this)
+  implicit val zioJsonDecoder: JsonDecoder[EntryType]         = ZioJson.decoder(this)
+  implicit val zioJsonKeyEncoder: JsonFieldEncoder[EntryType] = ZioJson.keyEncoder(this)
+  implicit val zioJsonKeyDecoder: JsonFieldDecoder[EntryType] = ZioJson.keyDecoder(this)
+}
+
+/**
+ * ZioJsonValueEnum for ShortEnumEntry
+ */
+trait ShortZioJsonEnum[EntryType <: ShortEnumEntry] extends ZioJsonValueEnum[Short, EntryType] {
+  this: ValueEnum[Short, EntryType] =>
+  import ZioJsonFieldInstances._
+  implicit val zioJsonEncoder: JsonEncoder[EntryType]         = ZioJson.encoder(this)
+  implicit val zioJsonDecoder: JsonDecoder[EntryType]         = ZioJson.decoder(this)
+  implicit val zioJsonKeyEncoder: JsonFieldEncoder[EntryType] = ZioJson.keyEncoder(this)
+  implicit val zioJsonKeyDecoder: JsonFieldDecoder[EntryType] = ZioJson.keyDecoder(this)
+}
+
+/**
+ * ZioJsonValueEnum for StringEnumEntry
+ */
+trait StringZioJsonEnum[EntryType <: StringEnumEntry] extends ZioJsonValueEnum[String, EntryType] {
+  this: ValueEnum[String, EntryType] =>
+  implicit val zioJsonEncoder: JsonEncoder[EntryType]         = ZioJson.encoder(this)
+  implicit val zioJsonDecoder: JsonDecoder[EntryType]         = ZioJson.decoder(this)
+  implicit val zioJsonKeyEncoder: JsonFieldEncoder[EntryType] = ZioJson.keyEncoder(this)
+  implicit val zioJsonKeyDecoder: JsonFieldDecoder[EntryType] = ZioJson.keyDecoder(this)
+}
+
+/**
+ * ZioJsonValueEnum for CharEnumEntry
+ */
+trait CharZioJsonEnum[EntryType <: CharEnumEntry] extends ZioJsonValueEnum[Char, EntryType] {
+  this: ValueEnum[Char, EntryType] =>
+  import ZioJsonFieldInstances._
+  implicit val zioJsonEncoder: JsonEncoder[EntryType]         = ZioJson.encoder(this)
+  implicit val zioJsonDecoder: JsonDecoder[EntryType]         = ZioJson.decoder(this)
+  implicit val zioJsonKeyEncoder: JsonFieldEncoder[EntryType] = ZioJson.keyEncoder(this)
+  implicit val zioJsonKeyDecoder: JsonFieldDecoder[EntryType] = ZioJson.keyDecoder(this)
+}
+
+/**
+ * ZioJsonValueEnum for ByteEnumEntry
+ */
+trait ByteZioJsonEnum[EntryType <: ByteEnumEntry] extends ZioJsonValueEnum[Byte, EntryType] {
+  this: ValueEnum[Byte, EntryType] =>
+  import ZioJsonFieldInstances._
+  implicit val zioJsonEncoder: JsonEncoder[EntryType]         = ZioJson.encoder(this)
+  implicit val zioJsonDecoder: JsonDecoder[EntryType]         = ZioJson.decoder(this)
+  implicit val zioJsonKeyEncoder: JsonFieldEncoder[EntryType] = ZioJson.keyEncoder(this)
+  implicit val zioJsonKeyDecoder: JsonFieldDecoder[EntryType] = ZioJson.keyDecoder(this)
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/ZioJsonKeySpec.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/ZioJsonKeySpec.scala
@@ -1,0 +1,38 @@
+package enumeratum
+
+import zio.json._
+import zio.test._
+
+object ZioJsonKeySpec extends ZIOSpecDefault {
+
+  def spec = suite("ZioJsonKey")(
+    suite("to JSON")(
+      test("should work") {
+        assertTrue(
+          Map(ZioJsonShirtSize.Small -> 5, ZioJsonShirtSize.Large -> 10).toJson
+            .fromJson[Map[String, Int]] == Right(Map("Small" -> 5, "Large" -> 10))
+        )
+      }
+    ),
+    suite("from JSON")(
+      test("should work") {
+        assertTrue(
+          """{"Medium":100,"Large":15}"""
+            .fromJson[Map[ZioJsonShirtSize, Int]] == Right(
+            Map[ZioJsonShirtSize, Int](
+              ZioJsonShirtSize.Medium -> 100,
+              ZioJsonShirtSize.Large  -> 15
+            )
+          )
+        )
+      },
+      test("should fail for invalid keys") {
+        assertTrue(
+          """{"XXL":100}""".fromJson[Map[ZioJsonShirtSize, Int]] ==
+            Left(".XXL('XXL' is not a member of enum ZioJsonShirtSize)")
+        )
+      }
+    )
+  )
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/ZioJsonShirtSize.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/ZioJsonShirtSize.scala
@@ -1,0 +1,16 @@
+package enumeratum
+
+sealed trait ZioJsonShirtSize extends EnumEntry
+
+case object ZioJsonShirtSize
+    extends ZioJsonEnum[ZioJsonShirtSize]
+    with ZioJsonKeyEnum[ZioJsonShirtSize]
+    with Enum[ZioJsonShirtSize] {
+
+  case object Small  extends ZioJsonShirtSize
+  case object Medium extends ZioJsonShirtSize
+  case object Large  extends ZioJsonShirtSize
+
+  val values = findValues
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/ZioJsonSpec.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/ZioJsonSpec.scala
@@ -1,0 +1,123 @@
+package enumeratum
+
+import zio.json._
+import zio.test._
+
+object ZioJsonSpec extends ZIOSpecDefault {
+
+  def spec = suite("ZioJson")(
+    suite("to JSON")(
+      test("should work") {
+        assertTrue(
+          ZioJsonShirtSize.values.forall(entry => entry.toJson == s""""${entry.entryName}"""")
+        )
+      },
+      test("should work for lower case") {
+        implicit val enc: JsonEncoder[ZioJsonShirtSize] =
+          ZioJson.encoderLowercase(ZioJsonShirtSize)
+        assertTrue(
+          ZioJsonShirtSize.values.forall(entry => entry.toJson == s""""${entry.entryName.toLowerCase}"""")
+        )
+      },
+      test("should work for upper case") {
+        implicit val enc: JsonEncoder[ZioJsonShirtSize] =
+          ZioJson.encoderUppercase(ZioJsonShirtSize)
+        assertTrue(
+          ZioJsonShirtSize.values.forall(entry => entry.toJson == s""""${entry.entryName.toUpperCase}"""")
+        )
+      }
+    ),
+    suite("round-trip")(
+      test("should encode and decode lowercase") {
+        implicit val enc: JsonEncoder[ZioJsonShirtSize] =
+          ZioJson.encoderLowercase(ZioJsonShirtSize)
+        implicit val dec: JsonDecoder[ZioJsonShirtSize] =
+          ZioJson.decoderLowercaseOnly(ZioJsonShirtSize)
+        assertTrue(
+          ZioJsonShirtSize.values.forall(entry => entry.toJson.fromJson[ZioJsonShirtSize] == Right(entry))
+        )
+      },
+      test("should encode and decode uppercase") {
+        implicit val enc: JsonEncoder[ZioJsonShirtSize] =
+          ZioJson.encoderUppercase(ZioJsonShirtSize)
+        implicit val dec: JsonDecoder[ZioJsonShirtSize] =
+          ZioJson.decoderUppercaseOnly(ZioJsonShirtSize)
+        assertTrue(
+          ZioJsonShirtSize.values.forall(entry => entry.toJson.fromJson[ZioJsonShirtSize] == Right(entry))
+        )
+      }
+    ),
+    suite("from JSON")(
+      test("should parse to members when given proper JSON") {
+        assertTrue(
+          ZioJsonShirtSize.values.forall(entry =>
+            s""""${entry.entryName}"""".fromJson[ZioJsonShirtSize] == Right(entry)
+          )
+        )
+      },
+      test("should parse to members when given proper JSON for lower case") {
+        implicit val dec: JsonDecoder[ZioJsonShirtSize] =
+          ZioJson.decoderLowercaseOnly(ZioJsonShirtSize)
+        assertTrue(
+          ZioJsonShirtSize.values.forall(entry =>
+            s""""${entry.entryName.toLowerCase}"""".fromJson[ZioJsonShirtSize] == Right(entry)
+          )
+        )
+      },
+      test("should parse to members when given proper JSON for upper case") {
+        implicit val dec: JsonDecoder[ZioJsonShirtSize] =
+          ZioJson.decoderUppercaseOnly(ZioJsonShirtSize)
+        assertTrue(
+          ZioJsonShirtSize.values.forall(entry =>
+            s""""${entry.entryName.toUpperCase}"""".fromJson[ZioJsonShirtSize] == Right(entry)
+          )
+        )
+      },
+      test("should parse to members when given proper JSON for ignoring case") {
+        implicit val dec: JsonDecoder[ZioJsonShirtSize] =
+          ZioJson.decoderCaseInsensitive(ZioJsonShirtSize)
+        assertTrue(
+          ZioJsonShirtSize.values.zipWithIndex.forall { case (entry, i) =>
+            val entryName =
+              if (i % 2 == 0) entry.entryName.toUpperCase
+              else entry.entryName.toLowerCase
+            s""""$entryName"""".fromJson[ZioJsonShirtSize] == Right(entry)
+          }
+        )
+      },
+      test("should fail to parse to members when given improper JSON, even when ignoring case") {
+        implicit val dec: JsonDecoder[ZioJsonShirtSize] =
+          ZioJson.decoderCaseInsensitive(ZioJsonShirtSize)
+        assertTrue(
+          """"123"""".fromJson[ZioJsonShirtSize] == Left("('123' is not a member of enum ZioJsonShirtSize)"),
+          """"Jumbo"""".fromJson[ZioJsonShirtSize] == Left("('Jumbo' is not a member of enum ZioJsonShirtSize)")
+        )
+      },
+      test("should fail to parse random JSON to members") {
+        assertTrue(
+          """"XXL"""".fromJson[ZioJsonShirtSize] == Left("('XXL' is not a member of enum ZioJsonShirtSize)"),
+          "123".fromJson[ZioJsonShirtSize] == Left("(expected string)")
+        )
+      },
+      test("should fail to parse mixed but not upper case") {
+        implicit val dec: JsonDecoder[ZioJsonShirtSize] =
+          ZioJson.decoderUppercaseOnly(ZioJsonShirtSize)
+        assertTrue(
+          Seq("Small", "Medium", "Large").forall(s =>
+            s""""$s"""".fromJson[ZioJsonShirtSize] == Left(s"('$s' is not a member of enum ZioJsonShirtSize)")
+          )
+        )
+      },
+      test("should fail to parse mixed but not lower case") {
+        implicit val dec: JsonDecoder[ZioJsonShirtSize] =
+          ZioJson.decoderLowercaseOnly(ZioJsonShirtSize)
+        assertTrue(
+          Seq("Small", "Medium", "Large").forall(s =>
+            s""""$s"""".fromJson[ZioJsonShirtSize] == Left(s"('$s' is not a member of enum ZioJsonShirtSize)")
+          )
+        )
+      }
+    )
+  )
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonAlphabet.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonAlphabet.scala
@@ -1,0 +1,14 @@
+package enumeratum.values
+
+sealed abstract class ZioJsonAlphabet(val value: Char) extends CharEnumEntry
+
+case object ZioJsonAlphabet extends CharEnum[ZioJsonAlphabet] with CharZioJsonEnum[ZioJsonAlphabet] {
+
+  case object A extends ZioJsonAlphabet('A')
+  case object B extends ZioJsonAlphabet('B')
+  case object C extends ZioJsonAlphabet('C')
+  case object D extends ZioJsonAlphabet('D')
+
+  val values = findValues
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonBites.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonBites.scala
@@ -1,0 +1,12 @@
+package enumeratum.values
+
+sealed abstract class ZioJsonBites(val value: Byte) extends ByteEnumEntry
+
+object ZioJsonBites extends ByteEnum[ZioJsonBites] with ByteZioJsonEnum[ZioJsonBites] {
+  val values = findValues
+
+  case object OneByte   extends ZioJsonBites(1)
+  case object TwoByte   extends ZioJsonBites(2)
+  case object ThreeByte extends ZioJsonBites(3)
+  case object FourByte  extends ZioJsonBites(4)
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonContentType.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonContentType.scala
@@ -1,0 +1,14 @@
+package enumeratum.values
+
+sealed abstract class ZioJsonContentType(val value: Long, @annotation.unused name: String) extends LongEnumEntry
+
+case object ZioJsonContentType extends LongEnum[ZioJsonContentType] with LongZioJsonEnum[ZioJsonContentType] {
+
+  val values = findValues
+
+  case object Text  extends ZioJsonContentType(value = 1L, name = "text")
+  case object Image extends ZioJsonContentType(value = 2L, name = "image")
+  case object Video extends ZioJsonContentType(value = 3L, name = "video")
+  case object Audio extends ZioJsonContentType(value = 4L, name = "audio")
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonDrinks.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonDrinks.scala
@@ -1,0 +1,14 @@
+package enumeratum.values
+
+sealed abstract class ZioJsonDrinks(val value: Short, @annotation.unused name: String) extends ShortEnumEntry
+
+case object ZioJsonDrinks extends ShortEnum[ZioJsonDrinks] with ShortZioJsonEnum[ZioJsonDrinks] {
+
+  case object OrangeJuice extends ZioJsonDrinks(value = 1, name = "oj")
+  case object AppleJuice  extends ZioJsonDrinks(value = 2, name = "aj")
+  case object Cola        extends ZioJsonDrinks(value = 3, name = "cola")
+  case object Beer        extends ZioJsonDrinks(value = 4, name = "beer")
+
+  val values = findValues
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonLibraryItem.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonLibraryItem.scala
@@ -1,0 +1,14 @@
+package enumeratum.values
+
+sealed abstract class ZioJsonLibraryItem(val value: Int, val name: String) extends IntEnumEntry
+
+case object ZioJsonLibraryItem extends IntEnum[ZioJsonLibraryItem] with IntZioJsonEnum[ZioJsonLibraryItem] {
+
+  case object Book     extends ZioJsonLibraryItem(value = 1, name = "book")
+  case object Movie    extends ZioJsonLibraryItem(name = "movie", value = 2)
+  case object Magazine extends ZioJsonLibraryItem(3, "magazine")
+  case object CD       extends ZioJsonLibraryItem(4, name = "cd")
+
+  val values = findValues
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonMovieGenre.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonMovieGenre.scala
@@ -1,0 +1,19 @@
+package enumeratum.values
+
+sealed abstract class ZioJsonMovieGenre extends IntEnumEntry
+
+case object ZioJsonMovieGenre extends IntEnum[ZioJsonMovieGenre] with IntZioJsonEnum[ZioJsonMovieGenre] {
+
+  case object Action extends ZioJsonMovieGenre {
+    val value = 1
+  }
+  case object Comedy extends ZioJsonMovieGenre {
+    val value: Int = 2
+  }
+  case object Romance extends ZioJsonMovieGenre {
+    val value = 3
+  }
+
+  val values = findValues
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonOperatingSystem.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonOperatingSystem.scala
@@ -1,0 +1,16 @@
+package enumeratum.values
+
+sealed abstract class ZioJsonOperatingSystem(val value: String) extends StringEnumEntry
+
+case object ZioJsonOperatingSystem
+    extends StringEnum[ZioJsonOperatingSystem]
+    with StringZioJsonEnum[ZioJsonOperatingSystem] {
+
+  case object Linux   extends ZioJsonOperatingSystem("linux")
+  case object OSX     extends ZioJsonOperatingSystem("osx")
+  case object Windows extends ZioJsonOperatingSystem("windows")
+  case object Android extends ZioJsonOperatingSystem("android")
+
+  val values = findValues
+
+}

--- a/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonValueEnumSpec.scala
+++ b/zio-json-interop-enumeratum/shared/src/test/scala/enumeratum/values/ZioJsonValueEnumSpec.scala
@@ -1,0 +1,90 @@
+package enumeratum.values
+
+import zio.json._
+import zio.test._
+
+object ZioJsonValueEnumSpec extends ZIOSpecDefault {
+
+  def spec = suite("ZioJsonValueEnum")(
+    testZioJsonEnum("LongZioJsonEnum", ZioJsonContentType),
+    testZioJsonEnum("ShortZioJsonEnum", ZioJsonDrinks),
+    testZioJsonEnum("IntZioJsonEnum", ZioJsonLibraryItem),
+    testZioJsonEnum("StringZioJsonEnum", ZioJsonOperatingSystem),
+    testZioJsonKeyEnum("StringZioJsonEnum", ZioJsonOperatingSystem),
+    testZioJsonKeyEnum("IntZioJsonEnum", ZioJsonLibraryItem),
+    testZioJsonKeyEnum("LongZioJsonEnum", ZioJsonContentType),
+    testZioJsonKeyEnum("ShortZioJsonEnum", ZioJsonDrinks),
+    testZioJsonKeyEnum("CharZioJsonEnum", ZioJsonAlphabet),
+    testZioJsonKeyEnum("ByteZioJsonEnum", ZioJsonBites),
+    testZioJsonEnum("CharEnum", ZioJsonAlphabet),
+    testZioJsonEnum("ByteEnum", ZioJsonBites),
+    testZioJsonEnum("IntZioJsonEnum with val value members", ZioJsonMovieGenre),
+    suite("error messages")(
+      test("IntZioJsonEnum should report unknown value") {
+        assertTrue(
+          "999".fromJson[ZioJsonLibraryItem] == Left("('999' is not a member of enum ZioJsonLibraryItem)")
+        )
+      },
+      test("LongZioJsonEnum should report unknown value") {
+        assertTrue(
+          "999".fromJson[ZioJsonContentType] == Left("('999' is not a member of enum ZioJsonContentType)")
+        )
+      },
+      test("StringZioJsonEnum should report unknown value") {
+        assertTrue(
+          """"unknown"""".fromJson[ZioJsonOperatingSystem] == Left(
+            "('unknown' is not a member of enum ZioJsonOperatingSystem)"
+          )
+        )
+      }
+    )
+  )
+
+  private def testZioJsonEnum[ValueType: JsonEncoder, EntryType <: ValueEnumEntry[
+    ValueType
+  ]: JsonEncoder: JsonDecoder](
+    enumKind: String,
+    myEnum: ValueEnum[ValueType, EntryType] with ZioJsonValueEnum[ValueType, EntryType]
+  ): Spec[Any, Nothing] =
+    suite(enumKind)(
+      suite("to JSON")(
+        test("should work") {
+          assertTrue(
+            myEnum.values.forall(entry => entry.toJson == entry.value.toJson)
+          )
+        }
+      ),
+      suite("from JSON")(
+        test("should parse to members when given proper JSON") {
+          assertTrue(
+            myEnum.values.forall(entry => entry.value.toJson.fromJson[EntryType] == Right(entry))
+          )
+        },
+        test("should fail to parse random JSON to members") {
+          assertTrue(
+            """"GOBBLYGOOKITY"""".fromJson[EntryType].isLeft
+          )
+        }
+      )
+    )
+
+  private def testZioJsonKeyEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]: JsonFieldEncoder: JsonFieldDecoder](
+    enumKind: String,
+    myEnum: ValueEnum[ValueType, EntryType] with ZioJsonValueEnum[ValueType, EntryType]
+  ): Spec[Any, Nothing] =
+    suite(s"$enumKind as Key")(
+      suite("to JSON")(
+        test("should round-trip") {
+          val map  = myEnum.values.zipWithIndex.map { case (e, i) => e -> i }.toMap
+          val json = map.toJson
+          assertTrue(json.fromJson[Map[EntryType, Int]] == Right(map))
+        }
+      ),
+      suite("from JSON")(
+        test("should fail to parse invalid key") {
+          assertTrue("""{"999":0}""".fromJson[Map[EntryType, Int]].isLeft)
+        }
+      )
+    )
+
+}


### PR DESCRIPTION
> [!NOTE]
> Unlike other interop modules which require a `zio.json.interop.` import I kept it inside of the `enumeratum` and `enumeratum.values` packages respectively since this aligns more closely with the other enumeratum integrations.

Previous work:
* #722 
* https://github.com/lloydmeta/enumeratum/pull/466