### PR TITLE
Fix `Lexer.skipValue` throwing `UnexpectedEnd` on bare number literals at EOF

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -138,7 +138,8 @@ object Lexer {
     }
 
   def skipNumber(in: RetractReader): Unit = {
-    while (isNumber(in.readChar())) ()
+    try while (isNumber(in.readChar())) ()
+    catch { case _: UnexpectedEnd => return }
     in.retract()
   }
 

--- a/zio-json/shared/src/test/scala/zio/json/internal/LexerSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/internal/LexerSpec.scala
@@ -1,0 +1,90 @@
+package zio.json.internal
+
+import zio.json._
+import zio.test._
+
+object LexerSpec extends ZIOSpecDefault {
+
+  final case class KnownField(b: Boolean)
+  object KnownField {
+    implicit val decoder: JsonDecoder[KnownField] = DeriveJsonDecoder.gen[KnownField]
+  }
+
+  private def skip(input: String): Either[Throwable, Unit] =
+    try {
+      Lexer.skipValue(Nil, new FastStringReader(input))
+      Right(())
+    } catch {
+      case t: Throwable => Left(t)
+    }
+
+  // Skip the first value and return whatever remains in the reader, including EOF as "".
+  private def skipAndRemainder(input: String): Either[Throwable, String] = {
+    val reader = new FastStringReader(input)
+    try {
+      Lexer.skipValue(Nil, reader)
+      val sb = new StringBuilder
+      try
+        while (true) sb.append(reader.readChar())
+      catch {
+        case _: UnexpectedEnd => ()
+      }
+      Right(sb.toString)
+    } catch {
+      case t: Throwable => Left(t)
+    }
+  }
+
+  val spec: Spec[Environment, Any] =
+    suite("Lexer.skipValue")(
+      suite("bare numbers terminated by EOF")(
+        test("integer")(assertTrue(skip("42").isRight)),
+        test("decimal")(assertTrue(skip("42.5").isRight)),
+        test("negative")(assertTrue(skip("-7").isRight)),
+        test("scientific")(assertTrue(skip("1e10").isRight)),
+        test("scientific with negative exponent")(assertTrue(skip("1.5e-3").isRight)),
+        test("zero")(assertTrue(skip("0").isRight)),
+        test("negative decimal")(assertTrue(skip("-3.14").isRight))
+      ),
+      suite("bare literals terminated by EOF")(
+        test("true")(assertTrue(skip("true").isRight)),
+        test("false")(assertTrue(skip("false").isRight)),
+        test("null")(assertTrue(skip("null").isRight))
+      ),
+      suite("numbers followed by a delimiter (regression guards)")(
+        test("trailing whitespace")(assertTrue(skipAndRemainder("42 ") == Right(" "))),
+        test("trailing comma")(assertTrue(skipAndRemainder("42,") == Right(","))),
+        test("trailing brace")(assertTrue(skipAndRemainder("42}") == Right("}"))),
+        test("trailing bracket")(assertTrue(skipAndRemainder("42]") == Right("]"))),
+        test("decimal followed by comma")(assertTrue(skipAndRemainder("3.14,rest") == Right(",rest"))),
+        test("exponent followed by whitespace")(assertTrue(skipAndRemainder("1e5 xyz") == Right(" xyz")))
+      ),
+      test("skipping a numeric unknown field inside an object works end-to-end") {
+        assertTrue("""{"a":42,"b":true}""".fromJson[KnownField] == Right(KnownField(true))) &&
+        assertTrue("""{"a":1.5e-3,"b":false}""".fromJson[KnownField] == Right(KnownField(false))) &&
+        assertTrue("""{"b":true,"a":42}""".fromJson[KnownField] == Right(KnownField(true)))
+      },
+      test("skipping multiple values in sequence") {
+        val reader = new FastStringReader("""42,true,null,"x",[1,2],{"k":1}""")
+        Lexer.skipValue(Nil, reader)
+        val c1 = reader.readChar()
+        Lexer.skipValue(Nil, reader)
+        val c2 = reader.readChar()
+        Lexer.skipValue(Nil, reader)
+        val c3 = reader.readChar()
+        Lexer.skipValue(Nil, reader)
+        val c4 = reader.readChar()
+        Lexer.skipValue(Nil, reader)
+        val c5 = reader.readChar()
+        Lexer.skipValue(Nil, reader)
+        // all values skipped; reader should now be exhausted
+        val exhausted =
+          try {
+            reader.readChar(); false
+          } catch {
+            case _: UnexpectedEnd => true
+          }
+        assertTrue(c1 == ',' && c2 == ',' && c3 == ',' && c4 == ',' && c5 == ',' && exhausted)
+      }
+    )
+}


### PR DESCRIPTION
Closes #1584.

## Summary

`Lexer.skipValue` threw `UnexpectedEnd` when the input was a bare JSON number at end-of-stream (no trailing whitespace, comma, or bracket) — e.g. `"42"`, `"-3.14"`, `"1e5"`. The root cause was `skipNumber`, which kept calling `readChar` until a non-number character was returned; at EOF that call throws `UnexpectedEnd` before the trailing `in.retract()` can run.

## Fix

Localized `try`/`catch` in `skipNumber`: treat `UnexpectedEnd` as a natural terminator and skip the `retract()` (there is nothing to retract when the read itself failed). This matches the pattern already used by `Lexer.byte`, `Lexer.short`, `Lexer.int`, etc.

```scala
def skipNumber(in: RetractReader): Unit = {
  try while (isNumber(in.readChar())) ()
  catch { case _: UnexpectedEnd => return }
  in.retract()
}
```

The `true`/`false`/`null` literal paths and the composite object/array/string paths terminate on explicit tokens (`skipFixedChars` for literals, `}`/`]`/`"` for composites) and were verified to be unaffected.

## Test coverage

New `LexerSpec` in `zio-json/shared/src/test/scala/zio/json/internal/` covering:

- Bare numbers at EOF: `42`, `42.5`, `-7`, `1e10`, `1.5e-3`, `-3.14`, `0` (previously failing, now passing)
- Bare literals at EOF: `true`, `false`, `null` (already passing — included as regression pins)
- Numbers followed by `,`, `}`, `]`, whitespace (regression guards that the number branch still terminates correctly when there is a delimiter)
- A numeric unknown field inside an object, decoded through a derived `JsonDecoder` (exercises `skipValue` via the normal macro-generated unknown-field path)
- Skipping multiple values in sequence from a single reader