### PR TITLE
Error when reading json array file? #1071

### DIFF
--- a/zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala
@@ -9,44 +9,68 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{ Path, Paths }
 
 trait JsonPackagePlatformSpecific {
+
   def readJsonAs(file: File): ZStream[Any, Throwable, ast.Json] =
-    readJsonLinesAs[ast.Json](file)
+    readJsonLinesAs[ast.Json](file.toPath, JsonStreamDelimiter.Newline)
+
+  def readJsonAs(file: File, delimiter: JsonStreamDelimiter): ZStream[Any, Throwable, ast.Json] =
+    readJsonLinesAs[ast.Json](file.toPath, delimiter)
 
   def readJsonAs(path: Path): ZStream[Any, Throwable, ast.Json] =
-    readJsonLinesAs[ast.Json](path)
+    readJsonLinesAs[ast.Json](path, JsonStreamDelimiter.Newline)
+
+  def readJsonAs(path: Path, delimiter: JsonStreamDelimiter): ZStream[Any, Throwable, ast.Json] =
+    readJsonLinesAs[ast.Json](path, delimiter)
 
   def readJsonAs(path: String): ZStream[Any, Throwable, ast.Json] =
-    readJsonLinesAs[ast.Json](path)
+    readJsonLinesAs[ast.Json](Paths.get(path), JsonStreamDelimiter.Newline)
+
+  def readJsonAs(path: String, delimiter: JsonStreamDelimiter): ZStream[Any, Throwable, ast.Json] =
+    readJsonLinesAs[ast.Json](Paths.get(path), delimiter)
 
   def readJsonAs(url: URL): ZStream[Any, Throwable, ast.Json] =
-    readJsonLinesAs[ast.Json](url)
+    readJsonLinesAs[ast.Json](url, JsonStreamDelimiter.Newline)
+
+  def readJsonAs(url: URL, delimiter: JsonStreamDelimiter): ZStream[Any, Throwable, ast.Json] =
+    readJsonLinesAs[ast.Json](url, delimiter)
 
   def readJsonLinesAs[A: JsonDecoder](file: File): ZStream[Any, Throwable, A] =
-    readJsonLinesAs(file.toPath)
+    readJsonLinesAs[A](file.toPath, JsonStreamDelimiter.Newline)
+
+  def readJsonLinesAs[A: JsonDecoder](file: File, delimiter: JsonStreamDelimiter): ZStream[Any, Throwable, A] =
+    readJsonLinesAs[A](file.toPath, delimiter)
 
   def readJsonLinesAs[A: JsonDecoder](path: Path): ZStream[Any, Throwable, A] =
+    readJsonLinesAs[A](path, JsonStreamDelimiter.Newline)
+
+  def readJsonLinesAs[A: JsonDecoder](path: Path, delimiter: JsonStreamDelimiter): ZStream[Any, Throwable, A] =
     ZStream
       .fromPath(path)
       .via(
         ZPipeline.utf8Decode >>>
           stringToChars >>>
-          JsonDecoder[A].decodeJsonPipeline(JsonStreamDelimiter.Newline)
+          JsonDecoder[A].decodeJsonPipeline(delimiter)
       )
 
   def readJsonLinesAs[A: JsonDecoder](path: String): ZStream[Any, Throwable, A] =
-    readJsonLinesAs(Paths.get(path))
+    readJsonLinesAs[A](Paths.get(path), JsonStreamDelimiter.Newline)
 
-  def readJsonLinesAs[A: JsonDecoder](url: URL): ZStream[Any, Throwable, A] = {
+  def readJsonLinesAs[A: JsonDecoder](path: String, delimiter: JsonStreamDelimiter): ZStream[Any, Throwable, A] =
+    readJsonLinesAs[A](Paths.get(path), delimiter)
+
+  def readJsonLinesAs[A: JsonDecoder](url: URL): ZStream[Any, Throwable, A] =
+    readJsonLinesAs[A](url, JsonStreamDelimiter.Newline)
+
+  def readJsonLinesAs[A: JsonDecoder](url: URL, delimiter: JsonStreamDelimiter): ZStream[Any, Throwable, A] = {
     val scoped = ZIO
       .fromAutoCloseable(ZIO.attempt(url.openStream()))
       .refineToOrDie[IOException]
-
     ZStream
       .fromInputStreamScoped(scoped)
       .via(
         ZPipeline.utf8Decode >>>
           stringToChars >>>
-          JsonDecoder[A].decodeJsonPipeline(JsonStreamDelimiter.Newline)
+          JsonDecoder[A].decodeJsonPipeline(delimiter)
       )
   }
 
@@ -64,10 +88,7 @@ trait JsonPackagePlatformSpecific {
 
   def writeJsonLinesAs[R, A: JsonEncoder](path: Path, stream: ZStream[R, Throwable, A]): RIO[R, Unit] =
     stream
-      .via(
-        JsonEncoder[A].encodeJsonLinesPipeline >>>
-          charsToUtf8
-      )
+      .via(JsonEncoder[A].encodeJsonLinesPipeline >>> charsToUtf8)
       .run(ZSink.fromPath(path))
       .unit
 
@@ -75,14 +96,11 @@ trait JsonPackagePlatformSpecific {
     writeJsonLinesAs(Paths.get(path), stream)
 
   private def stringToChars: ZPipeline[Any, Nothing, String, Char] =
-    ZPipeline.mapChunks[String, Char](_.flatMap(_.toCharArray))
+    ZPipeline.mapChunks[String, Char](_.flatMap(_.toCharArray)) >>>
+      ZPipeline.rechunk(4096)
 
   private def charsToUtf8: ZPipeline[Any, Nothing, Char, Byte] =
     ZPipeline.mapChunksZIO[Any, Nothing, Char, Byte] { chunk =>
-      ZIO.succeed {
-        Chunk.fromArray {
-          new String(chunk.toArray).getBytes(StandardCharsets.UTF_8)
-        }
-      }
+      ZIO.succeed(Chunk.fromArray(new String(chunk.toArray).getBytes(StandardCharsets.UTF_8)))
     }
 }

--- a/zio-json/jvm/src/test/resources/log.jsonarray
+++ b/zio-json/jvm/src/test/resources/log.jsonarray
@@ -1,0 +1,4 @@
+[
+    {"at": 1603669875, "message": "hello"},
+    {"at": 1603669876, "message": "world"}
+]

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -241,6 +241,19 @@ object DecoderPlatformSpecificSpec extends ZIOSpecDefault {
               assert(lines(1))(equalTo(Event(1603669876, "world")))
             }
           },
+          test("readJsonLines reads Array from files") {
+            import logEvent._
+
+            for {
+              lines <- readJsonLinesAs[Event](
+                         Paths.get("zio-json/jvm/src/test/resources/log.jsonarray"),
+                         JsonStreamDelimiter.Array
+                       ).runCollect
+            } yield {
+              assert(lines(0))(equalTo(Event(1603669875, "hello"))) &&
+              assert(lines(1))(equalTo(Event(1603669876, "world")))
+            }
+          },
           test("readJsonLines reads from URLs") {
             import logEvent._
 
@@ -248,6 +261,18 @@ object DecoderPlatformSpecificSpec extends ZIOSpecDefault {
 
             for {
               lines <- readJsonLinesAs[Event](url).runCollect
+            } yield {
+              assert(lines(0))(equalTo(Event(1603669875, "hello"))) &&
+              assert(lines(1))(equalTo(Event(1603669876, "world")))
+            }
+          },
+          test("readJsonLines reads Array from URLs") {
+            import logEvent._
+
+            val url = this.getClass.getClassLoader.getResource("log.jsonarray")
+
+            for {
+              lines <- readJsonLinesAs[Event](url, JsonStreamDelimiter.Array).runCollect
             } yield {
               assert(lines(0))(equalTo(Event(1603669875, "hello"))) &&
               assert(lines(1))(equalTo(Event(1603669876, "world")))


### PR DESCRIPTION
#  FIX: Error when reading json array file (#1071)
##  Bounty Information
/claim #1071
##  Description
This PR fix the ReadArray json issue.

### Key Fixes
- **Fixed `UnexpectedEnd` / `OneCharReader` issues:** Correctly synchronized the stream delimiters (`[` and `]`) to prevent premature stream termination.

##  Verification Results

- **Test Suite:** Successfully passed the all test cases.



## Evidence
https://github.com/user-attachments/assets/576ce96c-529d-483c-9582-09137b301b9d

