### PR TITLE
Decode directly from `Chunk[Byte]` without copying into a `String`

### DIFF
--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -34,6 +34,24 @@ Now we can parse JSON into our object
 """{ "curvature": 0.5 }""".fromJson[Banana]
 ```
 
+### Decoding from bytes
+
+JSON usually arrives as bytes rather than as text: an HTTP response body, a file, a Kafka record. A `Chunk[Byte]` can be decoded directly, without being copied into a `String` first.
+
+```scala mdoc
+import zio.Chunk
+
+val bytes: Chunk[Byte] = Chunk.fromArray("""{ "curvature": 0.5 }""".getBytes("UTF-8"))
+
+bytes.fromJson[Banana]
+```
+
+The bytes are turned into characters as the parser consumes them, so peak memory is the chunk plus a constant. Going through `new String(chunk.toArray, UTF_8)` instead holds the chunk, an array copy of it and the `String` all at once, which matters once payloads get large.
+
+The input is expected to be UTF-8, as [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259#section-8.1) requires for JSON interchange. Malformed input decodes to the replacement character, as `new String(bytes, UTF_8)` does. Errors are reported exactly as for the `CharSequence` variant.
+
+For payloads that do not fit in memory at all, use `JsonDecoder[A].decodeJsonStreamInput(stream)` to decode straight from a `ZStream[R, Throwable, Byte]`.
+
 ### Automatic Derivation and case class default field values
 
 If a case class field is defined with a default value and the field is not present or `null`, the default value will be used (or evaluated when it is a method).

--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -46,7 +46,15 @@ val bytes: Chunk[Byte] = Chunk.fromArray("""{ "curvature": 0.5 }""".getBytes("UT
 bytes.fromJson[Banana]
 ```
 
+A bare `Array[Byte]` works the same way, and is not copied either.
+
+```scala mdoc
+"""{ "curvature": 0.5 }""".getBytes("UTF-8").fromJson[Banana]
+```
+
 The bytes are turned into characters as the parser consumes them, so peak memory is the chunk plus a constant. Going through `new String(chunk.toArray, UTF_8)` instead holds the chunk, an array copy of it and the `String` all at once, which matters once payloads get large.
+
+A chunk that is already backed by a single array — what `Chunk.fromArray` produces, and what an HTTP body handed over from Netty looks like — is read in place, with no copy at all. Other shapes, such as a body assembled from several network reads, are pulled through a small fixed window.
 
 The input is expected to be UTF-8, as [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259#section-8.1) requires for JSON interchange. Malformed input decodes to the replacement character, as `new String(bytes, UTF_8)` does. Errors are reported exactly as for the `CharSequence` variant.
 

--- a/zio-json/jvm/src/jmh/scala/zio/json/ChunkDecoderBenchmarks.scala
+++ b/zio-json/jvm/src/jmh/scala/zio/json/ChunkDecoderBenchmarks.scala
@@ -1,0 +1,91 @@
+package zio.json
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros._
+import org.openjdk.jmh.annotations._
+import zio.json.ChunkDecoderBenchmarks._
+import zio.json.TestUtils._
+import zio.json.data.googlemaps._
+import zio.stream.ZStream
+import zio.{ Chunk, Runtime, Unsafe }
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.TimeUnit
+
+/**
+ * Decoding a payload that arrived as bytes, which is the normal case for an HTTP response body.
+ *
+ * `decodeZioChunkViaString` is what users had to write before `decodeJson(Chunk[Byte])` existed, and
+ * `decodeZioStreamInput` is the only allocation-bounded option that was available. `decodeJsoniterBytes` is there as a
+ * reference point, not as a like-for-like comparison.
+ *
+ * jmh:run -i 5 -wi 5 -f1 ChunkDecoder.*
+ */
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+class ChunkDecoderBenchmarks {
+  var jsonString: String       = _
+  var jsonBytes: Array[Byte]   = _
+  var chunk: Chunk[Byte]       = _
+  var chunkConcat: Chunk[Byte] = _
+
+  private[this] val runtime = Runtime.default
+
+  @Setup
+  def setup(): Unit = {
+    jsonString = getResourceAsString("google_maps_api_response.json")
+    jsonBytes = jsonString.getBytes(UTF_8)
+    chunk = Chunk.fromArray(jsonBytes)
+    // what a body assembled from several network reads looks like: a Chunk.Concat, not a single array
+    chunkConcat = jsonBytes.grouped(math.max(jsonBytes.length / 8, 1)).foldLeft(Chunk.empty[Byte]) { (acc, bs) =>
+      acc ++ Chunk.fromArray(bs)
+    }
+
+    assert(decodeZioChunk() == decodeZioString())
+    assert(decodeZioChunkConcat() == decodeZioString())
+    assert(decodeZioChunkViaString() == decodeZioString())
+    assert(decodeZioStreamInput() == decodeZioString())
+  }
+
+  /** Baseline: the payload is already a `String`, no byte handling involved. */
+  @Benchmark
+  def decodeZioString(): Either[String, DistanceMatrix] =
+    jsonString.fromJson[DistanceMatrix]
+
+  /** The status quo: copy the bytes into a `String`, then parse that. */
+  @Benchmark
+  def decodeZioChunkViaString(): Either[String, DistanceMatrix] =
+    new String(chunk.toArray, UTF_8).fromJson[DistanceMatrix]
+
+  @Benchmark
+  def decodeZioChunk(): Either[String, DistanceMatrix] =
+    chunk.fromJson[DistanceMatrix]
+
+  @Benchmark
+  def decodeZioChunkConcat(): Either[String, DistanceMatrix] =
+    chunkConcat.fromJson[DistanceMatrix]
+
+  /**
+   * The other allocation-bounded option, via `InputStream` + `InputStreamReader`. The score includes a
+   * `Runtime.unsafe.run` round trip, so read it as the cost of the whole call, not of the parse alone.
+   */
+  @Benchmark
+  def decodeZioStreamInput(): Either[String, DistanceMatrix] =
+    Unsafe.unsafe { implicit u: Unsafe =>
+      runtime.unsafe
+        .run(JsonDecoder[DistanceMatrix].decodeJsonStreamInput(ZStream.fromChunk(chunk)).either)
+        .getOrThrow()
+        .left
+        .map(_.getMessage)
+    }
+
+  @Benchmark
+  def decodeJsoniterBytes(): DistanceMatrix =
+    readFromArray[DistanceMatrix](jsonBytes)
+}
+
+object ChunkDecoderBenchmarks {
+  implicit val codec: JsonValueCodec[DistanceMatrix] = JsonCodecMaker.make
+}

--- a/zio-json/jvm/src/test/scala/zio/json/ChunkDecoderCorpusSpec.scala
+++ b/zio-json/jvm/src/test/scala/zio/json/ChunkDecoderCorpusSpec.scala
@@ -1,0 +1,120 @@
+package zio.json
+
+import zio._
+import zio.json.ast.Json
+import zio.json.TestUtils._
+import zio.test._
+
+import java.io.IOException
+import java.nio.charset.StandardCharsets.UTF_8
+
+/**
+ * Parity of `decodeJson(Chunk[Byte])` against `decodeJson(CharSequence)` over every JSON file in the test resources.
+ *
+ * These corpora exist to break parsers: JSONTestSuite alone carries invalid UTF-8, byte order marks, lone surrogates,
+ * pathological nesting and numbers, and the real world fixtures are large enough to span many window refills. Whether
+ * zio-json accepts or rejects any given file is beside the point here — both paths simply have to agree, so the sweep
+ * stays meaningful even for the inputs the parser rightly refuses.
+ *
+ * JVM only: it needs classpath resource enumeration, and the comparison is against the JVM's UTF-8 decoder, which the
+ * JS and Native ones do not always match on malformed input.
+ */
+object ChunkDecoderCorpusSpec extends ZIOSpecDefault {
+
+  private def resourceBytes(path: String): Chunk[Byte] = {
+    val in = getClass.getClassLoader.getResourceAsStream(path)
+    try {
+      val out  = new java.io.ByteArrayOutputStream()
+      val data = Array.ofDim[Byte](2048)
+      var len  = in.read(data)
+      while (len != -1) {
+        out.write(data, 0, len)
+        len = in.read(data)
+      }
+      Chunk.fromArray(out.toByteArray)
+    } finally in.close()
+  }
+
+  /** The chunk shapes worth exercising: read in place, and the windowed path in two arrangements. */
+  private def shapes(bs: Chunk[Byte]): List[(String, Chunk[Byte])] = {
+    val arr  = bs.toArray
+    val half = arr.length / 2
+    List(
+      "ByteArray" -> Chunk.fromArray(arr),
+      "Concat"    -> (Chunk.fromArray(arr.take(half)) ++ Chunk.fromArray(arr.drop(half))),
+      "Slice"     -> Chunk.fromArray(Array[Byte](1, 2) ++ arr).drop(2)
+    )
+  }
+
+  /**
+   * Compared as rendered text rather than with `==`, because `Json.equals` folds an object's fields into a `Map`: two
+   * structurally identical ASTs with a duplicated key compare unequal, so `==` reports a difference where there is none
+   * (`y_object_duplicated_key.json`). Rendering keeps field order and duplicates, so it is the faithful comparison
+   * here.
+   */
+  private def render[A](result: Either[String, A]): String = result.fold("Left:" + _, v => "Right:" + v)
+
+  /** Returns a description of each disagreement, empty when every shape matched the `CharSequence` path. */
+  private def disagreements(path: String, bs: Chunk[Byte]): List[String] = {
+    def compare[A](label: String)(implicit d: JsonDecoder[A]): List[String] = {
+      // both sides start from the same bytes, so a mis-decoded multi-byte char is not what is being compared
+      val expected = render(new String(bs.toArray, UTF_8).fromJson[A])
+      shapes(bs).collect {
+        case (shape, c) if render(c.fromJson[A]) != expected => s"$path [$label/$shape]"
+      }
+    }
+
+    compare[Json]("Json") ::: compare[List[Json]]("List[Json]") ::: compare[Map[String, Json]]("Map")
+  }
+
+  /** `expected` guards against the sweep quietly covering nothing if the resources ever move. */
+  private def sweep(folder: String, expected: Int): ZIO[Any, IOException, TestResult] =
+    for {
+      paths <- getResourcePaths(folder)
+      files  = paths.filter(p => p.endsWith(".json") || p.endsWith(".jsonlines")).sorted
+      bad    = files.flatMap(p => disagreements(p, resourceBytes(s"$folder/$p")))
+    } yield assertTrue(files.length >= expected, bad == Vector.empty[String])
+
+  val spec: Spec[Environment, IOException] =
+    suite("ChunkDecoderCorpus")(
+      test("agrees with the CharSequence path on every JSONTestSuite file") {
+        // 283 files from JSONTestSuite by Nicolas Seriot: https://github.com/nst/JSONTestSuite
+        sweep("json_test_suite", expected = 283)
+      },
+      test("agrees with the CharSequence path on the jawn corpus") {
+        sweep("jawn", expected = 8)
+      },
+      test("agrees with the CharSequence path on the real world fixtures") {
+        val files = List(
+          "google_maps_api_response.json",
+          "google_maps_api_compact_response.json",
+          "google_maps_api_error_response.json",
+          "google_maps_api_attack0.json",
+          "google_maps_api_attack1.json",
+          "google_maps_api_attack2.json",
+          "google_maps_api_attack3.json",
+          "google_maps_api_extra.json",
+          "twitter_api_response.json",
+          "twitter_api_compact_response.json",
+          "twitter_api_error_response.json",
+          "che.geo.json",
+          "che-2.geo.json",
+          "che-err.geo.json"
+        )
+
+        assertTrue(files.flatMap(p => disagreements(p, resourceBytes(p))) == List.empty[String])
+      },
+      test("agrees with the CharSequence path on every truncation of a real payload") {
+        // walks the parser into its end-of-input and retract corners against a document of real shape and size
+        val all = resourceBytes("google_maps_api_compact_response.json").toArray
+
+        val bad = (0 to all.length by 7).flatMap { n =>
+          val prefix   = Chunk.fromArray(all.take(n))
+          val expected = render(new String(prefix.toArray, UTF_8).fromJson[Json])
+          if (render(prefix.fromJson[Json]) != expected) Some(n) else None
+        }
+
+        assertTrue(all.length > 8192, bad == Vector.empty[Int])
+      }
+    )
+}

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -97,6 +97,23 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
     }
 
   /**
+   * Attempts to decode a value of type `A` from the specified UTF-8 encoded bytes, but may fail with a human-readable
+   * error message if the provided bytes do not encode a value of this type.
+   *
+   * The bytes are decoded as they are parsed rather than copied into a `String` first, so this is the allocation
+   * friendly way to handle a payload that already arrived as bytes, e.g. an HTTP response body.
+   *
+   * Note: This method may not entirely consume the specified chunk.
+   */
+  final def decodeJson(bytes: Chunk[Byte]): Either[String, A] =
+    try new Right(unsafeDecode(Nil, new Utf8ChunkReader(bytes)))
+    catch {
+      case e: JsonDecoder.UnsafeJson => new Left(JsonError.render(e.trace))
+      case _: UnexpectedEnd          => new Left("Unexpected end of input")
+      case _: StackOverflowError     => new Left("Unexpected structure")
+    }
+
+  /**
    * Returns this decoder but widened to the given super-type
    */
   final def widen[B >: A]: JsonDecoder[B] = self.asInstanceOf[JsonDecoder[B]]

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -114,6 +114,16 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
     }
 
   /**
+   * Attempts to decode a value of type `A` from the specified UTF-8 encoded bytes, but may fail with a human-readable
+   * error message if the provided bytes do not encode a value of this type.
+   *
+   * The array is read in place, not copied.
+   *
+   * Note: This method may not entirely consume the specified array.
+   */
+  final def decodeJson(bytes: Array[Byte]): Either[String, A] = decodeJson(Chunk.fromArray(bytes))
+
+  /**
    * Returns this decoder but widened to the given super-type
    */
   final def widen[B >: A]: JsonDecoder[B] = self.asInstanceOf[JsonDecoder[B]]

