### PR TITLE
A1 Option 2: span stack instead of consing the error trace — 31% less allocation, but regresses nested case classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         val tparams   = (1 to i).map(p => s"A$p").mkString(", ")
         val implicits = (1 to i).map(p => s"A$p: JsonDecoder[A$p]").mkString(", ")
         val work      = (1 to i)
-          .map(p => s"val a$p = A$p.unsafeDecode(traces(${p - 1}) :: trace, in)")
+          .map(p => s"st.push(traces(${p - 1})); val a$p = A$p.unsafeDecode(trace, in); st.pop()")
           .mkString("\n        Lexer.char(trace, in, ',')\n        ")
         val work2 = (1 to i)
           .map(p => s"val a$p = A$p.unsafeFromJsonAST(traces(${p - 1}) :: trace, arr($p - 1))")
@@ -160,6 +160,7 @@ lazy val zioJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
            |    new JsonDecoder.AbstractJsonDecoder[Tuple$i[$tparams]] {
            |      private[this] val traces: Array[JsonError] = (0 to ${i - 1}).map(JsonError.ArrayAccess(_)).toArray
            |      def unsafeDecode(trace: List[JsonError], in: RetractReader): Tuple$i[$tparams] = {
+           |        val st = SpanStack.get
            |        Lexer.char(trace, in, '[')
            |        $work
            |        Lexer.char(trace, in, ']')

--- a/zio-json/jvm/src/jmh/scala/zio/json/SpanStackBenchmarks.scala
+++ b/zio-json/jvm/src/jmh/scala/zio/json/SpanStackBenchmarks.scala
@@ -1,0 +1,125 @@
+package zio.json
+
+import org.openjdk.jmh.annotations._
+import zio.json.NestingDepthBenchmarks.{ W, d1dec, d3dec, d5dec, d8dec }
+import zio.json.SpanStackBenchmarks._
+import zio.json.internal.{ Lexer, RetractReader, StringMatrix }
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Prototype for issue #1651's A1 Option 2: replace the per-field `spans(idx) :: trace` cons-cell with a push/pop
+ * against a mutable counter -- no `try`/`catch` anywhere on the success path -- and check whether that avoids both the
+ * allocation Option 1 was meant to remove *and* the nesting-depth throughput regression that disqualified Option 1 (see
+ * `NestingDepthBenchmarks`), at the exact same depths and JSON shape.
+ *
+ * `pushed` hand-writes what a macro-emitted Option 2 decoder would do for `W[A]`: increment a depth counter before
+ * decoding the field, decrement after, unconditionally, on the plain success path. If the inner decode throws, the
+ * decrement is skipped -- deliberately: the whole point of Option 2 is that nothing needs to run on the way back up
+ * through a failure, because the decode is aborting all the way out regardless (to `orElse`'s catch or the top-level
+ * `decodeJson` boundary), not returning through this frame normally.
+ *
+ * The counter lives in a `ThreadLocal[Array[Int]]` single cell here, standing in for "wherever the real stack would
+ * live" -- the open design question from #1651. A `ThreadLocal` has a known correctness hole for a real implementation:
+ * nothing resets it at every possible entry point other than `decodeJson` (`unsafeDecode` is public and can be called
+ * directly), so a stray direct call on the same thread would inherit whatever depth a prior decode left behind. Hanging
+ * the stack off the reader instead (constructed fresh per top-level decode, so naturally scoped with no reset needed)
+ * is the safer answer for a real implementation, at the cost of touching the sealed `RetractReader` hierarchy. This
+ * prototype uses the simpler `ThreadLocal` because it only ever runs one decode per thread per benchmark invocation, so
+ * the hole it has does not affect what is being measured here.
+ *
+ * What this does NOT prototype: `Lexer.error`'s signature would need to gain access to the stack to attach spans at
+ * throw time (it only takes `trace` today, not the reader), so on a malformed or missing field, `pushed`'s error
+ * message is missing the intermediate `.w` spans a real implementation would include. Only successful decodes are
+ * measured or asserted here, same as `NestingDepthBenchmarks`. `unsafeFromJsonAST`'s parallel trace-prepend mechanism
+ * is untouched entirely -- it has no reader to hang a stack off, so it needs its own design if ever tackled, separate
+ * from this one.
+ *
+ * {{{
+ * jmh:run -i 5 -wi 5 -f 2 SpanStack.*
+ * jmh:run -i 3 -wi 3 -f 1 -prof gc SpanStack.*
+ * }}}
+ */
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 2)
+class SpanStackBenchmarks {
+  var j1, j3, j5, j8: String = _
+
+  @Setup
+  def setup(): Unit = {
+    j1 = nest(1)
+    j3 = nest(3)
+    j5 = nest(5)
+    j8 = nest(8)
+
+    assert(j1.fromJson[Any](d1dec).isRight)
+    assert(j1.fromJson[Any](d1dec) == j1.fromJson[Any](pushed1))
+    assert(j3.fromJson[Any](d3dec) == j3.fromJson[Any](pushed3))
+    assert(j5.fromJson[Any](d5dec) == j5.fromJson[Any](pushed5))
+    assert(j8.fromJson[Any](d8dec) == j8.fromJson[Any](pushed8))
+  }
+
+  /** `{"w":{"w":...{"w":1}...}}`, `depth` levels deep -- identical to `NestingDepthBenchmarks.nest`. */
+  private def nest(depth: Int): String =
+    (1 until depth).foldLeft("""{"w":1}""")((acc, _) => s"""{"w":$acc}""")
+
+  @Benchmark def derivedD1(): Either[String, Any] = j1.fromJson[Any](d1dec)
+  @Benchmark def derivedD3(): Either[String, Any] = j3.fromJson[Any](d3dec)
+  @Benchmark def derivedD5(): Either[String, Any] = j5.fromJson[Any](d5dec)
+  @Benchmark def derivedD8(): Either[String, Any] = j8.fromJson[Any](d8dec)
+
+  @Benchmark def pushedD1(): Either[String, Any] = j1.fromJson[Any](pushed1)
+  @Benchmark def pushedD3(): Either[String, Any] = j3.fromJson[Any](pushed3)
+  @Benchmark def pushedD5(): Either[String, Any] = j5.fromJson[Any](pushed5)
+  @Benchmark def pushedD8(): Either[String, Any] = j8.fromJson[Any](pushed8)
+}
+
+object SpanStackBenchmarks {
+
+  // stands in for "wherever the real span stack would live" -- see the class doc for why this has a known hole
+  // that doesn't matter for what's being measured here
+  private val depthTL = new ThreadLocal[Array[Int]] {
+    override def initialValue(): Array[Int] = new Array(1)
+  }
+
+  /** What a macro-emitted Option 2 decoder would do: push/pop a depth counter, never cons the trace. */
+  final class PushedWDecoder[A](inner: JsonDecoder[A]) extends JsonDecoder[W[A]] {
+    private[this] val matrix = new StringMatrix(Array("w"))
+
+    def unsafeDecode(trace: List[JsonError], in: RetractReader): W[A] = {
+      Lexer.char(trace, in, '{')
+      var w    = null.asInstanceOf[A]
+      var seen = false
+      if (Lexer.firstField(trace, in))
+        while ({
+          val idx = Lexer.field(trace, in, matrix)
+          if (idx == 0) {
+            seen = true
+            val d = depthTL.get
+            d(0) += 1
+            w = inner.unsafeDecode(trace, in) // same trace, unchanged: no allocation
+            d(0) -= 1                         // plain and unconditional -- skipped on a throw, which is fine, see the class doc
+          } else Lexer.skipValue(trace, in)
+          Lexer.nextField(trace, in)
+        }) ()
+      if (!seen) Lexer.error("missing", JsonError.ObjectAccess("w") :: trace)
+      new W(w)
+    }
+  }
+
+  private val p1 = new PushedWDecoder(JsonDecoder[Int])
+  private val p2 = new PushedWDecoder[W[Int]](p1)
+  private val p3 = new PushedWDecoder[W[W[Int]]](p2)
+  private val p4 = new PushedWDecoder[W[W[W[Int]]]](p3)
+  private val p5 = new PushedWDecoder[W[W[W[W[Int]]]]](p4)
+  private val p6 = new PushedWDecoder[W[W[W[W[W[Int]]]]]](p5)
+  private val p7 = new PushedWDecoder[W[W[W[W[W[W[Int]]]]]]](p6)
+  private val p8 = new PushedWDecoder[W[W[W[W[W[W[W[Int]]]]]]]](p7)
+
+  val pushed1: JsonDecoder[Any] = p1.widen[Any]
+  val pushed3: JsonDecoder[Any] = p3.widen[Any]
+  val pushed5: JsonDecoder[Any] = p5.widen[Any]
+  val pushed8: JsonDecoder[Any] = p8.widen[Any]
+}

--- a/zio-json/jvm/src/main/scala/zio/json/JsonDecoderPlatformSpecific.scala
+++ b/zio-json/jvm/src/main/scala/zio/json/JsonDecoderPlatformSpecific.scala
@@ -12,8 +12,10 @@ trait JsonDecoderPlatformSpecific[A] { self: JsonDecoder[A] =>
 
   private def readAll(reader: java.io.Reader): ZIO[Any, Throwable, A] =
     ZIO.attemptBlocking {
-      try unsafeDecode(Nil, new zio.json.internal.WithRetractReader(reader))
-      catch {
+      try {
+        zio.json.internal.SpanStack.get.release(0) // as decodeJson: a previous decode may have left spans behind
+        unsafeDecode(Nil, new zio.json.internal.WithRetractReader(reader))
+      } catch {
         case JsonDecoder.UnsafeJson(trace)      => throw new Exception(JsonError.render(trace))
         case _: zio.json.internal.UnexpectedEnd => throw new Exception("unexpected end of input")
       }
@@ -117,6 +119,7 @@ trait JsonDecoderPlatformSpecific[A] { self: JsonDecoder[A] =>
                   }
                 }
 
+                zio.json.internal.SpanStack.get.release(0)
                 unsafeDecode(Nil, jsonReader)
               } catch {
                 case t @ JsonDecoder.UnsafeJson(trace) =>

--- a/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-2.x/zio/json/macros.scala
@@ -4,7 +4,7 @@ import magnolia1._
 import zio.Chunk
 import zio.json.JsonDecoder.JsonError
 import zio.json.ast.Json
-import zio.json.internal.{ FieldEncoder, Lexer, RecordingReader, RetractReader, StringMatrix, Write }
+import zio.json.internal.{ FieldEncoder, Lexer, RecordingReader, RetractReader, SpanStack, StringMatrix, Write }
 import scala.annotation._
 import scala.collection.mutable.ArrayBuffer
 import scala.language.experimental.macros
@@ -275,13 +275,20 @@ object DeriveJsonDecoder {
                 else null
               }
               (idx: Int, trace: List[JsonError]) => {
-                val trace_  = spans(idx) :: trace
+                val st = SpanStack.get
+                st.push(spans(idx))
                 val decoder = missingValueDecoders(idx)
-                if (decoder eq null) Lexer.error("missing", trace_)
-                decoder.unsafeDecodeMissing(trace_)
+                if (decoder eq null) Lexer.error("missing", trace)
+                val a = decoder.unsafeDecodeMissing(trace)
+                st.pop()
+                a
               }
             } else { (idx: Int, trace: List[JsonError]) =>
-              tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+              val st = SpanStack.get
+              st.push(spans(idx))
+              val a = tcs(idx).unsafeDecodeMissing(trace)
+              st.pop()
+              a
             }
 
           @tailrec
@@ -318,6 +325,7 @@ object DeriveJsonDecoder {
             // to instantiate the case class. Would also require JsonDecoder to be
             // specialised.
             val ps = new Array[Any](len)
+            val st = SpanStack.get
             if (Lexer.firstField(trace, in)) {
               do {
                 val idx = Lexer.field(trace, in, matrix)
@@ -330,9 +338,16 @@ object DeriveJsonDecoder {
                           in.retract()
                           true
                         }
-                      ) tcs(idx).unsafeDecode(spans(idx) :: trace, in)
-                      else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default()
-                      else Lexer.error("expected 'null'", spans(idx) :: trace)
+                      ) {
+                        st.push(spans(idx))
+                        val a = tcs(idx).unsafeDecode(trace, in)
+                        st.pop()
+                        a
+                      } else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default()
+                      else {
+                        st.push(spans(idx))
+                        Lexer.error("expected 'null'", trace)
+                      }
                   } else Lexer.error("duplicate", trace)
                 } else if (no_extra) Lexer.error("invalid extra field", trace)
                 else Lexer.skipValue(trace, in)
@@ -407,13 +422,20 @@ object DeriveJsonDecoder {
                 else null
               }
               (idx: Int, trace: List[JsonError]) => {
-                val trace_  = spans(idx) :: trace
+                val st = SpanStack.get
+                st.push(spans(idx))
                 val decoder = missingValueDecoders(idx)
-                if (decoder eq null) Lexer.error("missing", trace_)
-                decoder.unsafeDecodeMissing(trace_)
+                if (decoder eq null) Lexer.error("missing", trace)
+                val a = decoder.unsafeDecodeMissing(trace)
+                st.pop()
+                a
               }
             } else { (idx: Int, trace: List[JsonError]) =>
-              tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+              val st = SpanStack.get
+              st.push(spans(idx))
+              val a = tcs(idx).unsafeDecodeMissing(trace)
+              st.pop()
+              a
             }
 
           @tailrec
