### PR TITLE
Return Left for a negative array index in delete and transformAt

### DIFF
--- a/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
+++ b/zio-json/shared/src/main/scala/zio/json/ast/ast.scala
@@ -285,7 +285,7 @@ sealed abstract class Json { self =>
       case JsonCursor.DownElement(parent, index) =>
         self.transformOrDelete(parent, false) { case Arr(elements) =>
           val (left, right) = elements.splitAt(index)
-          if (right.isEmpty)
+          if (index < 0 || right.isEmpty)
             Left(s"The array does not have index ${index}")
           else if (delete)
             Right(Arr(left ++ right.takeRight(right.length - 1)))

--- a/zio-json/shared/src/test/scala/zio/json/ast/JsonSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ast/JsonSpec.scala
@@ -115,6 +115,9 @@ object JsonSpec extends ZIOSpecDefault {
           test("failure") {
             val missingElement = JsonCursor.field("entities").isObject.field("hashtags").isArray.element(2)
             assert(tweet.delete(missingElement))(isLeft)
+          },
+          test("negative element index") {
+            assert(Json.Arr(Json.Str("a"), Json.Str("b")).delete(JsonCursor.element(-1)))(isLeft)
           }
         )
       ),
@@ -623,6 +626,9 @@ object JsonSpec extends ZIOSpecDefault {
           test("failure") {
             val missingElement = JsonCursor.field("entities").isObject.field("hashtags").isArray.element(2)
             assert(tweet.transformAt(missingElement)(identity))(isLeft)
+          },
+          test("negative element index") {
+            assert(Json.Arr(Json.Num(1), Json.Num(2)).transformAt(JsonCursor.element(-1))(_ => Json.Null))(isLeft)
           }
         )
       )


### PR DESCRIPTION
`Json.delete` and `Json.transformAt` on a **negative** array index silently operate on element 0 instead of returning an error.

`transformOrDelete`'s `DownElement` branch uses `elements.splitAt(index)`, but `Chunk.splitAt` clamps negative indices (`splitAt(-1)` drops nothing), so `right` is non-empty and the `right.isEmpty` guard is skipped — the code then acts on `right.head`, i.e. element 0. The sibling `get` avoids this by using `elements.lift(index)`, which returns `Left` for negatives. This change aligns `delete`/`transformAt` with that contract.

```scala
Json.Arr(Json.Str("a"), Json.Str("b")).delete(JsonCursor.element(-1))
// before: Right(["b"])   (element 0 deleted)
// after:  Left("The array does not have index -1")

Json.Arr(Json.Num(1), Json.Num(2)).transformAt(JsonCursor.element(-1))(_ => Json.Null)
// before: Right([null, 2])   (element 0 mutated)
// after:  Left("The array does not have index -1")
```

Adds regression tests for `delete` and `transformAt` on a negative index.

<sub>Disclosure, for the record: found + drafted with Claude Code; I reproduced and verified it myself (fails-before vs the published 0.9.2 artifact, passes-after via `sbt zioJsonJVM/testOnly JsonSpec`).</sub>