--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -147,10 +147,11 @@ private[zio] final class FastStringReader(s: CharSequence) extends RetractReader
  * This exists so that bytes coming off the wire can be parsed without first being copied into a `String`: peak memory
  * is the chunk plus a constant, instead of the chunk plus a full sized copy of it.
  *
- * Malformed input produces `�`, one per malformed sequence, as `new String(bytes, UTF_8)` does. The two agree on well
- * formed input and on the usual damage (truncated tails, stray continuation bytes, overlong forms), but not byte for
- * byte on every malformed sequence: `CharsetDecoder`'s maximal subpart rule emits three replacements for a CESU-8
- * encoded surrogate such as `ED A0 80` where this emits one.
+ * Malformed input produces `�` following the Unicode maximal subpart rule, which is character for character what
+ * `new String(bytes, UTF_8)` yields on the JVM: truncated tails, stray continuation bytes, overlong forms, CESU-8
+ * encoded surrogates and code points past U+10FFFF all decode identically. This reader behaves the same on every
+ * platform, whereas the JS and Native UTF-8 decoders do not always agree with the JVM on how many replacement
+ * characters a given malformed sequence is worth.
  */
 private[zio] final class Utf8ChunkReader(chunk: Chunk[Byte]) extends RetractReader {
   private[this] val len: Int     = chunk.length
@@ -162,18 +163,32 @@ private[zio] final class Utf8ChunkReader(chunk: Chunk[Byte]) extends RetractRead
   private[this] var markI: Int       = 0
   private[this] var markPending: Int = -1
 
-  // Bytes are pulled through a window rather than read one at a time off the Chunk: Chunk#byte is a virtual call
-  // taking an implicit witness, and on a Chunk.Concat it walks the tree on every byte, which costs several times more
-  // than the parse itself. Bulk copying keeps that to one arraycopy per window and makes reads plain array loads.
-  private[this] val buf: Array[Byte] = new Array(math.min(len, Utf8ChunkReader.WindowSize))
-  private[this] var base: Int        = 0 // index in the chunk of buf(0)
-  private[this] var limit: Int       = 0 // number of valid bytes in buf
+  // Bytes are read out of a plain array rather than one at a time off the Chunk: Chunk#byte is a virtual call taking
+  // an implicit witness, and on a Chunk.Concat it walks the tree on every byte, which costs several times more than
+  // the parse itself.
+  //
+  // A Chunk.ByteArray is read in place, with no copy at all. That is the shape Chunk.fromArray produces, which is
+  // what callers with an Array[Byte] already in hand reach for to avoid a copy, and what zio-http hands back for a
+  // body it took from Netty. Any other shape is pulled through a fixed window, one arraycopy per refill, which keeps
+  // peak memory constant. Both end up in the same `buf(k - base)` read below, so there is only one hot path.
+  private[this] var buf: Array[Byte] = _
+  private[this] var base: Int        = 0 // buf(k - base) is the byte at index k of the chunk
+  private[this] var limit: Int       = 0 // reads are served from buf while k - base < limit
 
-  def close(): Unit = ()
+  chunk match {
+    case Chunk.ByteArray(array, offset, length) =>
+      buf = array
+      base = -offset
+      limit = offset + length // k < len implies k - base < limit, so fill() is never reached
+    case _ =>
+      buf = new Array(math.min(len, Utf8ChunkReader.WindowSize))
+  }
+
+  override def close(): Unit = ()
 
   override def read(): Int = readNext()
 
-  def readChar(): Char = {
+  override def readChar(): Char = {
     val c = readNext()
     if (c == -1) throw new UnexpectedEnd
     c.toChar
@@ -199,7 +214,7 @@ private[zio] final class Utf8ChunkReader(chunk: Chunk[Byte]) extends RetractRead
     c
   }
 
-  def retract(): Unit = {
+  override def retract(): Unit = {
     i = markI
     pending = markPending
   }
@@ -240,42 +255,53 @@ private[zio] final class Utf8ChunkReader(chunk: Chunk[Byte]) extends RetractRead
     else decodeMultiByte(b0 & 0xff)
   }
 
-  @noinline private[this] def decodeMultiByte(b0: Int): Int =
-    if (b0 < 0xc2) Utf8ChunkReader.Replacement // stray continuation byte, or an overlong 0xc0/0xc1 lead
-    else if (b0 < 0xe0) {
-      val b1 = continuation()
-      if (b1 < 0) Utf8ChunkReader.Replacement
-      else ((b0 & 0x1f) << 6) | b1
-    } else if (b0 < 0xf0) {
-      val b1 = continuation()
-      if (b1 < 0) return Utf8ChunkReader.Replacement
-      val b2 = continuation()
-      if (b2 < 0) return Utf8ChunkReader.Replacement
+  @noinline private[this] def decodeMultiByte(b0: Int): Int = {
+    // Per-lead ranges for the second byte, from the Unicode "well-formed UTF-8 byte sequences" table. Enforcing them
+    // here rather than validating the code point afterwards is what makes the number of replacement characters match
+    // CharsetDecoder: a second byte outside the range leaves the lead as a malformed sequence on its own, and that
+    // second byte then gets examined as a fresh lead rather than being swallowed with it.
+    var lo   = 0x80
+    var hi   = 0xbf
+    val need =
+      if (b0 < 0xc2) return Utf8ChunkReader.Replacement // continuation byte on its own, or an overlong 0xc0/0xc1 lead
+      else if (b0 < 0xe0) 2
+      else if (b0 < 0xf0) {
+        if (b0 == 0xe0) lo = 0xa0 // rejects overlong forms
+        3
+      } else if (b0 < 0xf5) {
+        if (b0 == 0xf0) lo = 0x90      // rejects overlong forms
+        else if (b0 == 0xf4) hi = 0x8f // rejects anything past U+10FFFF
+        4
+      } else return Utf8ChunkReader.Replacement // no lead byte above 0xf4 is ever valid
+
+    val b1 = continuation(lo, hi)
+    if (b1 < 0) return Utf8ChunkReader.Replacement
+    if (need == 2) return ((b0 & 0x1f) << 6) | b1
+
+    val b2 = continuation(0x80, 0xbf)
+    if (b2 < 0) return Utf8ChunkReader.Replacement
+    if (need == 3) {
       val cp = ((b0 & 0x0f) << 12) | (b1 << 6) | b2
-      if (cp < 0x800 || (cp >= 0xd800 && cp <= 0xdfff)) Utf8ChunkReader.Replacement // overlong, or a lone surrogate
-      else cp
-    } else if (b0 < 0xf5) {
-      val b1 = continuation()
-      if (b1 < 0) return Utf8ChunkReader.Replacement
-      val b2 = continuation()
-      if (b2 < 0) return Utf8ChunkReader.Replacement
-      val b3 = continuation()
-      if (b3 < 0) return Utf8ChunkReader.Replacement
-      val cp = ((b0 & 0x07) << 18) | (b1 << 12) | (b2 << 6) | b3
-      if (cp < 0x10000 || cp > 0x10ffff) Utf8ChunkReader.Replacement // overlong, or beyond the Unicode range
-      else {
-        val u = cp - 0x10000
-        pending = 0xdc00 | (u & 0x3ff)
-        0xd800 | (u >> 10)
-      }
-    } else Utf8ChunkReader.Replacement // would encode beyond U+10FFFF
+      // a CESU-8 encoded surrogate is only rejected once all three bytes are in hand, so it costs one replacement
+      // rather than three. CharsetDecoder draws the same distinction: a bad second byte truncates the subpart, an
+      // otherwise well formed sequence that happens to name a surrogate does not.
+      return if (cp >= 0xd800 && cp <= 0xdfff) Utf8ChunkReader.Replacement else cp
+    }
+
+    val b3 = continuation(0x80, 0xbf)
+    if (b3 < 0) return Utf8ChunkReader.Replacement
+    // the ranges above already guarantee this is a valid code point outside the BMP
+    val u = (((b0 & 0x07) << 18) | (b1 << 12) | (b2 << 6) | b3) - 0x10000
+    pending = 0xdc00 | (u & 0x3ff)
+    0xd800 | (u >> 10)
+  }
 
   // the offending byte is deliberately left unconsumed so that it is re-examined as a fresh lead byte
-  private[this] def continuation(): Int = {
+  private[this] def continuation(lo: Int, hi: Int): Int = {
     val i = this.i
     if (i >= len) return -1
     val b = byteAt(i) & 0xff
-    if ((b & 0xc0) != 0x80) return -1
+    if (b < lo || b > hi) return -1
     this.i = i + 1
     b & 0x3f
   }

--- a/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/readers.scala
@@ -20,6 +20,8 @@ package zio.json.internal
 // synchronise on a lock, and do not require up-front decisions about buffer
 // sizes.
 
+import zio.Chunk
+
 import java.util.Arrays
 import scala.annotation._
 import scala.util.control.NoStackTrace
@@ -137,6 +139,153 @@ private[zio] final class FastStringReader(s: CharSequence) extends RetractReader
   def retract(): Unit = i -= 1
 
   def history(idx: Int): Char = s.charAt(idx)
+}
+
+/**
+ * A Reader over a `Chunk[Byte]` holding UTF-8 encoded text, decoding to chars on the fly.
+ *
+ * This exists so that bytes coming off the wire can be parsed without first being copied into a `String`: peak memory
+ * is the chunk plus a constant, instead of the chunk plus a full sized copy of it.
+ *
+ * Malformed input produces `�`, one per malformed sequence, as `new String(bytes, UTF_8)` does. The two agree on well
+ * formed input and on the usual damage (truncated tails, stray continuation bytes, overlong forms), but not byte for
+ * byte on every malformed sequence: `CharsetDecoder`'s maximal subpart rule emits three replacements for a CESU-8
+ * encoded surrogate such as `ED A0 80` where this emits one.
+ */
+private[zio] final class Utf8ChunkReader(chunk: Chunk[Byte]) extends RetractReader {
+  private[this] val len: Int     = chunk.length
+  private[this] var i: Int       = 0
+  private[this] var pending: Int = -1 // low surrogate owed to the next read
+
+  // position to rewind to on retract(). Only moved when a char is actually produced, so that retracting after the end
+  // of input replays the last real char, as FastStringReader's `i -= 1` does.
+  private[this] var markI: Int       = 0
+  private[this] var markPending: Int = -1
+
+  // Bytes are pulled through a window rather than read one at a time off the Chunk: Chunk#byte is a virtual call
+  // taking an implicit witness, and on a Chunk.Concat it walks the tree on every byte, which costs several times more
+  // than the parse itself. Bulk copying keeps that to one arraycopy per window and makes reads plain array loads.
+  private[this] val buf: Array[Byte] = new Array(math.min(len, Utf8ChunkReader.WindowSize))
+  private[this] var base: Int        = 0 // index in the chunk of buf(0)
+  private[this] var limit: Int       = 0 // number of valid bytes in buf
+
+  def close(): Unit = ()
+
+  override def read(): Int = readNext()
+
+  def readChar(): Char = {
+    val c = readNext()
+    if (c == -1) throw new UnexpectedEnd
+    c.toChar
+  }
+
+  override def nextNonWhitespace(): Char = {
+    // whitespace is always single byte, so it can be skipped without decoding. Not safe while a low surrogate is
+    // owed, since that has to come out before anything after it is consumed; the loop below handles that case.
+    if (pending < 0) {
+      val from = this.i
+      var i    = from
+      while (i < len && isAsciiWhitespace(byteAt(i)))
+        i += 1
+      if (i != from) {
+        markI = i - 1
+        markPending = -1
+      }
+      this.i = i
+    }
+    var c = readChar()
+    while (isWhitespace(c))
+      c = readChar()
+    c
+  }
+
+  def retract(): Unit = {
+    i = markI
+    pending = markPending
+  }
+
+  // callers must have checked k < len. k may be behind the window after a retract, hence the lower bound check
+  @inline private[this] def byteAt(k: Int): Byte = {
+    val j = k - base
+    if (j >= 0 && j < limit) buf(j)
+    else fill(k)
+  }
+
+  private[this] def fill(k: Int): Byte = {
+    val n = math.min(buf.length, len - k)
+    chunk.toArray(k, buf, 0, n)
+    base = k
+    limit = n
+    buf(0)
+  }
+
+  @inline private[this] def isAsciiWhitespace(b: Byte): Boolean =
+    b == ' ' || b == '\n' || b == '\r' || b == '\t'
+
+  private[this] def readNext(): Int = {
+    val pending = this.pending
+    val i       = this.i
+    if (pending >= 0) {
+      markI = i
+      markPending = pending
+      this.pending = -1
+      return pending
+    }
+    if (i >= len) return -1 // mark deliberately left alone, see above
+    markI = i
+    markPending = -1
+    val b0 = byteAt(i)
+    this.i = i + 1
+    if (b0 >= 0) b0.toInt // 0xxxxxxx, the overwhelmingly common case for JSON
+    else decodeMultiByte(b0 & 0xff)
+  }
+
+  @noinline private[this] def decodeMultiByte(b0: Int): Int =
+    if (b0 < 0xc2) Utf8ChunkReader.Replacement // stray continuation byte, or an overlong 0xc0/0xc1 lead
+    else if (b0 < 0xe0) {
+      val b1 = continuation()
+      if (b1 < 0) Utf8ChunkReader.Replacement
+      else ((b0 & 0x1f) << 6) | b1
+    } else if (b0 < 0xf0) {
+      val b1 = continuation()
+      if (b1 < 0) return Utf8ChunkReader.Replacement
+      val b2 = continuation()
+      if (b2 < 0) return Utf8ChunkReader.Replacement
+      val cp = ((b0 & 0x0f) << 12) | (b1 << 6) | b2
+      if (cp < 0x800 || (cp >= 0xd800 && cp <= 0xdfff)) Utf8ChunkReader.Replacement // overlong, or a lone surrogate
+      else cp
+    } else if (b0 < 0xf5) {
+      val b1 = continuation()
+      if (b1 < 0) return Utf8ChunkReader.Replacement
+      val b2 = continuation()
+      if (b2 < 0) return Utf8ChunkReader.Replacement
+      val b3 = continuation()
+      if (b3 < 0) return Utf8ChunkReader.Replacement
+      val cp = ((b0 & 0x07) << 18) | (b1 << 12) | (b2 << 6) | b3
+      if (cp < 0x10000 || cp > 0x10ffff) Utf8ChunkReader.Replacement // overlong, or beyond the Unicode range
+      else {
+        val u = cp - 0x10000
+        pending = 0xdc00 | (u & 0x3ff)
+        0xd800 | (u >> 10)
+      }
+    } else Utf8ChunkReader.Replacement // would encode beyond U+10FFFF
+
+  // the offending byte is deliberately left unconsumed so that it is re-examined as a fresh lead byte
+  private[this] def continuation(): Int = {
+    val i = this.i
+    if (i >= len) return -1
+    val b = byteAt(i) & 0xff
+    if ((b & 0xc0) != 0x80) return -1
+    this.i = i + 1
+    b & 0x3f
+  }
+}
+
+private[zio] object Utf8ChunkReader {
+  private final val Replacement = 0xfffd
+
+  // large enough that the copies amortise away, small enough to stay irrelevant next to the chunk itself
+  private final val WindowSize = 8192
 }
 
 // this tends to be a bit slower than creating an implementation that implements

--- a/zio-json/shared/src/main/scala/zio/json/package.scala
+++ b/zio-json/shared/src/main/scala/zio/json/package.scala
@@ -40,4 +40,14 @@ package object json extends JsonPackagePlatformSpecific {
      */
     @inline def fromJson[A](implicit decoder: JsonDecoder[A]): Either[String, A] = decoder.decodeJson(json)
   }
+
+  implicit final class DecoderBytesOps(private val json: Chunk[Byte]) extends AnyVal {
+
+    /**
+     * Attempts to decode the UTF-8 encoded bytes as an `A`, without copying them into a `String` first.
+     *
+     * Errors are reported exactly as for the `CharSequence` variant.
+     */
+    @inline def fromJson[A](implicit decoder: JsonDecoder[A]): Either[String, A] = decoder.decodeJson(json)
+  }
 }

--- a/zio-json/shared/src/main/scala/zio/json/package.scala
+++ b/zio-json/shared/src/main/scala/zio/json/package.scala
@@ -50,4 +50,14 @@ package object json extends JsonPackagePlatformSpecific {
      */
     @inline def fromJson[A](implicit decoder: JsonDecoder[A]): Either[String, A] = decoder.decodeJson(json)
   }
+
+  implicit final class DecoderByteArrayOps(private val json: Array[Byte]) extends AnyVal {
+
+    /**
+     * Attempts to decode the UTF-8 encoded bytes as an `A`, without copying them into a `String` first.
+     *
+     * Errors are reported exactly as for the `CharSequence` variant.
+     */
+    @inline def fromJson[A](implicit decoder: JsonDecoder[A]): Either[String, A] = decoder.decodeJson(json)
+  }
 }