@@ -450,6 +472,7 @@ object DeriveJsonDecoder {
             // to instantiate the case class. Would also require JsonDecoder to be
             // specialised.
             val ps = new Array[Any](len)
+            val st = SpanStack.get
             if (Lexer.firstField(trace, in)) {
               do {
                 val idx = Lexer.field128(trace, in, matrix1, matrix2)
@@ -462,9 +485,16 @@ object DeriveJsonDecoder {
                           in.retract()
                           true
                         }
-                      ) tcs(idx).unsafeDecode(spans(idx) :: trace, in)
-                      else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default()
-                      else Lexer.error("expected 'null'", spans(idx) :: trace)
+                      ) {
+                        st.push(spans(idx))
+                        val a = tcs(idx).unsafeDecode(trace, in)
+                        st.pop()
+                        a
+                      } else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default()
+                      else {
+                        st.push(spans(idx))
+                        Lexer.error("expected 'null'", trace)
+                      }
                   } else Lexer.error("duplicate", trace)
                 } else if (no_extra) Lexer.error("invalid extra field", trace)
                 else Lexer.skipValue(trace, in)
@@ -588,7 +618,10 @@ object DeriveJsonDecoder {
             if (Lexer.firstField(trace, in)) {
               val idx = Lexer.field(trace, in, matrix1)
               if (idx >= 0) {
-                val a = tcs(idx).unsafeDecode(spans(idx) :: trace, in).asInstanceOf[A]
+                val st = SpanStack.get
+                st.push(spans(idx))
+                val a = tcs(idx).unsafeDecode(trace, in).asInstanceOf[A]
+                st.pop()
                 Lexer.char(trace, in, '}')
                 a
               } else Lexer.error("invalid disambiguator", trace)
@@ -615,7 +648,10 @@ object DeriveJsonDecoder {
             if (Lexer.firstField(trace, in)) {
               val idx = Lexer.field128(trace, in, matrix1, matrix2)
               if (idx >= 0) {
-                val a = tcs(idx).unsafeDecode(spans(idx) :: trace, in).asInstanceOf[A]
+                val st = SpanStack.get
+                st.push(spans(idx))
+                val a = tcs(idx).unsafeDecode(trace, in).asInstanceOf[A]
+                st.pop()
                 Lexer.char(trace, in, '}')
                 a
               } else Lexer.error("invalid disambiguator", trace)
@@ -650,7 +686,11 @@ object DeriveJsonDecoder {
                   val idx = Lexer.enumeration(trace, in_, matrix1)
                   if (idx >= 0) {
                     in_.rewind()
-                    return tcs(idx).unsafeDecode(spans(idx) :: trace, in_).asInstanceOf[A]
+                    val st = SpanStack.get
+                    st.push(spans(idx))
+                    val a = tcs(idx).unsafeDecode(trace, in_).asInstanceOf[A]
+                    st.pop()
+                    return a
                   } else Lexer.error("invalid disambiguator", trace)
                 } else Lexer.skipValue(trace, in_)
               } while (Lexer.nextField(trace, in_))
@@ -690,7 +730,11 @@ object DeriveJsonDecoder {
                   val idx = Lexer.enumeration128(trace, in_, matrix1, matrix2)
                   if (idx >= 0) {
                     in_.rewind()
-                    return tcs(idx).unsafeDecode(spans(idx) :: trace, in_).asInstanceOf[A]
+                    val st = SpanStack.get
+                    st.push(spans(idx))
+                    val a = tcs(idx).unsafeDecode(trace, in_).asInstanceOf[A]
+                    st.pop()
+                    return a
                   } else Lexer.error("invalid disambiguator", trace)
                 } else Lexer.skipValue(trace, in_)
               } while (Lexer.nextField(trace, in_))

--- a/zio-json/shared/src/main/scala-3/zio/json/macros.scala
+++ b/zio-json/shared/src/main/scala-3/zio/json/macros.scala
@@ -8,7 +8,7 @@ import scala.reflect.*
 import zio.Chunk
 import zio.json.JsonDecoder.JsonError
 import zio.json.ast.Json
-import zio.json.internal.{ FieldEncoder, Lexer, RecordingReader, RetractReader, StringMatrix, Write }
+import zio.json.internal.{ FieldEncoder, Lexer, RecordingReader, RetractReader, SpanStack, StringMatrix, Write }
 
 import scala.annotation._
 import scala.collection.Factory
@@ -286,13 +286,22 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                 else null
               }
               (idx: Int, trace: List[JsonError]) => {
-                val trace_ = spans(idx) :: trace
+                val st = SpanStack.get
+                st.push(spans(idx))
                 val decoder = missingValueDecoders(idx)
-                if (decoder eq null) Lexer.error("missing", trace_)
-                decoder.unsafeDecodeMissing(trace_)
+                if (decoder eq null) Lexer.error("missing", trace)
+                val a = decoder.unsafeDecodeMissing(trace)
+                st.pop()
+                a
               }
             } else {
-              (idx: Int, trace: List[JsonError]) => tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+              (idx: Int, trace: List[JsonError]) => {
+                val st = SpanStack.get
+                st.push(spans(idx))
+                val a = tcs(idx).unsafeDecodeMissing(trace)
+                st.pop()
+                a
+              }
             }
 
           @tailrec
