### PR TITLE
Fixed #1071 - Added readJsonArrayAs for streaming JSON array files

### DIFF
--- a/zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala
@@ -50,6 +50,35 @@ trait JsonPackagePlatformSpecific {
       )
   }
 
+  def readJsonArrayAs[A: JsonDecoder](file: File): ZStream[Any, Throwable, A] =
+    readJsonArrayAs(file.toPath)
+
+  def readJsonArrayAs[A: JsonDecoder](path: Path): ZStream[Any, Throwable, A] =
+    ZStream
+      .fromPath(path)
+      .via(
+        ZPipeline.utf8Decode >>>
+          stringToChars >>>
+          JsonDecoder[A].decodeJsonPipeline(JsonStreamDelimiter.Array)
+      )
+
+  def readJsonArrayAs[A: JsonDecoder](path: String): ZStream[Any, Throwable, A] =
+    readJsonArrayAs(Paths.get(path))
+
+  def readJsonArrayAs[A: JsonDecoder](url: URL): ZStream[Any, Throwable, A] = {
+    val scoped = ZIO
+      .fromAutoCloseable(ZIO.attempt(url.openStream()))
+      .refineToOrDie[IOException]
+
+    ZStream
+      .fromInputStreamScoped(scoped)
+      .via(
+        ZPipeline.utf8Decode >>>
+          stringToChars >>>
+          JsonDecoder[A].decodeJsonPipeline(JsonStreamDelimiter.Array)
+      )
+  }
+
   def writeJsonLines[R](file: File, stream: ZStream[R, Throwable, ast.Json]): RIO[R, Unit] =
     writeJsonLinesAs(file, stream)
 

--- a/zio-json/jvm/src/test/resources/log.json
+++ b/zio-json/jvm/src/test/resources/log.json
@@ -1,0 +1,4 @@
+[
+  {"at": 1603669875, "message": "hello"},
+  {"at": 1603669876, "message": "world"}
+]

--- a/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala
@@ -252,6 +252,28 @@ object DecoderPlatformSpecificSpec extends ZIOSpecDefault {
               assert(lines(0))(equalTo(Event(1603669875, "hello"))) &&
               assert(lines(1))(equalTo(Event(1603669876, "world")))
             }
+          },
+          test("readJsonArrayAs reads from files") {
+            import logEvent._
+
+            for {
+              items <- readJsonArrayAs[Event](Paths.get("zio-json/jvm/src/test/resources/log.json")).runCollect
+            } yield {
+              assert(items(0))(equalTo(Event(1603669875, "hello"))) &&
+              assert(items(1))(equalTo(Event(1603669876, "world")))
+            }
+          },
+          test("readJsonArrayAs reads from URLs") {
+            import logEvent._
+
+            val url = this.getClass.getClassLoader.getResource("log.json")
+
+            for {
+              items <- readJsonArrayAs[Event](url).runCollect
+            } yield {
+              assert(items(0))(equalTo(Event(1603669875, "hello"))) &&
+              assert(items(1))(equalTo(Event(1603669876, "world")))
+            }
           }
         ),
         suite("combinators")(


### PR DESCRIPTION
/claim #1071

## Summary

Closes #1071. Adds `readJsonArrayAs[A: JsonDecoder]` overloads (`File`, `Path`, `String`, `URL`) to `zio.JsonPackagePlatformSpecific`, mirroring the existing `readJsonLinesAs` block but passing `JsonStreamDelimiter.Array` to `decodeJsonPipeline` instead of `JsonStreamDelimiter.Newline`. The underlying parser already supported array-mode streaming — only the user-facing helper was missing, which is why the issue's reporter had to hand-wire `ZStream.fromPath >>> utf8Decode >>> stringToChars >>> decodeJsonPipeline(Array)`.

The original `StackOverflowError` was irreproducible per the reporter's follow-up, and the `UnexpectedEnd` symptom was already fixed by #1585. This PR is strictly the missing helper.

## Usage

```scala
import zio._
import zio.json._
import zio.stream._

case class Competition(competition_id: Option[Int], country_name: Option[String], /* ... */)
object Competition {
  implicit val decoder: JsonDecoder[Competition] = DeriveJsonDecoder.gen[Competition]
}

val stream: ZStream[Any, Throwable, Competition] =
  zio.json.readJsonArrayAs[Competition]("competitions.json")

stream.runCount  // streams elements one-by-one, no whole-file buffering
```

## Changes

- `zio-json/jvm/src/main/scala/zio/JsonPackagePlatformSpecific.scala` — 4 new overloads (File / Path / String / URL), additive only.
- `zio-json/jvm/src/test/scala/zio/json/DecoderPlatformSpecificSpec.scala` — 2 tests in the existing `helpers in zio.json` suite, mirroring the existing `readJsonLines` tests and reusing the proven `logEvent.Event` decoder for cross-build safety.
- `zio-json/jvm/src/test/resources/log.json` — minimal 2-element fixture mirroring the existing `log.jsonlines`.

Empty-array and multi-element pipeline behavior is already exercised by the existing `Array delimited` suite — no duplication.


## Compatibility

Binary-additive (no signature changes to existing methods), so `mima_check` should pass cleanly.



https://github.com/user-attachments/assets/2838e1a4-481d-4703-85d0-b8e6da8857f4