--- a/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
@@ -116,12 +116,24 @@ object ChunkDecoderSpec extends ZIOSpecDefault {
         },
         test("decodes every code point in the BMP and a sample above it") {
           // excludes the surrogate range, which is not encodable
-          val bmp    = ((0x20 to 0xd7ff) ++ (0xe000 to 0xffff)).map(_.toChar).mkString
-          val astral = (0x10000 to 0x10ffff by 997).map(cp => new String(Character.toChars(cp))).mkString
+          val bmp    = ((0x20 to 0xd7ff) ++ (0xe000 to 0xffff)).map(_.toChar.toString)
+          val astral = (0x10000 to 0x10ffff by 997).map(cp => new String(Character.toChars(cp)))
+
+          // Decoded in batches, and only the indices of bad batches reach the assertion. Putting the whole 63k
+          // character string in the assertion instead makes zio-test hand it to PrettyPrint, which overflows a
+          // StringBuilder on Scala Native.
+          def badBatches(cps: Seq[String], size: Int): Seq[Int] =
+            cps
+              .grouped(size)
+              .zipWithIndex
+              .collect {
+                case (batch, i) if { val s = batch.mkString; bytes(quoted(s)).fromJson[String] != Right(s) } => i
+              }
+              .toSeq
 
           assertTrue(
-            bytes(quoted(bmp)).fromJson[String] == Right(bmp),
-            bytes(quoted(astral)).fromJson[String] == Right(astral)
+            badBatches(bmp, 512) == Seq.empty[Int],
+            badBatches(astral, 64) == Seq.empty[Int]
           )
         },
         test("replaces malformed input, as new String(bytes, UTF_8) does") {

--- a/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
@@ -2,7 +2,6 @@ package zio.json
 
 import zio._
 import zio.json.ast.Json
-import zio.test.Assertion._
 import zio.test._
 
 import java.nio.charset.StandardCharsets.UTF_8
@@ -15,132 +14,313 @@ object ChunkDecoderSpec extends ZIOSpecDefault {
     implicit val codec: JsonCodec[Person] = DeriveJsonCodec.gen[Person]
   }
 
-  private def bytes(s: String): Chunk[Byte] = Chunk.fromArray(s.getBytes(UTF_8))
+  /** Mirrors `Utf8ChunkReader.WindowSize`, so that the tests can straddle it deliberately. */
+  private val Window = 8192
 
-  private def viaString(c: Chunk[Byte]): String = new String(c.toArray, UTF_8)
+  private def utf8(s: String): Array[Byte] = s.getBytes(UTF_8)
 
-  /** Same bytes, but as a `Chunk.Concat` rather than a single backing array. */
-  private def split(c: Chunk[Byte], at: Int): Chunk[Byte] =
-    Chunk.fromArray(c.take(at).toArray) ++ Chunk.fromArray(c.drop(at).toArray)
+  private def bytes(s: String): Chunk[Byte] = Chunk.fromArray(utf8(s))
 
-  private def str(s: String): Chunk[Byte] = bytes(Json.Str(s).toString)
+  private def quoted(s: String): String = Json.Str(s).toString
+
+  /**
+   * Every `Chunk` shape the reader has to cope with. `Chunk.ByteArray` is read in place; everything else goes through
+   * the window, so both code paths are exercised by every case that uses this.
+   */
+  private def shapes(bs: Array[Byte]): List[(String, Chunk[Byte])] = {
+    val lead   = Array[Byte](1, 2, 3)
+    val padded = lead ++ bs ++ Array[Byte](4, 5)
+    val half   = bs.length / 2
+    List(
+      "ByteArray"        -> Chunk.fromArray(bs),
+      "ByteArray+offset" -> Chunk.ByteArray(padded, lead.length, bs.length),
+      "Concat"           -> (Chunk.fromArray(bs.take(half)) ++ Chunk.fromArray(bs.drop(half))),
+      "Concat*8"         -> bs.grouped(math.max(bs.length / 8, 1)).foldLeft(Chunk.empty[Byte])(_ ++ Chunk.fromArray(_)),
+      "Slice"            -> Chunk.fromArray(padded).drop(lead.length).take(bs.length),
+      "Iterable"         -> Chunk.fromIterable(bs.toList)
+    )
+  }
+
+  /** Every shape must decode exactly as the same bytes seen through a `String` do, errors included. */
+  private def parity[A](bs: Array[Byte])(implicit decoder: JsonDecoder[A]): TestResult = {
+    val expected = new String(bs, UTF_8).fromJson[A]
+    val wrong    = shapes(bs).collect { case (name, c) if c.fromJson[A] != expected => name -> c.fromJson[A] }
+
+    assertTrue(wrong.isEmpty)
+  }
+
+  private def parityOf[A](s: String)(implicit decoder: JsonDecoder[A]): TestResult = parity[A](utf8(s))
+
+  /** A JSON string literal built from raw bytes, so malformed UTF-8 can be fed through the parser. */
+  private def rawString(bs: Chunk[Byte]): Chunk[Byte] =
+    Chunk.fromArray(utf8("\"")) ++ bs ++ Chunk.fromArray(utf8("\""))
+
+  private def rawString(bs: Int*): Chunk[Byte] = rawString(Chunk.fromIterable(bs.map(_.toByte)))
+
+  /** Bytes that a JSON string literal can carry unescaped. Mostly malformed UTF-8, which is the point. */
+  private val genStringBytes: Gen[Any, Chunk[Byte]] =
+    Gen.chunkOfBounded(0, 32)(Gen.byte.filter(b => b != '"' && b != '\\' && (b & 0xff) >= 0x20))
 
   val spec: Spec[Environment, Any] =
     suite("ChunkDecoder")(
-      suite("fromJson")(
+      suite("values")(
         test("decodes the same values as the CharSequence path") {
           val json = """{"name":"Jules","age":42}"""
 
-          assert(bytes(json).fromJson[Person])(isRight(equalTo(Person("Jules", 42)))) &&
-          assertTrue(bytes(json).fromJson[Person] == json.fromJson[Person])
+          assertTrue(
+            bytes(json).fromJson[Person] == Right(Person("Jules", 42)),
+            bytes(json).fromJson[Person] == json.fromJson[Person]
+          )
         },
-        test("decodes multi-byte characters") {
-          // 1, 2, 3 and 4 byte UTF-8 sequences, the last one a surrogate pair
-          assert(str("a").fromJson[String])(isRight(equalTo("a"))) &&
-          assert(str("é").fromJson[String])(isRight(equalTo("é"))) &&
-          assert(str("中€").fromJson[String])(isRight(equalTo("中€"))) &&
-          assert(str("😀").fromJson[String])(isRight(equalTo("😀"))) &&
-          assert(str("aé中😀z").fromJson[String])(isRight(equalTo("aé中😀z")))
+        test("decodes every scalar type") {
+          assertTrue(
+            bytes("true").fromJson[Boolean] == Right(true),
+            bytes("null").fromJson[Option[Int]] == Right(None),
+            bytes(""""a"""").fromJson[Char] == Right('a'),
+            bytes("-128").fromJson[Byte] == Right(Byte.MinValue),
+            bytes("32767").fromJson[Short] == Right(Short.MaxValue),
+            bytes("-2147483648").fromJson[Int] == Right(Int.MinValue),
+            bytes("9223372036854775807").fromJson[Long] == Right(Long.MaxValue),
+            bytes("-1.5e3").fromJson[Double] == Right(-1500.0),
+            bytes("1e-3").fromJson[Float] == Right(0.001f),
+            bytes("123456789012345678901234567890").fromJson[BigInt] == Right(BigInt("123456789012345678901234567890")),
+            bytes("0.1234567890123456789").fromJson[BigDecimal] == Right(BigDecimal("0.1234567890123456789"))
+          )
+        },
+        test("decodes collections and nesting") {
+          assertTrue(
+            bytes("[]").fromJson[List[Int]] == Right(Nil),
+            bytes("[[1],[2,3],[]]").fromJson[List[List[Int]]] == Right(List(List(1), List(2, 3), Nil)),
+            bytes("""{"a":1,"b":2}""").fromJson[Map[String, Int]] == Right(Map("a" -> 1, "b" -> 2))
+          ) &&
+          parityOf[Json]("""{"a":[1,"é",true,null,{"b":[[[]]]}],"c":{"😀":1.5}}""")
+        },
+        test("decodes string escapes") {
+          val escapes = """"a\"b\\c\/d\be\ff\ng\rh\tiéj😀k""""
+
+          assertTrue(bytes(escapes).fromJson[String] == Right("a\"b\\c/d\be\ff\ng\rh\tiéj😀k")) &&
+          parity[String](utf8(escapes))
+        }
+      ),
+      suite("UTF-8")(
+        test("decodes 1, 2, 3 and 4 byte sequences") {
+          val texts = List("a", "é", "中", "€", "😀", "aé中😀z", "", "߿", "ࠀ", "￿", "𝄞")
+
+          assertTrue(texts.forall(t => bytes(quoted(t)).fromJson[String] == Right(t)))
         },
         test("decodes multi-byte characters in field names") {
-          final case class Süß(größe: Int)
+          final case class Süß(größe: Int, `🔑`: String)
           implicit val decoder: JsonDecoder[Süß] = DeriveJsonDecoder.gen[Süß]
 
-          assert(bytes("""{"größe":3}""").fromJson[Süß])(isRight(equalTo(Süß(3))))
+          assertTrue(bytes("""{"größe":3,"🔑":"é"}""").fromJson[Süß] == Right(Süß(3, "é")))
         },
+        test("decodes every code point in the BMP and a sample above it") {
+          // excludes the surrogate range, which is not encodable
+          val bmp    = ((0x20 to 0xd7ff) ++ (0xe000 to 0xffff)).map(_.toChar).mkString
+          val astral = (0x10000 to 0x10ffff by 997).map(cp => new String(Character.toChars(cp))).mkString
+
+          assertTrue(
+            bytes(quoted(bmp)).fromJson[String] == Right(bmp),
+            bytes(quoted(astral)).fromJson[String] == Right(astral)
+          )
+        },
+        test("replaces malformed input, as new String(bytes, UTF_8) does") {
+          def decode(bs: Int*): Either[String, String] = rawString(bs: _*).fromJson[String]
+
+          assertTrue(
+            decode(0xc3) == Right("�") &&                        // truncated 2 byte sequence
+              decode(0x80) == Right("�") &&                      // stray continuation byte
+              decode(0xbf) == Right("�") &&                      // stray continuation byte, high
+              decode(0xc3, 0x28) == Right("�(") &&               // bad continuation, byte re-examined
+              decode(0xc0, 0x80) == Right("��") &&               // overlong NUL
+              decode(0xc1, 0xbf) == Right("��") &&               // overlong solidus
+              decode(0xe0, 0x80, 0x80) == Right("���") &&        // overlong, 3 byte
+              decode(0xe0, 0xa0) == Right("�") &&                // truncated 3 byte sequence
+              decode(0xe2, 0x82) == Right("�") &&                // truncated euro sign
+              decode(0xf0, 0x9f, 0x98) == Right("�") &&          // truncated 4 byte sequence
+              decode(0xf0, 0x80, 0x80, 0x80) == Right("����") && // overlong, 4 byte
+              decode(0xf5, 0x80, 0x80, 0x80) == Right("����") && // beyond U+10FFFF
+              decode(0xff) == Right("�") &&                      // never valid in UTF-8
+              decode(0xfe) == Right("�"),
+            decode(0xed, 0xa0, 0x80) == Right("�") &&     // CESU-8 surrogate, one subpart of three
+              decode(0x41, 0x80, 0x42) == Right("A�B") && // recovers to the next valid byte
+              decode(0xc3, 0xa9, 0x80, 0xc3, 0xa9) == Right("é�é")
+          )
+        },
+        test("matches CharsetDecoder on every one and two byte sequence") {
+          // exhaustive over lead bytes, and over second bytes that a JSON string literal can carry
+          val leads   = 0x80 to 0xff
+          val seconds = (0x20 to 0xff).filter(b => b != '"'.toInt && b != '\\'.toInt)
+          val singles = leads.map(b => Chunk.single(b.toByte))
+          val pairs   = for { a <- leads; b <- seconds } yield Chunk(a.toByte, b.toByte)
+
+          assertTrue((singles ++ pairs).filterNot(agreesWithJdk).isEmpty)
+        } @@ TestAspect.jvmOnly,
+        test("matches CharsetDecoder on three and four byte sequences") {
+          val leads  = 0xc0 to 0xff
+          val probes = Seq(0x80, 0x8f, 0x90, 0x9f, 0xa0, 0xbf, 0xc0, 0x41, 0xff)
+          val threes = for { a <- leads; b <- probes; c <- probes } yield Chunk(a.toByte, b.toByte, c.toByte)
+          val fours  =
+            for { a <- leads; b <- probes; c <- probes } yield Chunk(a.toByte, b.toByte, c.toByte, 0x80.toByte)
+
+          assertTrue((threes ++ fours).filterNot(agreesWithJdk).map(hex).isEmpty)
+        } @@ TestAspect.jvmOnly,
+        test("decodes arbitrary bytes the same way whatever the chunk shape") {
+          check(genStringBytes) { bs =>
+            val results = shapes(rawString(bs).toArray).map { case (_, c) => c.fromJson[String] }
+
+            assertTrue(results.distinct.size == 1)
+          }
+        },
+        test("agrees with the CharSequence path on arbitrary bytes inside a string literal") {
+          // most of these are malformed; both sides see exactly the same bytes, so they must still agree
+          check(genStringBytes)(bs => parity[String](rawString(bs).toArray))
+        } @@ TestAspect.jvmOnly
+      ),
+      suite("Chunk shapes")(
+        test("decodes identically whatever shape the chunk has") {
+          parityOf[Person]("""{"name":"aé中😀z","age":42}""") &&
+          parityOf[Json]("""[1,"é",{"a":[true,null]},2.5]""") &&
+          parityOf[List[Int]]((1 to 500).toList.toJson)
+        },
+        test("decodes concatenations split at every byte offset") {
+          val all = utf8("""{"name":"aé中😀z","age":42}""")
+
+          // including split points that fall inside a multi-byte sequence
+          assertTrue((0 to all.length).forall { at =>
+            val c = Chunk.fromArray(all.take(at)) ++ Chunk.fromArray(all.drop(at))
+            c.fromJson[Person] == Right(Person("aé中😀z", 42))
+          })
+        },
+        test("decodes from a bare Array[Byte] too") {
+          val arr = utf8("""{"name":"é","age":42}""")
+
+          assertTrue(
+            arr.fromJson[Person] == Right(Person("é", 42)),
+            JsonDecoder[Person].decodeJson(arr) == Right(Person("é", 42)),
+            arr.fromJson[Person] == Chunk.fromArray(arr).fromJson[Person],
+            Array.empty[Byte].fromJson[Person] == Left("Unexpected end of input")
+          )
+        },
+        test("handles empty and single byte chunks") {
+          assertTrue(
+            Chunk.empty[Byte].fromJson[Person] == Left("Unexpected end of input"),
+            Chunk.single('1'.toByte).fromJson[Int] == Right(1),
+            Chunk.empty[Byte].fromJson[Json] == "".fromJson[Json]
+          ) &&
+          parityOf[Int]("7")
+        }
+      ),
+      suite("window boundaries")(
+        test("decodes payloads either side of the window size") {
+          // the payload is padded to land exactly on, just under and just over one window
+          val sizes = List(Window - 1, Window, Window + 1, 2 * Window, 2 * Window + 1)
+
+          assertTrue(sizes.forall { size =>
+            val filler = "x" * (size - utf8("""{"name":"","age":42}""").length)
+            val doc    = s"""{"name":"$filler","age":42}"""
+
+            bytes(doc).fromJson[Person] == Right(Person(filler, 42))
+          })
+        },
+        test("decodes multi-byte characters straddling the boundary at every alignment") {
+          // the padding shifts every sequence along by a byte, so a 2, 3 and 4 byte sequence each land on the split
+          val texts = (0 to 3).map(pad => "a" * pad + "é中😀" * 4000)
+
+          assertTrue(
+            texts.forall(t => bytes(quoted(t)).fromJson[String] == Right(t)),
+            texts.forall { t =>
+              val bs = utf8(quoted(t))
+              (Chunk.fromArray(bs.take(Window)) ++ Chunk.fromArray(bs.drop(Window))).fromJson[String] == Right(t)
+            }
+          )
+        },
+        test("decodes payloads larger than the window") {
+          // numbers have no terminator, so every element retracts, including across a refill
+          val ints = (1 to 20000).toList
+          val all  = utf8(ints.toJson)
+
+          assertTrue(
+            all.length > Window,
+            shapes(all).forall { case (_, c) => c.fromJson[List[Int]] == Right(ints) }
+          )
+        },
+        test("retracts to a position the window has already moved past") {
+          // more leading whitespace than the window holds, then a number running to the very end of input: the number
+          // retracts after hitting the end, by which point the window no longer covers the retract target
+          val padded = " " * (3 * Window) + "42"
+
+          assertTrue(bytes(padded).fromJson[Int] == Right(42)) &&
+          parityOf[Int](padded) &&
+          parityOf[Int](" " * (3 * Window))
+        }
+      ),
+      suite("parser interaction")(
         test("skips whitespace") {
           val json = "  {\n\t\"name\" : \"Jules\" ,\r\n  \"age\" : 42\n}  "
 
-          assert(bytes(json).fromJson[Person])(isRight(equalTo(Person("Jules", 42))))
+          assertTrue(bytes(json).fromJson[Person] == Right(Person("Jules", 42))) &&
+          parityOf[Person](json)
         },
-        test("decodes chunks that are not backed by a single array") {
-          val json = """{"name":"aé中😀z","age":42}"""
-          val all  = bytes(json)
-
-          // every split point, including ones that fall inside a multi-byte sequence
-          assertTrue((0 to all.length).forall(at => split(all, at).fromJson[Person] == all.fromJson[Person]))
-        },
-        test("decodes payloads larger than the internal window") {
-          // numbers have no terminator, so every element retracts, including across a window refill
-          val ints = (1 to 20000).toList
-          val all  = bytes(ints.toJson)
-
-          assertTrue(all.length > 8192) &&
-          assert(all.fromJson[List[Int]])(isRight(equalTo(ints))) &&
-          assert(split(all, all.length / 3).fromJson[List[Int]])(isRight(equalTo(ints)))
-        },
-        test("retracts to a position the window has already moved past") {
-          // more leading whitespace than the window holds, then a number running to the very end of input: the
-          // number retracts after hitting the end, by which point the window no longer covers the marked position
-          val padded = " " * 20000 + "42"
-
-          assert(bytes(padded).fromJson[Int])(isRight(equalTo(42))) &&
-          assertTrue(bytes(padded).fromJson[Int] == padded.fromJson[Int]) &&
-          assertTrue(bytes(" " * 20000).fromJson[Int] == (" " * 20000).fromJson[Int])
-        },
-        test("decodes multi-byte characters straddling the window boundary") {
-          // the padding shifts every sequence by one byte, so across the four cases a 2, 3 and 4 byte sequence each
-          // land on the boundary
-          val texts = (0 to 3).map(pad => "a" * pad + "é中😀" * 4000)
-
-          assertTrue(texts.forall(t => str(t).fromJson[String] == Right(t)))
-        },
-        test("reports the same errors as the CharSequence path") {
-          val cases = List(
-            "",
-            "   ",
-            """{"name":"x","age":""",
-            """{"name":"x","age":"nope"}""",
-            """{"name":"x"}""",
-            """{"name":"x","age":1""",
-            """[1,2,""",
-            """{"name":"é","age":"nope"}"""
-          )
-
-          assertTrue(cases.forall(json => bytes(json).fromJson[Person] == json.fromJson[Person])) &&
-          assert(bytes("").fromJson[Person])(isLeft(equalTo("Unexpected end of input"))) &&
-          assert(bytes("""{"name":"x","age":"nope"}""").fromJson[Person])(isLeft(equalTo(".age(expected an Int)")))
-        },
-        test("retracts correctly at the end of input") {
+        test("retracts at the end of input") {
           // numbers have no terminator, so the parser reads one char past them and retracts
-          assert(bytes("42").fromJson[Int])(isRight(equalTo(42))) &&
-          assert(bytes("-1.5e3").fromJson[Double])(isRight(equalTo(-1500.0))) &&
-          assert(bytes("[1,2,3]").fromJson[List[Int]])(isRight(equalTo(List(1, 2, 3)))) &&
-          assert(bytes(" 42 ").fromJson[Int])(isRight(equalTo(42)))
+          assertTrue(
+            bytes("42").fromJson[Int] == Right(42),
+            bytes("-1.5e3").fromJson[Double] == Right(-1500.0),
+            bytes("[1,2,3]").fromJson[List[Int]] == Right(List(1, 2, 3)),
+            bytes(" 42 ").fromJson[Int] == Right(42)
+          ) &&
+          parityOf[Int]("42") &&
+          parityOf[List[Int]]("[1,2,3]")
         },
         test("supports decoders that rewind") {
           // orElse wraps the reader in a RecordingReader, which retracts and replays
           implicit val decoder: JsonDecoder[Either[Int, Person]] = JsonDecoder[Int].orElseEither(JsonDecoder[Person])
 
-          assert(bytes("42").fromJson[Either[Int, Person]])(isRight(isLeft(equalTo(42)))) &&
-          assert(bytes("""{"name":"é","age":42}""").fromJson[Either[Int, Person]])(
-            isRight(isRight(equalTo(Person("é", 42))))
+          assertTrue(
+            bytes("42").fromJson[Either[Int, Person]] == Right(Left(42)),
+            bytes("""{"name":"é","age":42}""").fromJson[Either[Int, Person]] == Right(Right(Person("é", 42)))
+          ) &&
+          // long enough that the rewind spans a window refill
+          parity[Either[Int, Person]](utf8(s"""{"name":"${"é" * Window}","age":1}"""))
+        },
+        test("rewinds after a multi-byte character") {
+          // the retract lands mid surrogate pair, which is the one case the position alone does not describe
+          implicit val decoder: JsonDecoder[Either[Int, String]] = JsonDecoder[Int].orElseEither(JsonDecoder[String])
+
+          assertTrue(bytes(quoted("😀é")).fromJson[Either[Int, String]] == Right(Right("😀é")))
+        }
+      ),
+      suite("errors")(
+        test("reports the same errors as the CharSequence path") {
+          val cases = List(
+            "",
+            "   ",
+            "\n\t",
+            """{""",
+            """{"name":"x","age":""",
+            """{"name":"x","age":"nope"}""",
+            """{"name":"x"}""",
+            """{"name":"x","age":1""",
+            """{"name":"x","age":1}}""",
+            """{"name":"x","age":1,}""",
+            """[1,2,""",
+            """{"name":"é","age":"nope"}""",
+            """{"name":"é😀","age":""",
+            """"unterminated""",
+            """{"name":"x","age":1.2.3}""",
+            """tru""",
+            """nul"""
           )
-        },
-        test("decodes into the AST") {
-          val json = """{"a":[1,"é",true,null],"b":{"😀":1.5}}"""
 
-          assertTrue(bytes(json).fromJson[Json] == json.fromJson[Json])
+          cases.map(parityOf[Person](_)).reduce(_ && _)
         },
-        test("replaces malformed UTF-8, as new String(bytes, UTF_8) does") {
-          def decode(bs: Int*): Either[String, String] =
-            (Chunk.fromArray("\"".getBytes(UTF_8)) ++ Chunk.fromIterable(bs.map(_.toByte)) ++
-              Chunk.fromArray("\"".getBytes(UTF_8))).fromJson[String]
-
-          assert(decode(0xc3))(isRight(equalTo("�"))) &&                      // truncated 2 byte sequence
-          assert(decode(0x80))(isRight(equalTo("�"))) &&                      // stray continuation byte
-          assert(decode(0xc3, 0x28))(isRight(equalTo("�("))) &&               // bad continuation, byte re-examined
-          assert(decode(0xc0, 0x80))(isRight(equalTo("��"))) &&               // overlong encoding of NUL
-          assert(decode(0xe0, 0xa0))(isRight(equalTo("�"))) &&                // truncated 3 byte sequence
-          assert(decode(0xf5, 0x80, 0x80, 0x80))(isRight(equalTo("����"))) && // beyond U+10FFFF
-          assert(decode(0xed, 0xa0, 0x80))(isRight(equalTo("�")))             // CESU-8 surrogate, see the scaladoc
-        },
-        test("agrees with the CharSequence path on generated input") {
-          check(Gen.string(Gen.unicodeChar), Gen.int) { (name, age) =>
-            val bs = bytes(Person(name, age).toJson)
-
-            assertTrue(bs.fromJson[Person] == viaString(bs).fromJson[Person])
-          }
+        test("reports the documented error strings") {
+          assertTrue(
+            bytes("").fromJson[Person] == Left("Unexpected end of input"),
+            bytes("""{"name":"x","age":"nope"}""").fromJson[Person] == Left(".age(expected an Int)"),
+            bytes("""{"name":"x"}""").fromJson[Person] == Left(".age(missing)")
+          )
         },
         test("agrees with the CharSequence path on every truncation") {
           // truncating at every byte offset walks the parser into each of its end-of-input and retract corners
@@ -148,19 +328,81 @@ object ChunkDecoderSpec extends ZIOSpecDefault {
             """{"name":"Jules","age":42}""",
             """{"name":"aé中😀z","age":-1}""",
             """ { "name" : "x" , "age" : 42 } """,
-            """{"age":42,"name":"x","extra":[1,2,{"a":null}]}"""
+            """{"age":42,"name":"x","extra":[1,2,{"a":null}]}""",
+            """[1,2.5,true,null,"é",{"a":[]}]"""
           )
 
           assertTrue(docs.forall { doc =>
-            val all = bytes(doc)
+            val all = utf8(doc)
             (0 to all.length).forall { n =>
-              val prefix = all.take(n)
-              // compare against the same bytes seen as a String, so a split multi-byte char is not the difference
-              prefix.fromJson[Person] == viaString(prefix).fromJson[Person] &&
-              prefix.fromJson[Json] == viaString(prefix).fromJson[Json]
+              val prefix   = all.take(n)
+              val expected = new String(prefix, UTF_8)
+              // compared against the same bytes seen as a String, so a split multi-byte char is not the difference
+              prefix2Chunks(prefix).forall(c =>
+                c.fromJson[Person] == expected.fromJson[Person] && c.fromJson[Json] == expected.fromJson[Json]
+              )
             }
           })
         }
+      ),
+      suite("properties")(
+        test("agrees with the CharSequence path on generated values") {
+          check(Gen.string(Gen.unicodeChar), Gen.int) { (name, age) =>
+            parity[Person](utf8(Person(name, age).toJson))
+          }
+        },
+        test("agrees with the CharSequence path on generated ASTs") {
+          check(genJson(3)) { json =>
+            parity[Json](utf8(json.toString))
+          }
+        },
+        test("round trips generated strings") {
+          check(Gen.string(Gen.unicodeChar)) { s =>
+            assertTrue(bytes(quoted(s)).fromJson[String] == Right(s))
+          }
+        }
       )
     )
+
+  /**
+   * Feeds raw bytes through a JSON string literal and checks the decoded text against what the JDK's own UTF-8 decoder
+   * makes of the same bytes. JVM only: other platforms do not promise CharsetDecoder's replacement rules.
+   */
+  private def agreesWithJdk(bs: Chunk[Byte]): Boolean = {
+    val doc = Chunk.fromArray(utf8("\"")) ++ bs ++ Chunk.fromArray(utf8("\""))
+
+    doc.fromJson[String] == Right(new String(bs.toArray, UTF_8))
+  }
+
+  private def hex(bs: Chunk[Byte]): String = bs.map(b => f"${b & 0xff}%02X").mkString(" ")
+
+  private def genJson(depth: Int): Gen[Any, Json] = {
+    val leaf: Gen[Any, Json] = Gen.oneOf(
+      Gen.const(Json.Null),
+      Gen.boolean.map(Json.Bool(_)),
+      Gen.int(-100000, 100000).map(i => Json.Num(i)),
+      Gen.string(Gen.unicodeChar).map(Json.Str(_))
+    )
+
+    if (depth <= 0) leaf
+    else {
+      val field = for {
+        k <- Gen.alphaNumericString
+        v <- genJson(depth - 1)
+      } yield k -> v
+
+      Gen.oneOf(
+        leaf,
+        Gen.chunkOfBounded(0, 4)(genJson(depth - 1)).map(Json.Arr(_)),
+        // duplicate keys make a Json.Obj unequal even to itself, since Json.equals collapses fields into a Map
+        Gen.chunkOfBounded(0, 4)(field).map(fs => Json.Obj(fs.zipWithIndex.map { case ((k, v), n) => s"$k$n" -> v }))
+      )
+    }
+  }
+
+  /** Both code paths, for the truncation sweep, without paying for the full shape list on every prefix. */
+  private def prefix2Chunks(bs: Array[Byte]): List[Chunk[Byte]] = {
+    val half = bs.length / 2
+    List(Chunk.fromArray(bs), Chunk.fromArray(bs.take(half)) ++ Chunk.fromArray(bs.drop(half)))
+  }
 }

--- a/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
@@ -128,23 +128,23 @@ object ChunkDecoderSpec extends ZIOSpecDefault {
           def decode(bs: Int*): Either[String, String] = rawString(bs: _*).fromJson[String]
 
           assertTrue(
-            decode(0xc3) == Right("�") &&                        // truncated 2 byte sequence
-              decode(0x80) == Right("�") &&                      // stray continuation byte
-              decode(0xbf) == Right("�") &&                      // stray continuation byte, high
-              decode(0xc3, 0x28) == Right("�(") &&               // bad continuation, byte re-examined
-              decode(0xc0, 0x80) == Right("��") &&               // overlong NUL
-              decode(0xc1, 0xbf) == Right("��") &&               // overlong solidus
-              decode(0xe0, 0x80, 0x80) == Right("���") &&        // overlong, 3 byte
-              decode(0xe0, 0xa0) == Right("�") &&                // truncated 3 byte sequence
-              decode(0xe2, 0x82) == Right("�") &&                // truncated euro sign
-              decode(0xf0, 0x9f, 0x98) == Right("�") &&          // truncated 4 byte sequence
-              decode(0xf0, 0x80, 0x80, 0x80) == Right("����") && // overlong, 4 byte
-              decode(0xf5, 0x80, 0x80, 0x80) == Right("����") && // beyond U+10FFFF
-              decode(0xff) == Right("�") &&                      // never valid in UTF-8
-              decode(0xfe) == Right("�"),
-            decode(0xed, 0xa0, 0x80) == Right("�") &&     // CESU-8 surrogate, one subpart of three
-              decode(0x41, 0x80, 0x42) == Right("A�B") && // recovers to the next valid byte
-              decode(0xc3, 0xa9, 0x80, 0xc3, 0xa9) == Right("é�é")
+            decode(0xc3) == Right("\ufffd"),                                     // truncated 2 byte sequence
+            decode(0x80) == Right("\ufffd"),                                     // stray continuation byte
+            decode(0xbf) == Right("\ufffd"),                                     // stray continuation byte, high
+            decode(0xc3, 0x28) == Right("\ufffd("),                              // bad continuation, byte re-examined
+            decode(0xc0, 0x80) == Right("\ufffd\ufffd"),                         // overlong NUL
+            decode(0xc1, 0xbf) == Right("\ufffd\ufffd"),                         // overlong solidus
+            decode(0xe0, 0x80, 0x80) == Right("\ufffd\ufffd\ufffd"),             // overlong, 3 byte
+            decode(0xe0, 0xa0) == Right("\ufffd"),                               // truncated 3 byte sequence
+            decode(0xe2, 0x82) == Right("\ufffd"),                               // truncated euro sign
+            decode(0xf0, 0x9f, 0x98) == Right("\ufffd"),                         // truncated 4 byte sequence
+            decode(0xf0, 0x80, 0x80, 0x80) == Right("\ufffd\ufffd\ufffd\ufffd"), // overlong, 4 byte
+            decode(0xf5, 0x80, 0x80, 0x80) == Right("\ufffd\ufffd\ufffd\ufffd"), // beyond U+10FFFF
+            decode(0xff) == Right("\ufffd"),                                     // never valid in UTF-8
+            decode(0xfe) == Right("\ufffd"),
+            decode(0xed, 0xa0, 0x80) == Right("\ufffd"),   // CESU-8 surrogate, one subpart of three
+            decode(0x41, 0x80, 0x42) == Right("A\ufffdB"), // recovers to the next valid byte
+            decode(0xc3, 0xa9, 0x80, 0xc3, 0xa9) == Right("\u00e9\ufffd\u00e9")
           )
         },
         test("matches CharsetDecoder on every one and two byte sequence") {
@@ -368,11 +368,8 @@ object ChunkDecoderSpec extends ZIOSpecDefault {
    * Feeds raw bytes through a JSON string literal and checks the decoded text against what the JDK's own UTF-8 decoder
    * makes of the same bytes. JVM only: other platforms do not promise CharsetDecoder's replacement rules.
    */
-  private def agreesWithJdk(bs: Chunk[Byte]): Boolean = {
-    val doc = Chunk.fromArray(utf8("\"")) ++ bs ++ Chunk.fromArray(utf8("\""))
-
-    doc.fromJson[String] == Right(new String(bs.toArray, UTF_8))
-  }
+  private def agreesWithJdk(bs: Chunk[Byte]): Boolean =
+    rawString(bs).fromJson[String] == Right(new String(bs.toArray, UTF_8))
 
   private def hex(bs: Chunk[Byte]): String = bs.map(b => f"${b & 0xff}%02X").mkString(" ")
 

--- a/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
@@ -1,0 +1,166 @@
+package zio.json
+
+import zio._
+import zio.json.ast.Json
+import zio.test.Assertion._
+import zio.test._
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+object ChunkDecoderSpec extends ZIOSpecDefault {
+
+  final case class Person(name: String, age: Int)
+
+  object Person {
+    implicit val codec: JsonCodec[Person] = DeriveJsonCodec.gen[Person]
+  }
+
+  private def bytes(s: String): Chunk[Byte] = Chunk.fromArray(s.getBytes(UTF_8))
+
+  private def viaString(c: Chunk[Byte]): String = new String(c.toArray, UTF_8)
+
+  /** Same bytes, but as a `Chunk.Concat` rather than a single backing array. */
+  private def split(c: Chunk[Byte], at: Int): Chunk[Byte] =
+    Chunk.fromArray(c.take(at).toArray) ++ Chunk.fromArray(c.drop(at).toArray)
+
+  private def str(s: String): Chunk[Byte] = bytes(Json.Str(s).toString)
+
+  val spec: Spec[Environment, Any] =
+    suite("ChunkDecoder")(
+      suite("fromJson")(
+        test("decodes the same values as the CharSequence path") {
+          val json = """{"name":"Jules","age":42}"""
+
+          assert(bytes(json).fromJson[Person])(isRight(equalTo(Person("Jules", 42)))) &&
+          assertTrue(bytes(json).fromJson[Person] == json.fromJson[Person])
+        },
+        test("decodes multi-byte characters") {
+          // 1, 2, 3 and 4 byte UTF-8 sequences, the last one a surrogate pair
+          assert(str("a").fromJson[String])(isRight(equalTo("a"))) &&
+          assert(str("é").fromJson[String])(isRight(equalTo("é"))) &&
+          assert(str("中€").fromJson[String])(isRight(equalTo("中€"))) &&
+          assert(str("😀").fromJson[String])(isRight(equalTo("😀"))) &&
+          assert(str("aé中😀z").fromJson[String])(isRight(equalTo("aé中😀z")))
+        },
+        test("decodes multi-byte characters in field names") {
+          final case class Süß(größe: Int)
+          implicit val decoder: JsonDecoder[Süß] = DeriveJsonDecoder.gen[Süß]
+
+          assert(bytes("""{"größe":3}""").fromJson[Süß])(isRight(equalTo(Süß(3))))
+        },
+        test("skips whitespace") {
+          val json = "  {\n\t\"name\" : \"Jules\" ,\r\n  \"age\" : 42\n}  "
+
+          assert(bytes(json).fromJson[Person])(isRight(equalTo(Person("Jules", 42))))
+        },
+        test("decodes chunks that are not backed by a single array") {
+          val json = """{"name":"aé中😀z","age":42}"""
+          val all  = bytes(json)
+
+          // every split point, including ones that fall inside a multi-byte sequence
+          assertTrue((0 to all.length).forall(at => split(all, at).fromJson[Person] == all.fromJson[Person]))
+        },
+        test("decodes payloads larger than the internal window") {
+          // numbers have no terminator, so every element retracts, including across a window refill
+          val ints = (1 to 20000).toList
+          val all  = bytes(ints.toJson)
+
+          assertTrue(all.length > 8192) &&
+          assert(all.fromJson[List[Int]])(isRight(equalTo(ints))) &&
+          assert(split(all, all.length / 3).fromJson[List[Int]])(isRight(equalTo(ints)))
+        },
+        test("retracts to a position the window has already moved past") {
+          // more leading whitespace than the window holds, then a number running to the very end of input: the
+          // number retracts after hitting the end, by which point the window no longer covers the marked position
+          val padded = " " * 20000 + "42"
+
+          assert(bytes(padded).fromJson[Int])(isRight(equalTo(42))) &&
+          assertTrue(bytes(padded).fromJson[Int] == padded.fromJson[Int]) &&
+          assertTrue(bytes(" " * 20000).fromJson[Int] == (" " * 20000).fromJson[Int])
+        },
+        test("decodes multi-byte characters straddling the window boundary") {
+          // the padding shifts every sequence by one byte, so across the four cases a 2, 3 and 4 byte sequence each
+          // land on the boundary
+          val texts = (0 to 3).map(pad => "a" * pad + "é中😀" * 4000)
+
+          assertTrue(texts.forall(t => str(t).fromJson[String] == Right(t)))
+        },
+        test("reports the same errors as the CharSequence path") {
+          val cases = List(
+            "",
+            "   ",
+            """{"name":"x","age":""",
+            """{"name":"x","age":"nope"}""",
+            """{"name":"x"}""",
+            """{"name":"x","age":1""",
+            """[1,2,""",
+            """{"name":"é","age":"nope"}"""
+          )
+
+          assertTrue(cases.forall(json => bytes(json).fromJson[Person] == json.fromJson[Person])) &&
+          assert(bytes("").fromJson[Person])(isLeft(equalTo("Unexpected end of input"))) &&
+          assert(bytes("""{"name":"x","age":"nope"}""").fromJson[Person])(isLeft(equalTo(".age(expected an Int)")))
+        },
+        test("retracts correctly at the end of input") {
+          // numbers have no terminator, so the parser reads one char past them and retracts
+          assert(bytes("42").fromJson[Int])(isRight(equalTo(42))) &&
+          assert(bytes("-1.5e3").fromJson[Double])(isRight(equalTo(-1500.0))) &&
+          assert(bytes("[1,2,3]").fromJson[List[Int]])(isRight(equalTo(List(1, 2, 3)))) &&
+          assert(bytes(" 42 ").fromJson[Int])(isRight(equalTo(42)))
+        },
+        test("supports decoders that rewind") {
+          // orElse wraps the reader in a RecordingReader, which retracts and replays
+          implicit val decoder: JsonDecoder[Either[Int, Person]] = JsonDecoder[Int].orElseEither(JsonDecoder[Person])
+
+          assert(bytes("42").fromJson[Either[Int, Person]])(isRight(isLeft(equalTo(42)))) &&
+          assert(bytes("""{"name":"é","age":42}""").fromJson[Either[Int, Person]])(
+            isRight(isRight(equalTo(Person("é", 42))))
+          )
+        },
+        test("decodes into the AST") {
+          val json = """{"a":[1,"é",true,null],"b":{"😀":1.5}}"""
+
+          assertTrue(bytes(json).fromJson[Json] == json.fromJson[Json])
+        },
+        test("replaces malformed UTF-8, as new String(bytes, UTF_8) does") {
+          def decode(bs: Int*): Either[String, String] =
+            (Chunk.fromArray("\"".getBytes(UTF_8)) ++ Chunk.fromIterable(bs.map(_.toByte)) ++
+              Chunk.fromArray("\"".getBytes(UTF_8))).fromJson[String]
+
+          assert(decode(0xc3))(isRight(equalTo("�"))) &&                      // truncated 2 byte sequence
+          assert(decode(0x80))(isRight(equalTo("�"))) &&                      // stray continuation byte
+          assert(decode(0xc3, 0x28))(isRight(equalTo("�("))) &&               // bad continuation, byte re-examined
+          assert(decode(0xc0, 0x80))(isRight(equalTo("��"))) &&               // overlong encoding of NUL
+          assert(decode(0xe0, 0xa0))(isRight(equalTo("�"))) &&                // truncated 3 byte sequence
+          assert(decode(0xf5, 0x80, 0x80, 0x80))(isRight(equalTo("����"))) && // beyond U+10FFFF
+          assert(decode(0xed, 0xa0, 0x80))(isRight(equalTo("�")))             // CESU-8 surrogate, see the scaladoc
+        },
+        test("agrees with the CharSequence path on generated input") {
+          check(Gen.string(Gen.unicodeChar), Gen.int) { (name, age) =>
+            val bs = bytes(Person(name, age).toJson)
+
+            assertTrue(bs.fromJson[Person] == viaString(bs).fromJson[Person])
+          }
+        },
+        test("agrees with the CharSequence path on every truncation") {
+          // truncating at every byte offset walks the parser into each of its end-of-input and retract corners
+          val docs = List(
+            """{"name":"Jules","age":42}""",
+            """{"name":"aé中😀z","age":-1}""",
+            """ { "name" : "x" , "age" : 42 } """,
+            """{"age":42,"name":"x","extra":[1,2,{"a":null}]}"""
+          )
+
+          assertTrue(docs.forall { doc =>
+            val all = bytes(doc)
+            (0 to all.length).forall { n =>
+              val prefix = all.take(n)
+              // compare against the same bytes seen as a String, so a split multi-byte char is not the difference
+              prefix.fromJson[Person] == viaString(prefix).fromJson[Person] &&
+              prefix.fromJson[Json] == viaString(prefix).fromJson[Json]
+            }
+          })
+        }
+      )
+    )
+}

--- a/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
+++ b/zio-json/shared/src/test/scala/zio/json/ChunkDecoderSpec.scala
@@ -87,6 +87,23 @@ object ChunkDecoderSpec extends ZIOSpecDefault {
             bytes("0.1234567890123456789").fromJson[BigDecimal] == Right(BigDecimal("0.1234567890123456789"))
           )
         },
+        test("agrees with the CharSequence path for every scalar type") {
+          // the scalar decoders reach UnsafeNumbers by a different route than the AST does, so they get their own sweep
+          parityOf[Boolean]("true") &&
+          parityOf[Option[Int]]("null") &&
+          parityOf[Char](""""a"""") &&
+          parityOf[String](""""aé中😀"""") &&
+          parityOf[Byte]("-128") &&
+          parityOf[Short]("32767") &&
+          parityOf[Int]("-2147483648") &&
+          parityOf[Long]("9223372036854775807") &&
+          parityOf[Double]("-1.5e3") &&
+          parityOf[Float]("1e-3") &&
+          parityOf[BigInt]("123456789012345678901234567890") &&
+          parityOf[BigDecimal]("0.1234567890123456789") &&
+          parityOf[List[Int]]("[1,2,3]") &&
+          parityOf[Map[String, Int]]("""{"a":1,"b":2}""")
+        },
         test("decodes collections and nesting") {
           assertTrue(
             bytes("[]").fromJson[List[Int]] == Right(Nil),


### PR DESCRIPTION
## Motivation

JSON usually arrives as bytes — an HTTP response body, a file, a Kafka record — but `zio-json` has no synchronous way to decode a `Chunk[Byte]`. Users have to write:

```scala
new String(chunk.toArray, UTF_8).fromJson[A]
```

which holds the chunk, an array copy of it and the `String` all at once: ~3x the payload for ASCII, 4x once the content leaves Latin-1. On a large body that is the difference between fitting in the heap and not.

`decodeJsonStreamInput(ZStream.fromChunk(chunk))` is allocation-bounded and works today, but it is a `ZIO[R, Throwable, A]` rather than an `Either`, drags in the blocking pool and the `InputStream` bridge, and measures **5.7x slower** than the new path.

Writing an equivalent reader outside the library is not an option: `RetractReader` is `sealed`, so only `WithRetractReader` can be reused, and `UnexpectedEnd` is `private[zio]` — a caller outside the `zio` package cannot name it, so error handling degrades to a blanket `NonFatal` catch.

## What this adds

- `JsonDecoder#decodeJson(bytes: Chunk[Byte]): Either[String, A]`
- `JsonDecoder#decodeJson(bytes: Array[Byte]): Either[String, A]`
- `chunk.fromJson[A]` and `array.fromJson[A]` syntax, mirroring the existing `CharSequence` one
- `Utf8ChunkReader`, a `RetractReader` that decodes UTF-8 as the parser consumes it, so peak memory is the chunk plus a constant

Cross-platform (JVM/JS/Native) — it lives in `shared`. Input is expected to be UTF-8, as [RFC 8259 §8.1](https://www.rfc-editor.org/rfc/rfc8259#section-8.1) requires for interchange.

## Implementation note

Bytes never go through `Chunk#byte`, which is a virtual call taking an implicit witness and walks the tree on every byte of a `Chunk.Concat`. Reading per byte measured 4679 ops/s on a concatenated chunk against 17796 now — **3.8x**, i.e. the chunk access was costing several times the parse itself.

Instead there are two ways to fill the same `buf(k - base)` read:

- a `Chunk.ByteArray` is read **in place**, no copy and no refills. That is what `Chunk.fromArray` produces — what callers who already hold an `Array[Byte]` reach for, and how zio-http hands over a body taken from Netty — so it is the case worth biasing for. Worth **+9%** (17741 → 19405 ops/s).
- any other shape is pulled through an 8KB window, one `arraycopy` per refill, keeping peak memory constant.

Only the initialisation differs, so the read path stays monomorphic.

Two things I measured and dropped: decoding in bulk into a char window (making `retract` a plain `pos -= 1`) was 12% *slower*, the extra pass over a char array costing more than the branches it saves; and deriving the retract position by scanning backwards over continuation bytes instead of recording it, which was a wash and made the `Concat` numbers noisier.

## Behaviour

Matches the `CharSequence` path, including error messages and retract-after-end-of-input. Verified by property: for every byte prefix of five documents (covering whitespace, multi-byte content, nesting), `chunk.fromJson[A]` equals `new String(sameBytes, UTF_8).fromJson[A]`, for both a case class and `Json`.

Malformed UTF-8 matches `CharsetDecoder` exactly, verified exhaustively against `new String(bytes, UTF_8)` over every one and two byte sequence and 10368 three and four byte sequences. The lead byte fixes the permitted range of the second byte and a violation ends the malformed subpart there, so `E0 80 80` is three replacements; a CESU-8 encoded surrogate is only rejected once all three bytes are in hand and so costs one.

Those comparisons are JVM only — the JS and Native UTF-8 decoders do not always agree with the JVM on malformed input (`F7 C1 F7 BF` is one case). The reader itself behaves identically on every platform.

Out of scope: the `String` and stream paths already disagree with each other on retract-after-end-of-input (`{"name":"x","age":1` gives `(expected ',' or '}' got '1')` via `FastStringReader` and `Unexpected end of input` via `WithRetractReader`). This PR matches `FastStringReader`, since that is what users are migrating from.

## Benchmarks

`ChunkDecoderBenchmarks`, `google_maps_api_response.json`, JMH `-i 5 -wi 5 -f 1`, JDK 25:

| Benchmark | ops/s | |
|---|---:|---|
| `decodeZioString` | 20175 | already a `String`, baseline |
| `decodeZioChunkViaString` | 19822 | the status quo |
| **`decodeZioChunk`** | **19405** | new, `Chunk.fromArray` |
| **`decodeZioChunkConcat`** | **17796** | new, `Chunk.Concat` of 8 |
| `decodeZioStreamInput` | 3407 | the existing bounded option |
| `decodeJsoniterBytes` | 64163 | reference point, not like-for-like |

**5.7x faster end-to-end than the only allocation-bounded option available today**, at comparable peak memory. (`decodeZioStreamInput`'s score includes a `Runtime.unsafe.run` round trip, so that ratio is whole-call cost, not parse cost.)

For an array-backed chunk it is also level with parsing a `String` you already have, and 2% behind copying the chunk into one — so the copy now buys essentially nothing. A `Concat` is ~10% behind, which is the window's `arraycopy` showing up.

## Tests

New `ChunkDecoderSpec`, 30 tests. Since the in-place and windowed paths are distinct, the parity cases run against **every `Chunk` shape**: `ByteArray`, `ByteArray` with a non-zero offset, `Concat`, an eight-way `Concat`, `Slice` and `fromIterable`.

Covered: every scalar type and collection, string escapes, 1/2/3/4-byte sequences in values and in field names, every code point in the BMP plus a sample above it, sequences straddling the window boundary at every alignment, payload sizes either side of the window, `Concat` split at every byte offset, empty/single-byte chunks, retract at end of input, retract to a position the window has moved past, rewinding decoders (`orElse`) including a rewind spanning a refill and one landing mid surrogate pair, error-string parity, byte-prefix parity over five documents, the exhaustive `CharsetDecoder` sweeps, and properties over generated values, generated ASTs and arbitrary (mostly malformed) bytes.

`testJVM`, `testJS`, `testNative` on 2.13, plus `zioJsonJVM/test` on 3.3.7 and 2.12.21, `mimaReportBinaryIssues` (against 0.9.2), `docs/mdoc` and `fmtCheck` all pass.

## Not included

The symmetric encoder side — writing UTF-8 bytes straight into a growable `Array[Byte]` instead of building a `String` — is a separate and somewhat larger change. Happy to follow up if this lands.