@@ -321,6 +330,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
           override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
             Lexer.char(trace, in, '{')
             val ps = new Array[Any](len)
+            val st = SpanStack.get
             if (Lexer.firstField(trace, in))
               while({
                 val idx = Lexer.field(trace, in, matrix)
@@ -330,9 +340,17 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                     ps(idx) = if ((default eq null) || in.nextNonWhitespace() != 'n' && {
                       in.retract()
                       true
-                    }) tcs(idx).unsafeDecode(spans(idx) :: trace, in)
+                    }) {
+                      st.push(spans(idx))
+                      val a = tcs(idx).unsafeDecode(trace, in)
+                      st.pop()
+                      a
+                    }
                     else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default()
-                    else Lexer.error("expected 'null'", spans(idx) :: trace)
+                    else {
+                      st.push(spans(idx))
+                      Lexer.error("expected 'null'", trace)
+                    }
                   } else Lexer.error("duplicate", trace)
                 } else if (no_extra) Lexer.error("invalid extra field", trace)
                 else Lexer.skipValue(trace, in)
@@ -408,13 +426,22 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                 else null
               }
               (idx: Int, trace: List[JsonError]) => {
-                val trace_ = spans(idx) :: trace
+                val st = SpanStack.get
+                st.push(spans(idx))
                 val decoder = missingValueDecoders(idx)
-                if (decoder eq null) Lexer.error("missing", trace_)
-                decoder.unsafeDecodeMissing(trace_)
+                if (decoder eq null) Lexer.error("missing", trace)
+                val a = decoder.unsafeDecodeMissing(trace)
+                st.pop()
+                a
               }
             } else {
-              (idx: Int, trace: List[JsonError]) => tcs(idx).unsafeDecodeMissing(spans(idx) :: trace)
+              (idx: Int, trace: List[JsonError]) => {
+                val st = SpanStack.get
+                st.push(spans(idx))
+                val a = tcs(idx).unsafeDecodeMissing(trace)
+                st.pop()
+                a
+              }
             }
 
           @tailrec
