### PR TITLE
Add a benchmark for decoder throughput vs case class nesting depth

### DIFF
--- a/zio-json/jvm/src/jmh/scala/zio/json/NestingDepthBenchmarks.scala
+++ b/zio-json/jvm/src/jmh/scala/zio/json/NestingDepthBenchmarks.scala
@@ -1,0 +1,79 @@
+package zio.json
+
+import org.openjdk.jmh.annotations._
+import zio.json.NestingDepthBenchmarks._
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Decoder throughput as a function of case class nesting depth alone -- field count and payload size are fixed at one
+ * field, one leaf value, so this isolates depth from the width effects `ProductConstructionBenchmarks` measures.
+ *
+ * This exists because a try/catch based fix for issue #1651 (attach the error-trace span while unwinding a failed
+ * decode, instead of consing it on every successful one) was measured to regress recursively nested case classes
+ * specifically, starting around depth 3 and peaking around depth 5-7, with no `orElse` or failure involved at all -- a
+ * materially bigger problem than the `orElse`-fails cost the issue anticipated, since nested case classes are far more
+ * common. See the d1..d8 numbers in the class doc for the two variants compared to date.
+ *
+ * {{{
+ * jmh:run -i 5 -wi 5 -f 2 NestingDepth.*
+ * }}}
+ */
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 2)
+class NestingDepthBenchmarks {
+  var j1, j2, j3, j4, j5, j6, j7, j8: String = _
+
+  @Setup
+  def setup(): Unit = {
+    j1 = nest(1)
+    j2 = nest(2)
+    j3 = nest(3)
+    j4 = nest(4)
+    j5 = nest(5)
+    j6 = nest(6)
+    j7 = nest(7)
+    j8 = nest(8)
+
+    assert(j1.fromJson[Any](d1dec).isRight)
+    assert(j8.fromJson[Any](d8dec).isRight)
+  }
+
+  /** `{"w":{"w":...{"w":1}...}}`, `depth` levels deep. */
+  private def nest(depth: Int): String =
+    (1 until depth).foldLeft("""{"w":1}""")((acc, _) => s"""{"w":$acc}""")
+
+  @Benchmark def d1(): Either[String, Any] = j1.fromJson[Any](d1dec)
+  @Benchmark def d2(): Either[String, Any] = j2.fromJson[Any](d2dec)
+  @Benchmark def d3(): Either[String, Any] = j3.fromJson[Any](d3dec)
+  @Benchmark def d4(): Either[String, Any] = j4.fromJson[Any](d4dec)
+  @Benchmark def d5(): Either[String, Any] = j5.fromJson[Any](d5dec)
+  @Benchmark def d6(): Either[String, Any] = j6.fromJson[Any](d6dec)
+  @Benchmark def d7(): Either[String, Any] = j7.fromJson[Any](d7dec)
+  @Benchmark def d8(): Either[String, Any] = j8.fromJson[Any](d8dec)
+}
+
+object NestingDepthBenchmarks {
+  final case class W[A](w: A)
+
+  // one decoder per depth, each a val, derived once -- see OrElseDecoderBenchmarks for why that matters
+  private implicit val i1: JsonDecoder[W[Int]]                      = DeriveJsonDecoder.gen
+  private implicit val i2: JsonDecoder[W[W[Int]]]                   = DeriveJsonDecoder.gen
+  private implicit val i3: JsonDecoder[W[W[W[Int]]]]                = DeriveJsonDecoder.gen
+  private implicit val i4: JsonDecoder[W[W[W[W[Int]]]]]             = DeriveJsonDecoder.gen
+  private implicit val i5: JsonDecoder[W[W[W[W[W[Int]]]]]]          = DeriveJsonDecoder.gen
+  private implicit val i6: JsonDecoder[W[W[W[W[W[W[Int]]]]]]]       = DeriveJsonDecoder.gen
+  private implicit val i7: JsonDecoder[W[W[W[W[W[W[W[Int]]]]]]]]    = DeriveJsonDecoder.gen
+  private implicit val i8: JsonDecoder[W[W[W[W[W[W[W[W[Int]]]]]]]]] = DeriveJsonDecoder.gen
+
+  val d1dec: JsonDecoder[Any] = i1.widen[Any]
+  val d2dec: JsonDecoder[Any] = i2.widen[Any]
+  val d3dec: JsonDecoder[Any] = i3.widen[Any]
+  val d4dec: JsonDecoder[Any] = i4.widen[Any]
+  val d5dec: JsonDecoder[Any] = i5.widen[Any]
+  val d6dec: JsonDecoder[Any] = i6.widen[Any]
+  val d7dec: JsonDecoder[Any] = i7.widen[Any]
+  val d8dec: JsonDecoder[Any] = i8.widen[Any]
+}


### PR DESCRIPTION
Groundwork for #1651. Benchmark only — no library code changes.

## Why

#1651's error-trace fix has two candidate designs: attach each span while unwinding a failed decode (a `try`/`catch` per field/element — cheap to write), or push/pop a mutable span stack while descending (no exception handling on the hot path — more invasive to build, needs a design decision on where the stack lives without changing `unsafeDecode`'s public signature).

Nothing existing measured how either choice behaves as case classes **nest**, as opposed to how wide they are (`ProductConstructionBenchmarks` covers width). That turned out to matter: a `try`/`catch` prototype of the first option regressed recursively nested case classes by up to 36%, with **no `orElse` and no failure involved at all**, starting around depth 3 — an ordinary REST response shape (`Response -> Data -> Item -> Field`), not an edge case. Full writeup on #1651.

## What it measures

A one-field wrapper, `case class W[A](w: A)`, nested 1 to 8 deep, one decode call each — no failures, no `orElse`. Isolates depth from the field-count effects `ProductConstructionBenchmarks` already covers.

Baseline against unmodified `series/2.x`, JDK 25, `-i 5 -wi 5 -f 2`:

| depth | ops/s |
|---:|---:|
| 1 | 32.9M |
| 2 | 17.4M |
| 3 | 11.9M |
| 4 | 9.7M |
| 5 | 10.1M |
| 6 | 8.6M |
| 7 | 7.7M |
| 8 | 6.6M |

Throughput falling off with depth is expected on its own — eight levels of virtual dispatch through composed `JsonDecoder` instances cost more per level than a flat record's fields do. This baseline isn't the point; catching a **change to the curve** is. Any implementation of #1651 should run this benchmark before and after.

## Note

A `try`/`catch`-based prototype of the trace fix was measured against this and disqualified — non-overlapping error bars at every depth from 3 up, peaking around depth 5–7 at −34% to −36%, and not recovered by raising `MaxInlineLevel`/`FreqInlineSize`/`MaxInlineSize`. Details and the full before/after table are on #1651. That implementation is not part of this PR; only the benchmark is.
