### PR TITLE
Add a reproduction for the byte-vs-string allocation report on #1649

### DIFF
--- a/zio-json/jvm/src/jmh/scala/zio/json/BooleanArrayReproBenchmarks.scala
+++ b/zio-json/jvm/src/jmh/scala/zio/json/BooleanArrayReproBenchmarks.scala
@@ -1,0 +1,53 @@
+package zio.json
+
+import org.openjdk.jmh.annotations._
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduction for the allocation discrepancy reported on #1649 (comparing `Array[Boolean]` decoded from a `String`
+ * against the same bytes decoded via `decodeJson(Array[Byte])`), matching jsoniter-scala's `ArrayOfBooleansReading`
+ * shape as closely as possible: a flat JSON array of booleans, decoded straight into an `Array[Boolean]`.
+ *
+ * The allocation difference between the two paths turns out not to be a stable ratio -- it is a cliff that appears at a
+ * different array size for each reader, verified three independent ways (JFR allocation sampling, raw JVM GC logs, and
+ * `ThreadMXBean` allocated-byte counters): below the cliff the per-element error-trace allocation in `array[A]`'s
+ * decode loop (`new JsonError.ArrayAccess(i) :: trace`, unconditional, unread on the success path) gets scalar-replaced
+ * away by escape analysis; above it, escape analysis gives up and the full cost is paid. Which reader crosses its cliff
+ * at which size depends on how much per-character work that reader does, which is why the two paths disagree on
+ * direction depending where in the sweep you look -- around size 512 bytes reads as much worse, but at size 1000+ (both
+ * readers well past their cliffs) bytes reads as slightly better. See the writeup on issue #1651, which independently
+ * identified the same unconditional trace allocation from a completely different (wide, shallow object) workload.
+ *
+ * {{{
+ * jmh:run -i 5 -wi 5 -f 1 -prof gc BooleanArrayRepro.*
+ * }}}
+ */
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+class BooleanArrayReproBenchmarks {
+  // 400/512 straddle the byte reader's cliff, 200/300 straddle the string reader's, 1000 is past both
+  @Param(Array("200", "300", "400", "512", "1000"))
+  var size: Int = _
+
+  var jsonBytes: Array[Byte] = _
+
+  @Setup
+  def setup(): Unit = {
+    val obj = (1 to size).map(i => ((i * 1498724053) & 0x1) == 0).toArray
+    jsonBytes = obj.mkString("[", ",", "]").getBytes(UTF_8)
+
+    assert(viaString().sameElements(viaBytes()))
+  }
+
+  @Benchmark
+  def viaString(): Array[Boolean] =
+    new String(jsonBytes, UTF_8).fromJson[Array[Boolean]].fold(sys.error, identity)
+
+  @Benchmark
+  def viaBytes(): Array[Boolean] =
+    jsonBytes.fromJson[Array[Boolean]].fold(sys.error, identity)
+}


### PR DESCRIPTION
Groundwork for #1651. Benchmark only — no library code changes.

## Why

@plokhotnyuk reported ([comment](https://github.com/zio/zio-json/pull/1649#issuecomment-5090226758)) that decoding `Array[Boolean]` from bytes allocates roughly 4.4x more than from a `String`, using jsoniter-scala's `ArrayOfBooleansReading` shape. This reproduces that as closely as possible: a flat JSON array of booleans decoded straight into `Array[Boolean]`.

It isn't a stable ratio. It's a cliff at a *different* array size for each reader, confirmed three independent ways (JFR allocation sampling, raw JVM GC logs, `ThreadMXBean` allocated-byte counters):

| size | via bytes | via string |
|---:|---:|---:|
| 200 | 928 B/op | 2,016 B/op |
| 300 | 1,560 | 15,200 |
| 400 | 1,656 | 19,864 |
| 512 | **21,720** | 24,504 |
| 1000 | 43,296 | 48,800 |

`array[A]`'s decode loop (`JsonDecoder.scala:766`) does `new JsonError.ArrayAccess(i) :: trace` on every element, unconditionally — the same defect #1651 already identifies as the decoder's single largest allocation. On an all-valid input that allocation is never read, so below a size-dependent threshold HotSpot's escape analysis proves it never escapes and scalar-replaces it away entirely; above that threshold, escape analysis gives up and the full cost shows. Where that threshold falls depends on how much per-character work the reader does, which is why bytes-vs-string flips direction depending where you look in the sweep — at 512, bytes has just crossed its own cliff while string crossed its (lower) one earlier, so bytes looks much worse; by 1000, both are past their cliffs and bytes is ~11% *cheaper*, the opposite direction.

## What this does not fix

I tried the obvious repair against this exact benchmark — defer the trace/`ArrayAccess` construction to the catch block instead of building it eagerly (Option 1 from #1651). It did not reliably help: unchanged on the bytes path, *worse* at small sizes on the string path. Consistent with the nesting-depth finding already on #1651 — this class of fix interacts with escape analysis in ways that aren't simply "less allocation → faster."

## Note

This PR is the benchmark only, so the cliff can be tracked as #1651 progresses (a mutable span stack, avoiding exception machinery in the hot path entirely, is the direction that finding points toward). Full writeup on #1651 and in a reply on #1649.