@@ -443,6 +470,7 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
           override def unsafeDecode(trace: List[JsonError], in: RetractReader): A = {
             Lexer.char(trace, in, '{')
             val ps = new Array[Any](len)
+            val st = SpanStack.get
             if (Lexer.firstField(trace, in))
               while({
                 val idx = Lexer.field128(trace, in, matrix1, matrix2)
@@ -452,9 +480,17 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                     ps(idx) = if ((default eq null) || in.nextNonWhitespace() != 'n' && {
                       in.retract()
                       true
-                    }) tcs(idx).unsafeDecode(spans(idx) :: trace, in)
+                    }) {
+                      st.push(spans(idx))
+                      val a = tcs(idx).unsafeDecode(trace, in)
+                      st.pop()
+                      a
+                    }
                     else if (in.readChar() == 'u' && in.readChar() == 'l' && in.readChar() == 'l') default()
-                    else Lexer.error("expected 'null'", spans(idx) :: trace)
+                    else {
+                      st.push(spans(idx))
+                      Lexer.error("expected 'null'", trace)
+                    }
                   } else Lexer.error("duplicate", trace)
                 } else if (no_extra) Lexer.error("invalid extra field", trace)
                 else Lexer.skipValue(trace, in)
@@ -579,7 +615,10 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
             if (Lexer.firstField(trace, in)) {
               val idx = Lexer.field(trace, in, matrix1)
               if (idx >= 0) {
-                val a = tcs(idx).unsafeDecode(spans(idx) :: trace, in).asInstanceOf[A]
+                val st = SpanStack.get
+                st.push(spans(idx))
+                val a = tcs(idx).unsafeDecode(trace, in).asInstanceOf[A]
+                st.pop()
                 Lexer.char(trace, in, '}')
                 a
               } else Lexer.error("invalid disambiguator", trace)
@@ -606,7 +645,10 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
             if (Lexer.firstField(trace, in)) {
               val idx = Lexer.field128(trace, in, matrix1, matrix2)
               if (idx >= 0) {
-                val a = tcs(idx).unsafeDecode(spans(idx) :: trace, in).asInstanceOf[A]
+                val st = SpanStack.get
+                st.push(spans(idx))
+                val a = tcs(idx).unsafeDecode(trace, in).asInstanceOf[A]
+                st.pop()
                 Lexer.char(trace, in, '}')
                 a
               } else Lexer.error("invalid disambiguator", trace)
@@ -641,7 +683,11 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                   val idx = Lexer.enumeration(trace, in_, matrix1)
                   if (idx >= 0) {
                     in_.rewind()
-                    return tcs(idx).unsafeDecode(spans(idx) :: trace, in_).asInstanceOf[A]
+                    val st = SpanStack.get
+                    st.push(spans(idx))
+                    val a = tcs(idx).unsafeDecode(trace, in_).asInstanceOf[A]
+                    st.pop()
+                    return a
                   } else Lexer.error("invalid disambiguator", trace)
                 } else Lexer.skipValue(trace, in_)
                 Lexer.nextField(trace, in_)
@@ -681,7 +727,11 @@ sealed class JsonDecoderDerivation(config: JsonCodecConfiguration) extends Deriv
                   val idx = Lexer.enumeration128(trace, in_, matrix1, matrix2)
                   if (idx >= 0) {
                     in_.rewind()
-                    return tcs(idx).unsafeDecode(spans(idx) :: trace, in_).asInstanceOf[A]
+                    val st = SpanStack.get
+                    st.push(spans(idx))
+                    val a = tcs(idx).unsafeDecode(trace, in_).asInstanceOf[A]
+                    st.pop()
+                    return a
                   } else Lexer.error("invalid disambiguator", trace)
                 } else Lexer.skipValue(trace, in_)
                 Lexer.nextField(trace, in_)

--- a/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
+++ b/zio-json/shared/src/main/scala/zio/json/JsonDecoder.scala
@@ -89,8 +89,10 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
    * Note: This method may not entirely consume the specified character sequence.
    */
   final def decodeJson(str: CharSequence): Either[String, A] =
-    try new Right(unsafeDecode(Nil, new FastStringReader(str)))
-    catch {
+    try {
+      SpanStack.get.release(0) // a previous decode on this thread may have failed and left spans behind
+      new Right(unsafeDecode(Nil, new FastStringReader(str)))
+    } catch {
       case e: JsonDecoder.UnsafeJson => new Left(JsonError.render(e.trace))
       case _: UnexpectedEnd          => new Left("Unexpected end of input")
       case _: StackOverflowError     => new Left("Unexpected structure")
@@ -106,8 +108,10 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
    * Note: This method may not entirely consume the specified chunk.
    */
   final def decodeJson(bytes: Chunk[Byte]): Either[String, A] =
-    try new Right(unsafeDecode(Nil, new Utf8ChunkReader(bytes)))
-    catch {
+    try {
+      SpanStack.get.release(0) // a previous decode on this thread may have failed and left spans behind
+      new Right(unsafeDecode(Nil, new Utf8ChunkReader(bytes)))
+    } catch {
       case e: JsonDecoder.UnsafeJson => new Left(JsonError.render(e.trace))
       case _: UnexpectedEnd          => new Left("Unexpected end of input")
       case _: StackOverflowError     => new Left("Unexpected structure")
@@ -146,10 +150,13 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
     new JsonDecoder.AbstractJsonDecoder[A1] {
       def unsafeDecode(trace: List[JsonError], in: RetractReader): A1 = {
         val rr = RecordingReader(in)
+        val st = SpanStack.get
+        val m  = st.mark()
         try self.unsafeDecode(trace, rr)
         catch {
           case _: JsonDecoder.UnsafeJson | _: UnexpectedEnd =>
             rr.rewind()
+            st.release(m) // the failed alternative unwound without popping; those spans are not ours
             that.unsafeDecode(trace, rr)
         }
       }
@@ -160,11 +167,16 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
           case _: JsonDecoder.UnsafeJson | _: UnexpectedEnd => that.unsafeFromJsonAST(trace, json)
         }
 
-      override def unsafeDecodeMissing(trace: List[JsonError]): A1 =
+      override def unsafeDecodeMissing(trace: List[JsonError]): A1 = {
+        val st = SpanStack.get
+        val m  = st.mark()
         try self.unsafeDecodeMissing(trace)
         catch {
-          case _: JsonDecoder.UnsafeJson | _: UnexpectedEnd => that.unsafeDecodeMissing(trace)
+          case _: JsonDecoder.UnsafeJson | _: UnexpectedEnd =>
+            st.release(m)
+            that.unsafeDecodeMissing(trace)
         }
+      }
     }
 
   /**
@@ -254,8 +266,10 @@ trait JsonDecoder[A] extends JsonDecoderPlatformSpecific[A] {
    * more performant implementation.
    */
   final def fromJsonAST(json: Json): Either[String, A] =
-    try new Right(unsafeFromJsonAST(Nil, json))
-    catch {
+    try {
+      SpanStack.get.release(0) // as decodeJson: a previous decode may have failed and left spans behind
+      new Right(unsafeFromJsonAST(Nil, json))
+    } catch {
       case e: JsonDecoder.UnsafeJson => new Left(JsonError.render(e.trace))
       case _: UnexpectedEnd          => new Left("Unexpected end of input")
       case _: StackOverflowError     => new Left("Unexpected structure")
@@ -661,13 +675,16 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
             val field = Lexer.field(trace, in, matrix)
             if (field == -1) Lexer.skipValue(trace, in)
             else {
-              val trace_ = spans(field) :: trace
+              val st = SpanStack.get
+              st.push(spans(field))
               if (field < 3) {
-                if (left != null) Lexer.error("duplicate", trace_)
-                left = A.unsafeDecode(trace_, in)
+                if (left != null) Lexer.error("duplicate", trace)
+                left = A.unsafeDecode(trace, in)
+                st.pop()
               } else {
-                if (right != null) Lexer.error("duplicate", trace_)
-                right = B.unsafeDecode(trace_, in)
+                if (right != null) Lexer.error("duplicate", trace)
+                right = B.unsafeDecode(trace, in)
+                st.pop()
               }
             }
             Lexer.nextField(trace, in)
@@ -686,9 +703,12 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
   )(implicit A: JsonDecoder[A]): T[A] = {
     val c = in.nextNonWhitespace()
     if (c == '[') {
-      var i = 0
+      var i  = 0
+      val st = SpanStack.get
       if (Lexer.firstArrayElement(in)) while ({
-        builder += A.unsafeDecode(new JsonError.ArrayAccess(i) :: trace, in)
+        st.push(new JsonError.ArrayAccess(i))
+        builder += A.unsafeDecode(trace, in)
+        st.pop()
         i += 1
         Lexer.nextArrayElement(trace, in)
       }) ()
@@ -706,12 +726,14 @@ object JsonDecoder extends GeneratedTupleDecoders with DecoderLowPriority1 with 
     if (c == '{') {
       if (Lexer.firstField(trace, in))
         while ({
-          val field  = Lexer.string(trace, in).toString
-          val trace_ = new JsonError.ObjectAccess(field) :: trace
+          val field = Lexer.string(trace, in).toString
+          val st    = SpanStack.get
+          st.push(new JsonError.ObjectAccess(field))
           c = in.nextNonWhitespace()
           if (c != ':') Lexer.error("':'", c, trace)
-          val value = V.unsafeDecode(trace_, in)
-          builder += ((K.unsafeDecodeField(trace_, field), value))
+          val value = V.unsafeDecode(trace, in)
+          builder += ((K.unsafeDecodeField(trace, field), value))
+          st.pop()
           Lexer.nextField(trace, in)
         }) ()
       return builder.result()
@@ -753,9 +775,10 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
         val c = in.nextNonWhitespace()
         if (c == '[') {
           if (Lexer.firstArrayElement(in)) {
-            var l = 8
-            var x = new Array[A](l)
-            var i = 0
+            var l  = 8
+            var x  = new Array[A](l)
+            var i  = 0
+            val st = SpanStack.get
             while ({
               if (i == l) {
                 l <<= 1
@@ -763,7 +786,9 @@ private[json] trait DecoderLowPriority1 extends DecoderLowPriority2 {
                 System.arraycopy(x, 0, x1, 0, i)
                 x = x1
               }
-              x(i) = A.unsafeDecode(new JsonError.ArrayAccess(i) :: trace, in)
+              st.push(new JsonError.ArrayAccess(i))
+              x(i) = A.unsafeDecode(trace, in)
+              st.pop()
               i += 1
               Lexer.nextArrayElement(trace, in)
             }) ()

--- a/zio-json/shared/src/main/scala/zio/json/internal/SpanStack.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/SpanStack.scala
@@ -1,0 +1,72 @@
+package zio.json.internal
+
+import zio.json.JsonError
+
+/**
+ * The path of `JsonError` spans from the top of the current decode down to the frame being decoded right now.
+ *
+ * Decoders used to record that path by consing onto the `trace` they were handed —
+ * `child.unsafeDecode(spans(idx) :: trace, in)` — which allocates a cons cell per object field and per array element on
+ * every *successful* decode, purely so that a failure *could* render `.rows[0].elements[0].value`. Issue #1651 measures
+ * that at 28% of everything the decoder allocates.
+ *
+ * Instead each frame pushes its span before descending and pops it after, and the path is turned into the
+ * `List[JsonError]` that [[zio.json.JsonError.render]] expects only when an error is actually raised, in
+ * [[Lexer.error]]. The success path allocates nothing.
+ *
+ * A pop is deliberately *not* run when the frame below throws: the decode is unwinding all the way out to either
+ * `orElse`'s catch or the top-level `decodeJson` boundary, so nothing between here and there will read the stack again,
+ * and both of those restore the depth themselves ([[mark]]/[[release]]). Skipping the pop is what keeps this off the
+ * `try`/`catch` machinery that made #1651's Option 1 regress nested case classes.
+ *
+ * Being thread-local, one instance is shared by every decode on a thread — but only one decode is ever in flight on a
+ * thread at a time, and [[release]] at each top-level entry point makes a decode independent of whatever the previous
+ * one left behind.
+ */
+private[zio] final class SpanStack {
+  private[this] var spans: Array[JsonError] = new Array(32)
+  private[this] var depth: Int              = 0
+
+  /** The current depth, to be handed back to [[release]] once this subtree is done or has been abandoned. */
+  @inline def mark(): Int = depth
+
+  /** Discards everything pushed since [[mark]], whether or not it was popped. */
+  @inline def release(m: Int): Unit = depth = m
+
+  @inline def push(span: JsonError): Unit = {
+    var ss = spans
+    val d  = depth
+    if (d == ss.length) {
+      ss = java.util.Arrays.copyOf(ss, d << 1)
+      spans = ss
+    }
+    ss(d) = span
+    depth = d + 1
+  }
+
+  @inline def pop(): Unit = depth -= 1
+
+  /**
+   * The spans from here up to the top, innermost first, prepended onto `base` — the shape `JsonError.render` folds
+   * over. Only ever called while raising an error.
+   */
+  def pathTo(base: List[JsonError]): List[JsonError] = {
+    var out = base
+    var i   = 0
+    val d   = depth
+    val ss  = spans
+    while (i < d) { // spans(0) is outermost, so prepending in order leaves the innermost at the head
+      out = ss(i) :: out
+      i += 1
+    }
+    out
+  }
+}
+
+private[zio] object SpanStack {
+  private[this] val stacks = new ThreadLocal[SpanStack] {
+    override def initialValue(): SpanStack = new SpanStack
+  }
+
+  @inline def get: SpanStack = stacks.get
+}

--- a/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
+++ b/zio-json/shared/src/main/scala/zio/json/internal/lexer.scala
@@ -30,8 +30,10 @@ object Lexer {
 
   val NumberMaxBits: Int = 256
 
+  // the spans between `trace` and here are on the SpanStack rather than consed onto `trace` (see SpanStack); this is
+  // the one place that turns them back into the list JsonError.render folds over
   @noinline def error(msg: String, trace: List[JsonError]): Nothing =
-    throw UnsafeJson(JsonError.Message(msg) :: trace)
+    throw UnsafeJson(JsonError.Message(msg) :: SpanStack.get.pathTo(trace))
 
   @noinline private[json] def error(expected: String, got: Char, trace: List[JsonError]): Nothing =
     error(s"expected $expected got '$got'", trace)


### PR DESCRIPTION
## Summary

Implements #1651's A1 Option 2 — track the error-trace path on a mutable stack and materialise it only when an error is raised, instead of consing a cell per field/element on every successful decode.

**It works, it's correct, and it should not be merged.** Allocation drops 31% on the realistic fixture, but deeply nested case classes regress 22–42% — the same failure profile that disqualified Option 1. Pushed so the implementation and its numbers are reviewable, and so nobody spends this day again.

## What's implemented

- `SpanStack` (thread-local, array-backed): `push`/`pop` on the success path, `mark`/`release` for recovery.
- `Lexer.error` materialises the stack into the `List[JsonError]` that `JsonError.render` folds over. **No signature changes anywhere** — that's what kept this tractable.
- Every reader-path prepend site converted: both `macros.scala` files (product fields, missing-value decoders, sum-type dispatch), `JsonDecoder.scala` (array, `Array[A]`, either, keyValue), and the generated tuple decoders in `build.sbt`.
- Stack reset at every top-level entry (`decodeJson` ×2, `fromJsonAST`, the two stream entries) and depth restore in `orElse`'s catch.

`unsafeFromJsonAST` deliberately still conses — it has no reader and never interleaves with the reader path, so it works unchanged as long as the stack is empty, which the entry-point resets guarantee.

## Correctness

Error strings are a public contract asserted literally by `DecoderSpec` and `ConfigurableDeriveCodecSpec`. Both pass, on **2.13.18 (597 tests)** and **3.3.7 (620 tests)**, plus `mimaReportBinaryIssues` and `fmtCheck`.

Two real bugs showed up mid-implementation and are fixed, both worth knowing about for any future attempt:
1. **Mixing the two mechanisms reverses span order.** Tuple decoders still consed while the enclosing array pushed, producing `[1][2]` where `[2][1]` was expected. Every site between an entry point and an error has to use the same mechanism — there's no partial conversion.
2. **A thread-local stack leaks across decodes.** A failed decode unwinds without popping, so the next decode on that thread inherited stale spans (`.a.b(missing)` instead of `.b(missing)`). Hence the reset at *every* entry point, not just `decodeJson`.

## Benchmarks

JDK 25, JMH `-i 5 -wi 5 -f 2 -prof gc`, same machine, before/after on the same commit.

**`NestingDepthBenchmarks`** — the shape that disqualified Option 1:

| depth | before ops/s | after ops/s | Δ | before B/op | after B/op | Δ |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 31.8M | 30.3M | −5% | 88 | 88 | 0 |
| 2 | 18.0M | 14.0M | **−22%** | 176 | 128 | −27% |
| 3 | 11.4M | 10.3M | −9% | 288 | 216 | −25% |
| 4 | 9.96M | 7.58M | **−24%** | 368 | 272 | −26% |
| 5 | 9.77M | 5.65M | **−42%** | 448 | 328 | −27% |
| 6 | 8.07M | 4.93M | **−39%** | 528 | 384 | −27% |
| 7 | 7.22M | 4.38M | **−39%** | 608 | 440 | −28% |
| 8 | 6.45M | 4.29M | **−33%** | 688 | 496 | −28% |

**`ChunkDecoderBenchmarks`** (GoogleMaps fixture, wide and shallow) — allocation **65,848 → 45,592 B/op (−31%)**, throughput ~flat (19,975 vs 20,175 ops/s on the `String` path, 18,736 vs 19,405 on the `Chunk` path).

So: fine on wide/shallow payloads, bad on deep ones. Depth 3–5 is an ordinary REST response shape, not an edge case.

## Why the earlier spike was wrong

The prototype in this PR's first commit predicted **+41%** at depth 8. It measured a bare `Int` counter in a hand-written, single-field, monomorphic decoder. The real thing stores `JsonError` *references* into a long-lived array from inside the derived decoder — reference stores carry a GC write barrier, and the derived `unsafeDecode` is already at its inlining limit (see the A2/A3/A4 root-cause in #1651). Neither cost exists in the spike. **A spike that doesn't allocate what the real thing allocates, in the method the real thing lives in, doesn't predict the real thing.**

## What this means for #1651

Option 1 (`try`/`catch`) and Option 2 (mutable stack) now both regress nested case classes by a similar amount, via visibly different mechanisms. That's the useful finding: the problem is likely not `try`/`catch` specifically, but that the derived `unsafeDecode` cannot absorb *any* additional per-frame bookkeeping without falling off a JIT cliff — consistent with the constant-338-byte / inlining-wall analysis already in #1651.

If someone wants to keep pulling this thread, the next question is that cliff, not a third way to track spans. I'd suggest not writing more span-tracking prototypes until it's understood.

Leaving as draft. Happy to close if the conclusion is accepted, or to keep it open as the reference for why this line is closed.
